### PR TITLE
fix: honor -indexer without -network and reject unusable config

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 )
@@ -16,12 +17,29 @@ type AppConfig struct {
 	Networks []NetworkConfig `json:"networks"`
 }
 
+// implicitConfigFile is picked up from the working directory when neither
+// -config nor the single-network flags are given.
+const implicitConfigFile = "networks.json"
+
+// defaultNetworkID names the network when -indexer is passed without -network.
+const defaultNetworkID = "default"
+
 var defaultConfig = &AppConfig{
 	Networks: []NetworkConfig{
 		{ID: "gnoland1", IndexerURL: "https://indexer.gno.land/graphql/query", RPCURL: "https://rpc.gno.land"},
 		{ID: "test12", IndexerURL: "https://indexer.test12.moul.p2p.team/graphql"},
 	},
 }
+
+// ConfigSource records where the effective config came from so startup can log it.
+type ConfigSource string
+
+const (
+	ConfigSourceFile     ConfigSource = "config file"
+	ConfigSourceFlags    ConfigSource = "command-line flags"
+	ConfigSourceImplicit ConfigSource = implicitConfigFile + " in working directory"
+	ConfigSourceDefault  ConfigSource = "built-in defaults"
+)
 
 func LoadConfig(path string) (*AppConfig, error) {
 	data, err := os.ReadFile(path)
@@ -33,4 +51,92 @@ func LoadConfig(path string) (*AppConfig, error) {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 	return &cfg, nil
+}
+
+// ResolveConfig determines the effective network configuration from the flags.
+//
+// Flags that cannot be honored are reported as errors rather than dropped. A
+// misconfigured instance still starts, still syncs and still looks healthy — it
+// just serves a different chain than the operator asked for — so a silent
+// fallback is close to undetectable in production.
+func ResolveConfig(configPath, networkID, indexerURL, rpcURL string) (*AppConfig, ConfigSource, error) {
+	cfg, source, err := resolveConfig(configPath, networkID, indexerURL, rpcURL)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := cfg.validate(); err != nil {
+		return nil, "", fmt.Errorf("%s: %w", source, err)
+	}
+	return cfg, source, nil
+}
+
+func resolveConfig(configPath, networkID, indexerURL, rpcURL string) (*AppConfig, ConfigSource, error) {
+	single := networkID != "" || indexerURL != "" || rpcURL != ""
+
+	switch {
+	case configPath != "" && single:
+		return nil, "", errors.New("-config cannot be combined with -network/-indexer/-rpc")
+
+	case configPath != "":
+		cfg, err := LoadConfig(configPath)
+		if err != nil {
+			return nil, "", err
+		}
+		return cfg, ConfigSourceFile, nil
+
+	case single:
+		// -indexer alone is enough: the network ID only labels the data.
+		if indexerURL == "" {
+			return nil, "", errors.New("-network and -rpc require -indexer to be set")
+		}
+		if networkID == "" {
+			networkID = defaultNetworkID
+		}
+		return &AppConfig{Networks: []NetworkConfig{{
+			ID:         networkID,
+			IndexerURL: indexerURL,
+			RPCURL:     rpcURL,
+		}}}, ConfigSourceFlags, nil
+
+	default:
+		if _, err := os.Stat(implicitConfigFile); err == nil {
+			cfg, err := LoadConfig(implicitConfigFile)
+			if err != nil {
+				return nil, "", err
+			}
+			return cfg, ConfigSourceImplicit, nil
+		}
+		return defaultConfig, ConfigSourceDefault, nil
+	}
+}
+
+// validate rejects configs that would sync into the wrong place or not at all.
+func (c *AppConfig) validate() error {
+	if len(c.Networks) == 0 {
+		return errors.New("no networks defined")
+	}
+	seen := make(map[string]bool, len(c.Networks))
+	for i, n := range c.Networks {
+		if n.ID == "" {
+			return fmt.Errorf("network %d: missing id", i)
+		}
+		if n.IndexerURL == "" {
+			return fmt.Errorf("network %q: missing indexer URL", n.ID)
+		}
+		// Duplicate IDs would give two syncers the same rows to write.
+		if seen[n.ID] {
+			return fmt.Errorf("duplicate network id %q", n.ID)
+		}
+		seen[n.ID] = true
+	}
+	return nil
+}
+
+// IDs returns the configured network IDs, for logging.
+func (c *AppConfig) IDs() []string {
+	ids := make([]string, 0, len(c.Networks))
+	for _, n := range c.Networks {
+		ids = append(ids, n.ID)
+	}
+	return ids
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	writeConfig := func(name, body string) string {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return path
+	}
+
+	valid := writeConfig("valid.json", `{"networks":[
+		{"id":"topaz","indexer":"https://indexer.topaz.example/graphql/query","rpc":"https://rpc.topaz.example"},
+		{"id":"staging","indexer":"https://indexer.staging.example/graphql/query"}
+	]}`)
+	empty := writeConfig("empty.json", `{"networks":[]}`)
+	dupes := writeConfig("dupes.json", `{"networks":[
+		{"id":"topaz","indexer":"https://a.example/graphql/query"},
+		{"id":"topaz","indexer":"https://b.example/graphql/query"}
+	]}`)
+	noIndexer := writeConfig("no-indexer.json", `{"networks":[{"id":"topaz"}]}`)
+	malformed := writeConfig("malformed.json", `{"networks":`)
+
+	tests := []struct {
+		name       string
+		configPath string
+		networkID  string
+		indexerURL string
+		rpcURL     string
+		wantErr    bool
+		wantSource ConfigSource
+		wantIDs    []string
+	}{
+		{
+			// The regression this fix is about: -indexer alone used to be
+			// silently dropped in favor of the built-in defaults.
+			name:       "indexer flag alone is honored",
+			indexerURL: "http://127.0.0.1:8546/graphql/query",
+			wantSource: ConfigSourceFlags,
+			wantIDs:    []string{defaultNetworkID},
+		},
+		{
+			name:       "indexer and network flags",
+			networkID:  "topaz",
+			indexerURL: "http://127.0.0.1:8546/graphql/query",
+			wantSource: ConfigSourceFlags,
+			wantIDs:    []string{"topaz"},
+		},
+		{
+			name:       "rpc flag is carried through",
+			networkID:  "topaz",
+			indexerURL: "http://127.0.0.1:8546/graphql/query",
+			rpcURL:     "http://127.0.0.1:26657",
+			wantSource: ConfigSourceFlags,
+			wantIDs:    []string{"topaz"},
+		},
+		{
+			name:      "network without indexer is an error",
+			networkID: "topaz",
+			wantErr:   true,
+		},
+		{
+			name:    "rpc without indexer is an error",
+			rpcURL:  "http://127.0.0.1:26657",
+			wantErr: true,
+		},
+		{
+			name:       "config file",
+			configPath: valid,
+			wantSource: ConfigSourceFile,
+			wantIDs:    []string{"topaz", "staging"},
+		},
+		{
+			name:       "config file combined with flags is an error",
+			configPath: valid,
+			indexerURL: "http://127.0.0.1:8546/graphql/query",
+			wantErr:    true,
+		},
+		{
+			name:       "config file with no networks is an error",
+			configPath: empty,
+			wantErr:    true,
+		},
+		{
+			name:       "duplicate network ids are rejected",
+			configPath: dupes,
+			wantErr:    true,
+		},
+		{
+			name:       "network without indexer url is rejected",
+			configPath: noIndexer,
+			wantErr:    true,
+		},
+		{
+			// Previously this fell back to the defaults, so a typo in the
+			// config file meant silently syncing a different chain.
+			name:       "malformed config file is an error",
+			configPath: malformed,
+			wantErr:    true,
+		},
+		{
+			name:       "missing config file is an error",
+			configPath: filepath.Join(dir, "does-not-exist.json"),
+			wantErr:    true,
+		},
+		{
+			name:       "no flags falls back to defaults",
+			wantSource: ConfigSourceDefault,
+			wantIDs:    defaultConfig.IDs(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The no-flag case consults ./networks.json; keep the working
+			// directory clean so it cannot pick up a stray file.
+			t.Chdir(t.TempDir())
+
+			cfg, source, err := ResolveConfig(tt.configPath, tt.networkID, tt.indexerURL, tt.rpcURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got config %+v", cfg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if source != tt.wantSource {
+				t.Errorf("source = %q, want %q", source, tt.wantSource)
+			}
+			got := cfg.IDs()
+			if len(got) != len(tt.wantIDs) {
+				t.Fatalf("network ids = %v, want %v", got, tt.wantIDs)
+			}
+			for i := range got {
+				if got[i] != tt.wantIDs[i] {
+					t.Fatalf("network ids = %v, want %v", got, tt.wantIDs)
+				}
+			}
+			if tt.rpcURL != "" && cfg.Networks[0].RPCURL != tt.rpcURL {
+				t.Errorf("rpc url = %q, want %q", cfg.Networks[0].RPCURL, tt.rpcURL)
+			}
+		})
+	}
+}
+
+func TestResolveConfigImplicitFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	body := `{"networks":[{"id":"local","indexer":"http://127.0.0.1:8546/graphql/query"}]}`
+	if err := os.WriteFile(implicitConfigFile, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", implicitConfigFile, err)
+	}
+
+	cfg, source, err := ResolveConfig("", "", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if source != ConfigSourceImplicit {
+		t.Errorf("source = %q, want %q", source, ConfigSourceImplicit)
+	}
+	if ids := cfg.IDs(); len(ids) != 1 || ids[0] != "local" {
+		t.Errorf("network ids = %v, want [local]", ids)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -47,25 +47,11 @@ func run() error {
 	defer db.Close()
 
 	// Load config
-	var cfg *AppConfig
-	if *configPath != "" {
-		loaded, err := LoadConfig(*configPath)
-		if err != nil {
-			return err
-		}
-		cfg = loaded
-	} else if *indexerFlag != "" && *networkFlag != "" {
-		cfg = &AppConfig{Networks: []NetworkConfig{{ID: *networkFlag, IndexerURL: *indexerFlag, RPCURL: *rpcFlag}}}
-	} else {
-		if _, serr := os.Stat("networks.json"); serr == nil {
-			if loaded, lerr := LoadConfig("networks.json"); lerr == nil {
-				cfg = loaded
-			}
-		}
-		if cfg == nil {
-			cfg = defaultConfig
-		}
+	cfg, cfgSource, err := ResolveConfig(*configPath, *networkFlag, *indexerFlag, *rpcFlag)
+	if err != nil {
+		return err
 	}
+	log.Printf("networks %v (from %s)", cfg.IDs(), cfgSource)
 
 	// Create per-network clients
 	clients := make(map[string]*IndexerClient)
@@ -202,13 +188,7 @@ func run() error {
 		srv.Shutdown(context.Background())
 	}()
 
-	log.Printf("mygnoscan listening on %s (networks: %v)", *listenAddr, func() []string {
-		var ids []string
-		for _, n := range cfg.Networks {
-			ids = append(ids, n.ID)
-		}
-		return ids
-	}())
+	log.Printf("mygnoscan listening on %s (networks: %v)", *listenAddr, cfg.IDs())
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 		return err
 	}


### PR DESCRIPTION
Closes #18.

`-indexer` on its own had no effect: the value was accepted, nothing was logged, and the process fell back to `defaultConfig` — so it synced from the built-in default networks instead of the indexer the operator asked for. `-rpc` alone was dropped the same way, since it was only ever read inside the branch that required `-network`.

The failure mode is nasty because nothing looks wrong. The process starts, the logs show healthy sync activity, and real data appears — just from a different chain. `/api/networks` was the only tell.

## Changes

Config resolution moves out of `main()` into `ResolveConfig` in `config.go`, which returns the config, a `ConfigSource` describing where it came from, and an error.

Behavior:

- **`-indexer` alone now works.** The network ID defaults to `"default"` when `-network` is not given — the ID only labels the data, so requiring it was arbitrary.
- **Incomplete flag combinations are errors**, not silent fallbacks: `-network` or `-rpc` without `-indexer` now exits with a message instead of quietly serving the default networks.
- **`-config` combined with `-network`/`-indexer`/`-rpc` is an error.** Previously `-config` silently won and the other flags were discarded.
- **A malformed or unreadable `networks.json` in the working directory is now an error.** Previously the load error was swallowed (`if lerr == nil`) and it fell through to the defaults — so a typo in the config meant silently syncing the wrong chain, which is the same bug in a different disguise.
- **Configs are validated**: at least one network, every network needs an `id` and an `indexer`, and duplicate network IDs are rejected. Duplicate IDs are worth calling out — they would have given two syncer goroutines the same rows to write.
- **Startup logs the config source**: `networks [topaz staging] (from config file)`. The point of the whole change is that an operator can tell at a glance which chains they are actually pointed at.

## Tests

`config_test.go`, table-driven, covering each resolution path and each rejection — including the two silent-fallback cases that motivated this (`-indexer` alone, and a malformed implicit config). These are the first tests in the repo (#14 tracks the rest); they pass under `go test ./...`.

## Note for operators

If you are running with **only** `-indexer` today, you are currently syncing the default networks, and after this change you will sync the indexer you specified — under the network ID `default`, which will not match any data already stored under a different ID. If you want to keep existing rows, pass `-network <existing-id>` explicitly, or use a `-config` file. Worth checking before rolling this out.

Also relevant: `gofmt -l .` currently reports `api.go` and `syncer.go` as unformatted on `main`. Not touched here — that gets fixed in the #15 CI PR, which is what should have been catching it.
