### PR TITLE
ci: build and publish Docker image to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.ignore
+.claude
+.DS_Store
+mygnoscan
+*.db

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,100 @@
+# PR builds validate the Dockerfile for both platforms without registry
+# credentials — a compromised action in the build graph can't exfiltrate a
+# token the job never had. Pushes to main (and manual dispatch from any
+# branch) publish ghcr.io/gnoverse/mygnoscan:<branch> + :sha-<short>;
+# gno-infra pins those tags by digest.
+name: docker
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Deny by default; each job opts in to what it needs.
+permissions: {}
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Build (no push)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          build-args: |
+            COMMIT=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  publish:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # required for Sigstore provenance attestation
+      attestations: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute build time
+        id: build_time
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            COMMIT=${{ github.sha }}
+            BUILD_TIME=${{ steps.build_time.outputs.value }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Provenance + SBOM so `gh attestation verify` can prove the image
+          # came from this workflow.
+          provenance: mode=max
+          sbom: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ permissions: {}
 
 concurrency:
   group: docker-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,8 +53,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write # required for Sigstore provenance attestation
-      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -94,7 +92,8 @@ jobs:
             BUILD_TIME=${{ steps.build_time.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          # Provenance + SBOM so `gh attestation verify` can prove the image
-          # came from this workflow.
+          # Attach SLSA provenance + SBOM as attestations embedded in the
+          # image index in GHCR. Verify with cosign or
+          # `docker buildx imagetools inspect --format '{{ json .Provenance }}'`.
           provenance: mode=max
           sbom: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+#
+# mygnoscan — single static Go binary (pure-Go SQLite, embedded frontend).
+#
+# Local build:
+#   docker build \
+#     --build-arg COMMIT=$(git rev-parse --short HEAD) \
+#     --build-arg BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+#     -t mygnoscan:dev .
+
+# ---- Build
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS
+ARG TARGETARCH
+ARG COMMIT=dev
+ARG BUILD_TIME=unknown
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+  go build \
+  -trimpath \
+  -ldflags "-s -w -X main.gitHash=$COMMIT -X main.buildTime=$BUILD_TIME" \
+  -o /out/mygnoscan .
+
+# ---- Runtime
+FROM alpine:3.24
+RUN apk add --no-cache ca-certificates wget && \
+  addgroup -S -g 10001 app && \
+  adduser -S -u 10001 -G app app && \
+  mkdir -p /var/lib/mygnoscan && chown -R app:app /var/lib/mygnoscan
+COPY --from=build /out/mygnoscan /usr/local/bin/mygnoscan
+ARG COMMIT=dev
+LABEL org.opencontainers.image.title="mygnoscan" \
+  org.opencontainers.image.description="Gno.land explorer — syncs tx-indexer data into SQLite and serves an embedded web UI." \
+  org.opencontainers.image.source="https://github.com/gnoverse/mygnoscan" \
+  org.opencontainers.image.revision="$COMMIT"
+EXPOSE 8888
+USER app
+# HEALTHCHECK assumes the default -listen :8888; a deployment that overrides
+# -listen must override the healthcheck as well.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8888/api/version || exit 1
+ENTRYPOINT ["/usr/local/bin/mygnoscan"]
+# Deployments append/override flags here (e.g. -config /etc/mygnoscan/networks.json).
+CMD ["-db", "/var/lib/mygnoscan/mygnoscan.db"]


### PR DESCRIPTION
## Summary

Adds container packaging and CI so the app ships as `ghcr.io/gnoverse/mygnoscan`:

- **Dockerfile** — multi-stage; the static Go binary is cross-compiled on the build platform and runs in a non-root `alpine:3.24` image (uid 10001, data dir `/var/lib/mygnoscan`), with a healthcheck on `/api/version`. Builds `linux/amd64` + `linux/arm64`.
- **`docker` workflow** — PRs build-validate the image for both platforms with no registry credentials; pushes to `main` (and manual `workflow_dispatch`) publish `:<branch>` + `:sha-<short>` multi-arch, with SLSA provenance + SBOM attestations embedded in the image.

Why: so gno-infra can pull and pin it by digest the same way it deploys gnoland, gnoweb, and gnockpit.

## Changes

- Dockerfile + `.dockerignore` — [`f96be8b`](https://github.com/aeddi/mygnoscan/commit/f96be8b2587b4c139b59cf4d72dfd9836e9485e0)
- `docker.yml` validate/publish workflow, third-party actions SHA-pinned — [`b5ba744`](https://github.com/aeddi/mygnoscan/commit/b5ba744586c21b11e020891604ef06102a180d3c)
- Scope concurrency cancellation to PRs so an in-flight publish is never cancelled — [`79033a4`](https://github.com/aeddi/mygnoscan/commit/79033a471c08235a0e35a3a743ad4c646170917b)
- Correct the attestation comment and drop unused `id-token`/`attestations` permissions — [`2f84089`](https://github.com/aeddi/mygnoscan/commit/2f840897cf772ff01db99204816e83e0932b703f)
- Dependabot for the `github-actions` ecosystem to keep the SHA pins current — [`f948b8c`](https://github.com/aeddi/mygnoscan/commit/f948b8c8425ed7a601b71202ba825ae73b858f68)

## Verifying the published image

After the first publish, the GHCR package defaults to private — set `ghcr.io/gnoverse/mygnoscan` visibility to public so infra can pull unauthenticated.

```
docker buildx imagetools inspect --format '{{ json .Provenance }}' ghcr.io/gnoverse/mygnoscan:main
```

Provenance + SBOM are attached to the image index in the registry (verify with `cosign` or `imagetools inspect`), not to GitHub's artifact-attestation store.
