### PR TITLE
fix: discard local data when the upstream chain has been reset

### DIFF
--- a/db.go
+++ b/db.go
@@ -348,6 +348,62 @@ func (d *DB) SetSyncState(key, value string) error {
 	return err
 }
 
+// networkScopedTables lists every table whose rows belong to a single network.
+var networkScopedTables = []string{
+	"packages",
+	"package_files",
+	"dependencies",
+	"calls",
+	"msg_runs",
+	"bank_sends",
+	"transactions",
+}
+
+// DeleteNetworkData removes every row belonging to a network, in one transaction.
+// Used when a chain reset makes the stored history refer to blocks that no longer
+// exist. Returns the number of rows removed.
+func (d *DB) DeleteNetworkData(network string) (int64, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	tx, err := d.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	var total int64
+	for _, table := range networkScopedTables {
+		// Table names come from the constant above, never from input.
+		res, err := tx.Exec(fmt.Sprintf(`DELETE FROM %s WHERE network = ?`, table), network)
+		if err != nil {
+			return 0, fmt.Errorf("delete from %s: %w", table, err)
+		}
+		if n, err := res.RowsAffected(); err == nil {
+			total += n
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+// MaxBlockHeight returns the highest block height stored for a network, or 0 if
+// the network has no data yet.
+func (d *DB) MaxBlockHeight(network string) (int, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	var height sql.NullInt64
+	err := d.db.QueryRow(
+		`SELECT MAX(block_height) FROM transactions WHERE network = ?`, network,
+	).Scan(&height)
+	if err != nil {
+		return 0, err
+	}
+	return int(height.Int64), nil
+}
+
 type PackageInfo struct {
 	Network     string `json:"network,omitempty"`
 	Path        string `json:"path"`

--- a/syncer.go
+++ b/syncer.go
@@ -19,8 +19,15 @@ func NewSyncer(client *IndexerClient, db *DB, analyzer *Analyzer, networkID stri
 	return &Syncer{client: client, db: db, analyzer: analyzer, networkID: networkID}
 }
 
+// fingerprintKeyPrefix namespaces the stored chain fingerprint per network.
+const fingerprintKeyPrefix = "chain_fingerprint:"
+
 // SyncAll fetches all data from the indexer and processes it.
 func (s *Syncer) SyncAll(ctx context.Context) error {
+	if err := s.checkChainReset(ctx); err != nil {
+		return err
+	}
+	s.warnOnHeightRegression(ctx)
 	if err := s.syncPackages(ctx); err != nil {
 		return err
 	}
@@ -95,6 +102,88 @@ func (s *Syncer) syncPackages(ctx context.Context) error {
 	}
 	log.Printf("[%s] synced %d packages", s.networkID, count)
 	return nil
+}
+
+// chainFingerprint identifies a specific chain instance by its first block.
+// The chain ID alone is not enough: a reset network keeps its chain ID and comes
+// back with a different block 1, which is exactly what portal-loop and staging
+// style networks do.
+func (s *Syncer) chainFingerprint(ctx context.Context) (string, error) {
+	block, err := s.client.GetBlock(ctx, 1)
+	if err != nil {
+		return "", err
+	}
+	if block.Hash == "" {
+		return "", errors.New("block 1 has no hash")
+	}
+	return block.ChainID + ":" + block.Hash, nil
+}
+
+// checkChainReset wipes locally stored data when the indexer is no longer serving
+// the chain that data came from.
+//
+// Sync cursors are derived from the highest stored block height, so after a reset
+// to a lower height the cursor sits above the new tip permanently: every pass asks
+// for blocks that do not exist yet, stores nothing, and reports success. The
+// network silently freezes while continuing to serve pre-reset rows whose heights
+// and tx hashes no longer refer to anything on that chain.
+//
+// Detection is by fingerprint rather than by height comparison on purpose. A
+// lagging indexer replica also reports a tip below what we have stored, and
+// wiping a large chain because a replica was behind would be far worse than the
+// bug being fixed.
+func (s *Syncer) checkChainReset(ctx context.Context) error {
+	key := fingerprintKeyPrefix + s.networkID
+
+	current, err := s.chainFingerprint(ctx)
+	if err != nil {
+		// Never wipe on uncertainty: an unreachable indexer or a pruned block 1
+		// is not evidence of a reset.
+		log.Printf("[%s] chain fingerprint unavailable, skipping reset check: %v", s.networkID, err)
+		return nil
+	}
+
+	stored, err := s.db.GetSyncState(key)
+	if err != nil {
+		return fmt.Errorf("read chain fingerprint: %w", err)
+	}
+
+	switch stored {
+	case "":
+		// First sync for this network, or a database predating this check.
+		return s.db.SetSyncState(key, current)
+	case current:
+		return nil
+	}
+
+	log.Printf("[%s] CHAIN RESET DETECTED: stored chain %q is no longer served (indexer now serves %q); discarding local data for this network",
+		s.networkID, stored, current)
+
+	deleted, err := s.db.DeleteNetworkData(s.networkID)
+	if err != nil {
+		return fmt.Errorf("discard data after chain reset: %w", err)
+	}
+	log.Printf("[%s] removed %d rows, re-syncing from the new genesis", s.networkID, deleted)
+
+	return s.db.SetSyncState(key, current)
+}
+
+// warnOnHeightRegression reports the lagging-replica case: the same chain, but an
+// indexer tip below what is already stored, so sync cannot advance until it
+// catches up. Not an error, and deliberately not a reason to discard data.
+func (s *Syncer) warnOnHeightRegression(ctx context.Context) {
+	remote, err := s.client.LatestBlockHeight(ctx)
+	if err != nil {
+		return
+	}
+	stored, err := s.db.MaxBlockHeight(s.networkID)
+	if err != nil || stored == 0 {
+		return
+	}
+	if remote < stored {
+		log.Printf("[%s] indexer tip %d is below stored height %d on the same chain; sync will not advance until the indexer catches up",
+			s.networkID, remote, stored)
+	}
 }
 
 func (s *Syncer) getLastBlockHeight(ctx context.Context, tableName string) (*int, error) {
@@ -222,4 +311,3 @@ func (s *Syncer) syncMsgRuns(ctx context.Context) error {
 	log.Printf("[%s] synced %d msg_runs", s.networkID, count)
 	return nil
 }
-

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeIndexer serves just enough of the tx-indexer GraphQL API to drive the
+// syncer: block 1 (the reset fingerprint) and the latest height.
+type fakeIndexer struct {
+	mu sync.Mutex
+
+	block1Hash    string
+	chainID       string
+	latestHeight  int
+	block1Failing bool
+}
+
+func (f *fakeIndexer) set(hash string, height int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.block1Hash = hash
+	f.latestHeight = height
+}
+
+func (f *fakeIndexer) failBlock1(failing bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.block1Failing = failing
+}
+
+func (f *fakeIndexer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	query := string(body)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	switch {
+	case strings.Contains(query, "latestBlockHeight"):
+		fmt.Fprintf(w, `{"data":{"latestBlockHeight":%d}}`, f.latestHeight)
+
+	case strings.Contains(query, "getBlocks"):
+		if f.block1Failing {
+			http.Error(w, "indexer unavailable", http.StatusInternalServerError)
+			return
+		}
+		b, _ := json.Marshal(f.block1Hash)
+		fmt.Fprintf(w, `{"data":{"getBlocks":[{"hash":%s,"height":1,"chain_id":%q,"time":"2026-01-01T00:00:00Z"}]}}`,
+			b, f.chainID)
+
+	default:
+		// Any transaction query: no results, so sync is a no-op.
+		fmt.Fprint(w, `{"data":{"getTransactions":[]}}`)
+	}
+}
+
+// newTestSyncer wires a syncer against a fake indexer and a real temp database.
+func newTestSyncer(t *testing.T, network string) (*Syncer, *fakeIndexer, *DB) {
+	t.Helper()
+
+	fake := &fakeIndexer{chainID: "testchain", block1Hash: "genesis-a", latestHeight: 1000}
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+
+	db, err := NewDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	return NewSyncer(NewIndexerClient(srv.URL), db, NewAnalyzer(db), network), fake, db
+}
+
+// seedNetwork writes one row into every network-scoped table.
+func seedNetwork(t *testing.T, db *DB, network string, height int) {
+	t.Helper()
+
+	if err := db.UpsertPackage(network, "gno.land/r/demo/foo", "foo", "g1creator", "TXHASH", height, "", true, 1); err != nil {
+		t.Fatalf("upsert package: %v", err)
+	}
+	if err := db.UpsertPackageFile(network, "gno.land/r/demo/foo", "foo.gno", "package foo"); err != nil {
+		t.Fatalf("upsert package file: %v", err)
+	}
+	if err := db.SetDependencies(network, "gno.land/r/demo/foo", []string{"gno.land/p/demo/avl"}); err != nil {
+		t.Fatalf("set dependencies: %v", err)
+	}
+	if err := db.InsertCall(network, "TXHASH", height, "", "g1caller", "gno.land/r/demo/foo", "Bar", true); err != nil {
+		t.Fatalf("insert call: %v", err)
+	}
+	if err := db.InsertMsgRun(network, "TXHASH", height, "", "g1caller", "package main", true); err != nil {
+		t.Fatalf("insert msg run: %v", err)
+	}
+	if err := db.InsertBankSend(network, "TXHASH", height, "", "g1from", "g1to", "1ugnot", true); err != nil {
+		t.Fatalf("insert bank send: %v", err)
+	}
+	if err := db.UpsertTransaction(network, "TXHASH", height, "", 100, 200, 1, true); err != nil {
+		t.Fatalf("upsert transaction: %v", err)
+	}
+}
+
+func countNetworkRows(t *testing.T, db *DB, network string) int {
+	t.Helper()
+
+	total := 0
+	for _, table := range networkScopedTables {
+		var n int
+		q := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE network = ?`, table)
+		if err := db.db.QueryRow(q, network).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		total += n
+	}
+	return total
+}
+
+func TestCheckChainResetDiscardsDataFromAPreviousChain(t *testing.T) {
+	ctx := context.Background()
+	syncer, fake, db := newTestSyncer(t, "staging")
+
+	// First pass records the fingerprint of the chain we are syncing.
+	if err := syncer.checkChainReset(ctx); err != nil {
+		t.Fatalf("first reset check: %v", err)
+	}
+	seedNetwork(t, db, "staging", 900)
+	seedNetwork(t, db, "topaz", 900) // another network, must survive
+
+	if got := countNetworkRows(t, db, "staging"); got != len(networkScopedTables) {
+		t.Fatalf("seeded rows = %d, want %d", got, len(networkScopedTables))
+	}
+
+	// Same chain: nothing is discarded.
+	if err := syncer.checkChainReset(ctx); err != nil {
+		t.Fatalf("second reset check: %v", err)
+	}
+	if got := countNetworkRows(t, db, "staging"); got != len(networkScopedTables) {
+		t.Fatalf("rows after no-op check = %d, want %d", got, len(networkScopedTables))
+	}
+
+	// The chain is reset: same chain ID, new genesis, height back near zero.
+	fake.set("genesis-b", 5)
+	if err := syncer.checkChainReset(ctx); err != nil {
+		t.Fatalf("reset check after reset: %v", err)
+	}
+
+	if got := countNetworkRows(t, db, "staging"); got != 0 {
+		t.Errorf("stale rows left after reset: %d", got)
+	}
+	if got := countNetworkRows(t, db, "topaz"); got != len(networkScopedTables) {
+		t.Errorf("other network lost %d rows", len(networkScopedTables)-got)
+	}
+
+	// The new fingerprint is now the stored one, so this is not re-detected.
+	stored, err := db.GetSyncState(fingerprintKeyPrefix + "staging")
+	if err != nil {
+		t.Fatalf("read fingerprint: %v", err)
+	}
+	if want := "testchain:genesis-b"; stored != want {
+		t.Errorf("stored fingerprint = %q, want %q", stored, want)
+	}
+}
+
+func TestCheckChainResetKeepsDataWhenIndexerIsUnreachable(t *testing.T) {
+	ctx := context.Background()
+	syncer, fake, db := newTestSyncer(t, "staging")
+
+	if err := syncer.checkChainReset(ctx); err != nil {
+		t.Fatalf("first reset check: %v", err)
+	}
+	seedNetwork(t, db, "staging", 900)
+
+	// An indexer that cannot answer is not evidence of a reset. This is the
+	// case that must never wipe: it would turn a transient outage into data loss.
+	fake.failBlock1(true)
+	if err := syncer.checkChainReset(ctx); err != nil {
+		t.Fatalf("reset check with failing indexer: %v", err)
+	}
+	if got := countNetworkRows(t, db, "staging"); got != len(networkScopedTables) {
+		t.Errorf("rows = %d after indexer failure, want %d", got, len(networkScopedTables))
+	}
+}
+
+func TestCheckChainResetIgnoresALaggingIndexer(t *testing.T) {
+	ctx := context.Background()
+	syncer, fake, db := newTestSyncer(t, "betanet")
+
+	if err := syncer.checkChainReset(ctx); err != nil {
+		t.Fatalf("first reset check: %v", err)
+	}
+	seedNetwork(t, db, "betanet", 3_000_000)
+
+	// Same genesis, tip far below what we stored: a replica that is behind.
+	// Sync will not advance, but the data is still valid and must be kept.
+	fake.set("genesis-a", 12)
+	if err := syncer.checkChainReset(ctx); err != nil {
+		t.Fatalf("reset check with lagging indexer: %v", err)
+	}
+	if got := countNetworkRows(t, db, "betanet"); got != len(networkScopedTables) {
+		t.Errorf("rows = %d after lagging indexer, want %d", got, len(networkScopedTables))
+	}
+
+	syncer.warnOnHeightRegression(ctx) // logs only; must not panic or delete
+	if got := countNetworkRows(t, db, "betanet"); got != len(networkScopedTables) {
+		t.Errorf("rows = %d after regression warning, want %d", got, len(networkScopedTables))
+	}
+}
+
+func TestDeleteNetworkDataIsScopedToOneNetwork(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	seedNetwork(t, db, "topaz", 100)
+	seedNetwork(t, db, "staging", 200)
+
+	deleted, err := db.DeleteNetworkData("topaz")
+	if err != nil {
+		t.Fatalf("delete network data: %v", err)
+	}
+	if want := int64(len(networkScopedTables)); deleted != want {
+		t.Errorf("deleted %d rows, want %d", deleted, want)
+	}
+	if got := countNetworkRows(t, db, "topaz"); got != 0 {
+		t.Errorf("topaz rows remaining: %d", got)
+	}
+	if got := countNetworkRows(t, db, "staging"); got != len(networkScopedTables) {
+		t.Errorf("staging rows = %d, want %d", got, len(networkScopedTables))
+	}
+}
+
+func TestMaxBlockHeight(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	// No data yet: 0 rather than an error, so callers can treat it as "unknown".
+	got, err := db.MaxBlockHeight("topaz")
+	if err != nil {
+		t.Fatalf("max block height on empty db: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("height = %d on empty db, want 0", got)
+	}
+
+	if err := db.UpsertTransaction("topaz", "A", 10, "", 0, 0, 0, true); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := db.UpsertTransaction("topaz", "B", 42, "", 0, 0, 0, true); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := db.UpsertTransaction("staging", "C", 99, "", 0, 0, 0, true); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err = db.MaxBlockHeight("topaz")
+	if err != nil {
+		t.Fatalf("max block height: %v", err)
+	}
+	if got != 42 {
+		t.Errorf("height = %d, want 42 (highest for topaz, ignoring other networks)", got)
+	}
+}


### PR DESCRIPTION
Closes #19.

Sync cursors are derived from the highest block height already stored for a network (`syncer.go`), which is correct for a chain that only moves forward and broken for one that restarts. After a reset to a lower height, the cursor sits above the new tip permanently: every pass asks the indexer for blocks that do not exist yet, stores nothing, and reports success. The network silently freezes.

The stale rows are also actively wrong rather than merely old — post-reset those heights and tx hashes no longer refer to anything on that chain, but they keep being served from `/api/*` as current.

## Detection: genesis fingerprint, not height regression

Detection uses a fingerprint of block 1 (`chain_id + ":" + hash`) stored in `sync_state` per network, compared on every pass.

Height regression is deliberately *not* the trigger. A lagging indexer replica also reports a tip below what we have stored, and wiping a large chain because a replica was briefly behind would be worse than the bug being fixed. Chain ID alone does not work either — verified against the live networks, a reset keeps its chain ID:

| network | chain_id | block 1 hash | genesis time |
|---|---|---|---|
| topaz | `topaz-1` | `4ijwK4ft3cOz…` | 2026-07-12 |
| betanet | `gnoland1` | `QER3KkgN0LtK…` | 2026-03-16 |
| staging | `staging` | `1UPHCjDyksFE…` | 2026-03-19 |

`staging` keeps the chain ID `staging` across resets, so only the block-1 hash distinguishes one instance from the next. All three indexers answer a `getBlocks(where:{height:{eq:1}})` query, so this needs no RPC endpoint and works for networks configured with `indexer` only.

## Behavior

- **Fingerprint differs** → log loudly, delete every row for that network in one transaction, store the new fingerprint, resume from the new genesis.
- **No stored fingerprint** (first sync, or a database predating this change) → record it and carry on. Existing deployments are not wiped on upgrade.
- **Fingerprint matches** → no-op.
- **Fingerprint unavailable** (indexer down, block 1 pruned, malformed response) → log and skip the check. Never wipe on uncertainty; a transient outage must not become data loss.
- **Same fingerprint but a regressed tip** → one warning line naming both heights, no deletion. This is the lagging-replica case, and previously it was indistinguishable from a freeze.

The wipe covers all seven network-scoped tables (`packages`, `package_files`, `dependencies`, `calls`, `msg_runs`, `bank_sends`, `transactions`) via `DB.DeleteNetworkData`, in a single transaction, scoped by `network` so other networks in the same database are untouched.

## Tests

`syncer_test.go` runs the syncer against an `httptest` fake indexer and a real temp SQLite database:

- a reset (same chain ID, new block 1) discards that network's rows, leaves a second network's rows intact, and updates the stored fingerprint so it is not re-detected
- an unreachable indexer keeps all rows — the case that must never wipe
- a lagging indexer (same genesis, tip at 12 vs 3,000,000 stored) keeps all rows
- `DeleteNetworkData` is scoped to one network and reports the row count
- `MaxBlockHeight` returns 0 rather than an error on an empty database, and ignores other networks

## Cost

Two extra indexer queries per network per sync pass (block 1, latest height). Both are cheap point queries against an API already being polled every 30s.

Also formats the trailing blank line at the end of `syncer.go`, which `gofmt` had been flagging on `main`.
