### PR TITLE
docs: add AGENTS.md, docs/ folder and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md
+
+Conventions and invariants for working in this repo. Read this first; it is meant
+to stay stable. For what the system *is* and how it behaves, see [`docs/`](docs/)
+— that changes far more often and is deliberately kept separate.
+
+## What this is
+
+A single Go binary that serves a gno.land block explorer with an embedded
+frontend. No build step for the frontend, no Node.js in the shipped artifact.
+
+## Layout
+
+```
+main.go       entrypoint: flags, wiring, HTTP routes
+config.go     network configuration and flag resolution
+indexer.go    GraphQL client for the tx-indexer API
+db.go         SQLite storage: schema, migrations, all queries
+analyzer.go   import extraction from .gno source, dependency graph building
+syncer.go     background sync from tx-indexer into SQLite
+api.go        REST API handlers
+ws.go         SSE live feed (polls the indexer, fans out to browsers)
+frontend/     static HTML/JS/CSS, embedded with go:embed
+docs/         project documentation
+```
+
+See [`docs/architecture.md`](docs/architecture.md) for how these fit together.
+
+## Invariants
+
+Break these and things go wrong in ways that are hard to see:
+
+- **Everything is network-scoped.** Rows in `packages`, `package_files`,
+  `dependencies`, `calls`, `msg_runs`, `bank_sends` and `transactions` all carry a
+  `network` column, and it is part of the primary key or unique constraint. Any
+  new query, join or aggregate must filter or group by `network`, otherwise data
+  from two chains gets silently mixed. Joins on `pkg_path` alone are the usual way
+  this goes wrong.
+- **Sync is incremental and cursor-driven.** Cursors are derived from the highest
+  stored `block_height` for that network, not stored separately. Anything that
+  deletes or rewrites rows moves the cursor as a side effect.
+- **`network` IDs are labels, not chain IDs.** They name a configured network and
+  key its data. Renaming one orphans its existing rows.
+- **The frontend builds DOM, never HTML strings.** Use the `el()` helper. There is
+  no `innerHTML` with interpolated data anywhere, and it should stay that way —
+  the explorer renders on-chain content, all of which is attacker-controlled.
+- **Never commit the built binary.** `mygnoscan` and `*.db` are gitignored.
+
+## Conventions
+
+- **Go**, latest stable. Toolchain version comes from `go.mod`.
+- **Formatting is enforced.** `gofmt -l .` must be empty; CI fails otherwise.
+- **Tests are table-driven** where there is more than one case, with a temp
+  SQLite file rather than a mock. The driver (`modernc.org/sqlite`) is pure Go, so
+  a real database works everywhere including CI.
+- **Commits are conventional and single-line**: `feat:`, `fix:`, `docs:`, `ci:`,
+  `refactor:`, `test:`, `chore:`. No trailing co-author lines.
+- **`make` targets** are the entry points: `test`, `run`, `install`, `dev`.
+- **Errors go up, not into logs.** The exception is the sync loop, which logs and
+  continues per-item so one bad package cannot stall a whole pass. Do not copy
+  that pattern into query paths — several aggregate readers currently swallow
+  errors and return zeroes, and that is a known bug, not a style to follow.
+
+## Before opening a PR
+
+```bash
+gofmt -l .        # must print nothing
+go vet ./...
+go test ./...
+```
+
+CI runs the same three plus `golangci-lint` and a multi-arch Docker build. See
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Gotchas
+
+- `db.go` is large and mixes schema, migrations and every query. Adding to it is
+  fine; just know that queries are not grouped by domain yet.
+- The startup migration path rebuilds tables (`packages_new` and friends) to add
+  columns SQLite cannot add in place. It runs against real user data on every
+  deploy, so treat changes there as high-risk.
+- `network` is string-concatenated into a few aggregate queries rather than bound
+  as a parameter. It is quote-escaped, so not currently exploitable, but do not
+  add more of it — bind parameters.
+- Some `/api/*` endpoints query the indexer live on every request instead of
+  reading local SQLite. Check which before assuming an endpoint is cheap.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,38 +1,13 @@
-# mygnoscan
+# CLAUDE.md
 
-## Architecture
+See [AGENTS.md](AGENTS.md) for repo conventions and invariants, and
+[`docs/`](docs/) for what the system does:
 
-Single Go binary with embedded frontend. No build step for frontend.
+- [`docs/spec.md`](docs/spec.md) — what mygnoscan is, and its data model
+- [`docs/architecture.md`](docs/architecture.md) — components and data flow
+- [`docs/api.md`](docs/api.md) — HTTP API reference
+- [`docs/development.md`](docs/development.md) — local development
+- [`docs/deployment.md`](docs/deployment.md) — running it for real
 
-```
-main.go       - entrypoint, HTTP server, route setup
-indexer.go    - GraphQL client for tx-indexer API
-db.go         - SQLite storage layer, queries, schema
-analyzer.go   - import extraction from .gno source, dependency graph building
-syncer.go     - background sync from tx-indexer to local SQLite
-api.go        - REST API handlers
-frontend/     - static HTML/JS/CSS (embedded via go:embed)
-```
-
-## Data flow
-
-1. **Syncer** periodically fetches all transactions from tx-indexer GraphQL
-2. **Analyzer** parses MsgAddPackage source files to extract `import "gno.land/..."` statements
-3. **DB** stores packages, files, dependency edges, call records, MsgRun sources
-4. **API** serves cached data from SQLite + live queries to tx-indexer
-5. **Frontend** is a vanilla JS SPA with D3 for dependency graphs
-
-## Key design decisions
-
-- SQLite for local cache (not in-memory) — survives restarts, enables complex queries
-- Import extraction via regex on .gno files — no Go parser needed, fast
-- Dependency graph is recursive (walks imports of imports)
-- MsgRun references found by LIKE search on stored source text
-- Frontend uses safe DOM construction (el() helper) — no innerHTML
-
-## tx-indexer endpoint
-
-Default: `https://indexer.gno.land/graphql/query`
-
-Queries: `getTransactions` (with filters), `getBlocks`, `latestBlockHeight`
-Message types: MsgAddPackage, MsgCall, MsgRun, BankMsgSend
+This file is intentionally a pointer. Instructions live in `AGENTS.md` so every
+tool reads the same thing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing
+
+## Setup
+
+Go, version per `go.mod`. That is all — no CGO, no system SQLite, no Node.js.
+
+```bash
+git clone https://github.com/gnoverse/mygnoscan
+cd mygnoscan
+make run      # http://localhost:8888
+```
+
+See [`docs/development.md`](docs/development.md) for the development loop, how to
+point the binary at a specific indexer, and how to work offline against an existing
+database.
+
+## Make targets
+
+| target | what it does |
+|---|---|
+| `make run` | run from source |
+| `make dev` | run with hot reload (`goloop`) |
+| `make test` | `go test ./...` |
+| `make install` | install the binary |
+
+## Before opening a PR
+
+```bash
+gofmt -l .        # must print nothing
+go vet ./...
+go test ./...
+```
+
+CI runs those three, plus `golangci-lint` and a multi-arch Docker build. A PR that
+fails `gofmt` fails CI.
+
+## Commits
+
+Conventional, single line, imperative:
+
+```
+feat: add per-realm activity time series
+fix: honor -indexer without -network
+docs: document network scoping
+ci: pin actions to commit SHAs
+```
+
+Prefixes in use: `feat`, `fix`, `docs`, `ci`, `refactor`, `test`, `chore`, `build`.
+
+Keep commits atomic — a formatting sweep and a behavior change should not share a
+commit.
+
+## Code
+
+Read [AGENTS.md](AGENTS.md) before a first change. The short version:
+
+- **Everything is network-scoped.** New queries, joins and aggregates must filter or
+  group by `network`. Joining on package path alone silently mixes chains.
+- **Bind SQL parameters.** A few existing aggregate queries concatenate the network
+  string; do not add more.
+- **The frontend builds DOM, never HTML strings.** Use the `el()` helper. Everything
+  rendered comes from the chain and is attacker-controlled.
+- **Return errors, do not log and continue.** The sync loop is the deliberate
+  exception, so one bad package cannot stall a pass.
+
+## Tests
+
+Table-driven where there is more than one case. Prefer a temp SQLite file over a
+mock, and an `httptest` server over a fake client — the driver is pure Go, so real
+databases work in CI.
+
+Coverage is thin right now, so tests with new code are especially welcome. High-value
+untested areas are listed in
+[#14](https://github.com/gnoverse/mygnoscan/issues/14).
+
+## Pull requests
+
+- Say what changes and why. If it fixes a bug, describe the failure it produces.
+- Link the issue (`Closes #N`).
+- Call out behavior changes that affect running deployments — config handling and
+  sync semantics both have live consequences.
+- One concern per PR.
+
+## Reporting bugs
+
+Include the output of `/api/version` and `/api/networks`, the network in question,
+and whether the instance uses a config file or flags. A surprising number of issues
+turn out to be an instance pointed at a different chain than intended.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Built on the [tx-indexer](https://github.com/gnolang/tx-indexer) GraphQL API wit
 - **Dependency graph** — interactive D3 visualization of what imports what
 - **Transaction inspector** — full message details, events, errors
 - **Usage tracking** — direct MsgCall, indirect imports from other contracts, MsgRun references
+- **Multi-network** — track several chains in one instance and one database
 - **Smart caching** — SQLite stores computed dependency graphs and usage stats
 - **Single binary** — Go backend with embedded frontend, no Node.js
 
@@ -21,26 +22,81 @@ mygnoscan
 # open http://localhost:8888
 ```
 
-## Usage
+By default it syncs the built-in default networks. To point it at one specific
+indexer:
+
+```bash
+mygnoscan -indexer https://indexer.topaz.testnets.gno.land/graphql/query -network topaz
+```
+
+For several networks at once, use a config file:
+
+```json
+{
+  "networks": [
+    {"id": "topaz", "indexer": "https://indexer.topaz.testnets.gno.land/graphql/query", "rpc": "https://rpc.topaz.testnets.gno.land"},
+    {"id": "betanet", "indexer": "https://indexer.betanet.testnets.gno.land/graphql/query", "rpc": "https://rpc.betanet.testnets.gno.land"}
+  ]
+}
+```
+
+```bash
+mygnoscan -config networks.json
+```
+
+## Flags
 
 ```
 mygnoscan [flags]
   -listen    listen address (default ":8888")
-  -indexer   tx-indexer GraphQL endpoint (default "https://indexer.gno.land/graphql/query")
   -db        SQLite database path (default "mygnoscan.db")
-  -sync      sync data from indexer on start (default true)
+  -config    JSON config file, for multiple networks
+  -network   single network ID
+  -indexer   single network tx-indexer GraphQL URL
+  -rpc       single network RPC URL (needed for account balances)
+  -sync      run the background sync (default true)
 ```
+
+`-config` and the single-network flags are mutually exclusive. Startup logs which
+configuration source was used and which networks resulted — worth checking, along
+with `/api/networks`, after any config change.
+
+## Docker
+
+```bash
+docker run -p 8888:8888 ghcr.io/gnoverse/mygnoscan:main
+```
+
+## Documentation
+
+| | |
+|---|---|
+| [docs/spec.md](docs/spec.md) | what mygnoscan is, and its data model |
+| [docs/architecture.md](docs/architecture.md) | components, data flow, design decisions |
+| [docs/api.md](docs/api.md) | full HTTP API reference |
+| [docs/development.md](docs/development.md) | local development |
+| [docs/deployment.md](docs/deployment.md) | running it for real |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | how to contribute |
+| [AGENTS.md](AGENTS.md) | conventions and invariants for code changes |
 
 ## API
 
+The most-used endpoints — see [docs/api.md](docs/api.md) for all of them, including
+analytics, time series and the SSE live feed.
+
 | Endpoint | Description |
 |---|---|
+| `GET /api/networks` | Configured network IDs |
 | `GET /api/stats` | Aggregate statistics |
-| `GET /api/realms` | List realms (query: `limit`, `offset`) |
+| `GET /api/realms` | List realms (`limit`, `offset`) |
 | `GET /api/packages` | List all packages |
 | `GET /api/realm/{path}` | Realm/package detail with deps, calls, source |
+| `GET /api/deps/{path}` | Dependency graph (`?dir=dependents` for reverse) |
 | `GET /api/tx/{hash}` | Transaction detail |
 | `GET /api/txs` | Recent transactions |
 | `GET /api/address/{addr}` | Address activity |
 | `GET /api/search?q=...` | Search packages by path, name, creator |
-| `GET /api/deps/{path}` | Dependency graph (`?dir=dependents` for reverse) |
+| `GET /api/live` | Live block/tx feed (SSE) |
+
+Most endpoints accept `?network=<id>` to scope results to one network; omitting it
+spans all of them.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,110 @@
+# HTTP API
+
+All responses are JSON. Errors are `{"error": "..."}` with a non-200 status.
+
+## Common parameters
+
+**`network`** — accepted by most endpoints. A configured network ID restricts
+results to that network. `all`, or omitting it, applies **no filter**, so results
+span every configured network.
+
+Careful with the unfiltered case on anything address-related: a balance or RPC
+lookup has to resolve against exactly one network, and with no filter it uses the
+first configured network that has an RPC URL, regardless of where the address is
+actually active.
+
+**`limit`, `offset`** — pagination, where supported. Noted per endpoint below.
+
+**Time-series parameters**, on every `/api/timeseries/*` endpoint:
+
+| parameter | values | default |
+|---|---|---|
+| `days` | 1–365, clamped | `30` |
+| `granularity` | `hourly`, `daily`, `weekly` | `daily` |
+
+## Meta
+
+| endpoint | description |
+|---|---|
+| `GET /api/version` | build info: `git_hash`, `build_time` |
+| `GET /api/networks` | configured network IDs — the fastest way to confirm which chains an instance is actually serving |
+
+## Packages and realms
+
+| endpoint | description |
+|---|---|
+| `GET /api/realms` | list realms. `limit`, `offset` |
+| `GET /api/packages` | list all packages, realms and pure packages. `limit`, `offset` |
+| `GET /api/realm/{path...}` | detail for one package: metadata, source files, imports, dependents, callers, MsgRun references |
+| `GET /api/deps/{path...}` | dependency graph as `{path: [imports]}`. `dir=dependents` reverses direction |
+| `GET /api/storage/{path...}` | storage events for a package |
+| `GET /api/events/{path...}` | events emitted by a package |
+
+## Transactions and blocks
+
+| endpoint | description |
+|---|---|
+| `GET /api/txs` | recent transactions. Queried live from the indexer |
+| `GET /api/tx/{hash}` | one transaction: messages, events, errors |
+| `GET /api/blocks` | recent blocks. `limit` |
+| `GET /api/block/{height}` | one block and its transactions |
+| `GET /api/allevents` | recent events across all packages |
+
+## Addresses and accounts
+
+| endpoint | description |
+|---|---|
+| `GET /api/address/{addr}` | activity for an address: calls, deploys, runs, sends, and balance |
+| `GET /api/accounts` | most active accounts. **Returns the top 100 by total activity, with no pagination or sort controls** |
+
+## Aggregates
+
+| endpoint | description |
+|---|---|
+| `GET /api/stats` | totals: transactions, calls, deploys, msg_runs, sends, realms, packages, unique callers, latest block |
+| `GET /api/analytics` | leaderboards and aggregate breakdowns |
+| `GET /api/gas` | gas usage, by realm |
+| `GET /api/bankstats` | transfer volume statistics |
+| `GET /api/tokens` | detected token packages |
+| `GET /api/validators` | validator set |
+| `GET /api/govdao` | GovDAO activity |
+| `GET /api/sanity/overview` | internal consistency counters, for debugging a sync |
+
+## Time series
+
+All accept `days` and `granularity`.
+
+| endpoint | description |
+|---|---|
+| `GET /api/timeseries/transactions` | transaction counts |
+| `GET /api/timeseries/packages` | deployments |
+| `GET /api/timeseries/callers` | unique callers |
+| `GET /api/timeseries/gas` | gas consumption |
+| `GET /api/timeseries/active-addresses` | active addresses |
+| `GET /api/timeseries/health` | chain health indicators |
+| `GET /api/timeseries/storage` | storage growth. `realm=<path>` scopes it to one realm |
+| `GET /api/timeseries/storage/realms` | realms that have storage data, for populating a selector |
+
+There is no per-realm **activity** time series; `storage` is the only endpoint that
+accepts a `realm` parameter.
+
+## Search
+
+```
+GET /api/search?q=<query>
+```
+
+Searches **package paths, names and creators only**. It does not search
+transaction hashes, block heights, or addresses — an address matches only when it
+happens to be a package creator.
+
+## Live feed
+
+```
+GET /api/live?network=<id>
+```
+
+Server-Sent Events. Emits `{"type": "block" | "tx", "network_id": ..., "payload": ...}`
+as new blocks arrive, with a keepalive comment every 15s. Omitting `network`, or
+passing `all`, subscribes to every network. The server polls the indexer every 3s
+while at least one client is connected.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,120 @@
+# Architecture
+
+## Shape
+
+One Go binary. SQLite on disk. Frontend compiled in via `go:embed`. No Node.js,
+no separate frontend build, no external services beyond the tx-indexer it reads
+from.
+
+```
+                    ┌──────────────┐
+                    │  tx-indexer  │  GraphQL, one per network
+                    └──────┬───────┘
+                           │
+        ┌──────────────────┼──────────────────┐
+        │                  │                  │
+   ┌────▼─────┐      ┌─────▼─────┐      ┌─────▼─────┐
+   │  syncer  │      │    api    │      │ live feed │
+   │ (per net)│      │ (handlers)│      │   (SSE)   │
+   └────┬─────┘      └─────┬─────┘      └─────┬─────┘
+        │                  │                  │
+   ┌────▼──────────────────▼────┐             │
+   │        SQLite (db.go)      │             │
+   └────────────────────────────┘             │
+                    │                         │
+              ┌─────▼─────────────────────────▼─────┐
+              │   frontend/index.html (go:embed)    │
+              └─────────────────────────────────────┘
+```
+
+## Components
+
+**`main.go`** — flags, config resolution, database open, one syncer goroutine per
+configured network, route table, graceful shutdown. Thin by intent; the route
+table is the bulk of it.
+
+**`config.go`** — `NetworkConfig` (id, indexer URL, optional RPC URL) and
+`ResolveConfig`, which decides where configuration comes from: an explicit
+`-config` file, single-network flags, a `networks.json` in the working directory,
+or built-in defaults. Incomplete or contradictory input is an error rather than a
+silent fallback, because an instance pointed at the wrong chain looks healthy.
+
+**`indexer.go`** — GraphQL client. One instance per network. Every query the
+explorer needs lives here: transactions by various filters, blocks, latest height.
+
+**`syncer.go`** — the background loop, one per network, every 30s. Each pass
+checks chain identity, then syncs packages, calls/sends, and msg_runs. Cursors come
+from the highest stored height, so a pass only fetches what is new.
+
+**`analyzer.go`** — takes `MsgAddPackage` source and extracts
+`import "gno.land/..."` statements by regex, then writes package, file and
+dependency rows.
+
+**`db.go`** — schema, startup migrations, and every query. Large and not yet split
+by domain.
+
+**`api.go`** — HTTP handlers. Most read SQLite; some query the indexer live.
+
+**`ws.go`** — Server-Sent Events. Polls the indexer for new blocks every 3s and
+fans out to connected browsers. Starts polling on the first subscriber and stops
+when the last one leaves.
+
+**`frontend/index.html`** — the whole client: markup, CSS and vanilla JS in one
+file, with D3 for the dependency graph. Routing is client-side; the server serves
+`index.html` for any non-API path.
+
+## Data flow
+
+1. The syncer asks the indexer for transactions above its cursor.
+2. `MsgAddPackage` messages go to the analyzer, which extracts imports and writes
+   packages, files and dependency edges. `MsgCall`, `MsgRun` and `BankMsgSend`
+   become `calls`, `msg_runs` and `bank_sends` rows. Every transaction also becomes
+   a `transactions` row with its gas and success status.
+3. Block times are fetched per unique height and stamped onto the rows.
+4. Handlers read SQLite, and for a few endpoints query the indexer or RPC live.
+5. The frontend calls `/api/*` and renders.
+
+## Design decisions
+
+**SQLite on disk, not in memory.** Survives restarts, so a restart is not a full
+re-sync, and it makes the recursive dependency queries and time-series aggregates
+possible at all.
+
+**Regex import extraction, not a Go parser.** Imports are the only thing needed,
+they are syntactically trivial, and this keeps the binary free of the Go toolchain.
+The tradeoff is no understanding of anything needing type resolution.
+
+**Recursive dependency walking at query time, not materialized.** The graph is
+small enough, and materializing it would need invalidation on every new deployment.
+
+**Per-network syncer goroutines sharing one database.** Networks sync
+independently at their own pace; the `network` column keeps them separate. An
+application-level `RWMutex` guards writes, which is redundant with WAL and mostly
+serializes writers — a known wart.
+
+**MsgRun references by text search.** A `MsgRun` carries source, not a structured
+import list, so a substring match is the only option. Accepts false positives.
+
+**DOM construction, never HTML strings.** The explorer renders package names,
+source and addresses straight from chain data, all of which is attacker-supplied.
+A single `innerHTML` with interpolation would be an XSS hole, so the frontend uses
+an `el()` helper throughout.
+
+**Polling SSE rather than WebSockets.** The indexer has no subscription API worth
+relying on, and SSE survives proxies without special configuration.
+
+## Known weak points
+
+Documented so they are not rediscovered as surprises:
+
+- `db.go` (schema + migrations + all queries) and `api.go` are large and mix
+  concerns.
+- The startup migration path rebuilds tables to add columns, running against real
+  data on every deploy.
+- Several aggregate readers swallow errors and return zeroes rather than failing.
+- Some analytics joins group by path without including `network`, risking
+  cross-network double counting.
+- Database methods do not take a `context.Context`, so a client disconnect does not
+  cancel an expensive scan.
+- Block-time stamping issues one indexer call per unique height per list request.
+- The frontend is a single 3000+ line file with no component boundaries.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,147 @@
+# Deployment
+
+One static binary and one SQLite file. No runtime dependencies.
+
+## Flags
+
+| flag | default | description |
+|---|---|---|
+| `-listen` | `:8888` | listen address |
+| `-db` | `mygnoscan.db` | SQLite database path |
+| `-config` | — | JSON config file, for multiple networks |
+| `-network` | — | single network ID |
+| `-indexer` | — | single network tx-indexer GraphQL URL |
+| `-rpc` | — | single network RPC URL, needed for account balances |
+| `-sync` | `true` | run the background sync |
+
+## Configuration
+
+Config comes from exactly one of these, in order:
+
+1. `-config <path>`
+2. the single-network flags (`-indexer`, optionally `-network` and `-rpc`)
+3. `networks.json` in the working directory
+4. built-in defaults
+
+Combining `-config` with the single-network flags is an error, as is passing
+`-network` or `-rpc` without `-indexer`. Startup logs which source was used and the
+resulting network IDs:
+
+```
+networks [topaz betanet] (from config file)
+```
+
+Check that line, or `/api/networks`, after any config change. A wrongly configured
+instance starts cleanly, syncs real data and looks healthy — it is just the wrong
+chain.
+
+### Config file
+
+```json
+{
+  "networks": [
+    {
+      "id": "topaz",
+      "indexer": "https://indexer.topaz.testnets.gno.land/graphql/query",
+      "rpc": "https://rpc.topaz.testnets.gno.land"
+    },
+    {
+      "id": "betanet",
+      "indexer": "https://indexer.betanet.testnets.gno.land/graphql/query",
+      "rpc": "https://rpc.betanet.testnets.gno.land"
+    }
+  ]
+}
+```
+
+`id` and `indexer` are required for every network, and IDs must be unique. `rpc` is
+optional but **account balances need it** — an address on a network with no `rpc`
+shows no balance.
+
+Give each network an `rpc` if you can. Balance lookups resolve against a single
+network, and with no network filter they fall back to the first configured network
+that has one.
+
+## Choosing network IDs
+
+The `id` labels the network and keys every row belonging to it. It is not the chain
+ID and nothing ties the two together.
+
+**Renaming an ID orphans the data stored under the old one.** Since sync cursors
+are derived from the highest stored height per network, a renamed network looks
+brand new and re-syncs from genesis. To relabel while keeping history, update the
+`network` column across all seven network-scoped tables (`packages`,
+`package_files`, `dependencies`, `calls`, `msg_runs`, `bank_sends`,
+`transactions`) — that preserves the cursor too. Back up first.
+
+## Reset-prone networks
+
+Portal-loop and staging style chains restart from a low height. mygnoscan detects
+this by fingerprinting block 1 (chain ID plus hash) per network: when the
+fingerprint changes, that network's rows are discarded and it re-syncs from the new
+genesis. Chain ID alone is not enough — a reset chain keeps its chain ID.
+
+A lagging indexer replica reporting a tip below the stored height is *not* treated
+as a reset. It logs a warning and changes nothing.
+
+## Running it
+
+Any process supervisor works. A systemd unit needs nothing special:
+
+```ini
+[Unit]
+Description=mygnoscan
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/mygnoscan --listen 127.0.0.1:8888 --db /var/lib/mygnoscan/mygnoscan.db --config /etc/mygnoscan/networks.json
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Put it behind a reverse proxy for TLS. `/api/live` is Server-Sent Events, so
+disable response buffering for it (nginx: `proxy_buffering off`); Caddy's default
+`reverse_proxy` needs no change.
+
+## Docker
+
+A multi-arch image is published to GHCR on every push to `main`:
+
+```bash
+docker run -p 8888:8888 \
+  -v mygnoscan-data:/data \
+  ghcr.io/gnoverse/mygnoscan:main \
+  --listen :8888 --db /data/mygnoscan.db --config /data/networks.json
+```
+
+Prefer the image over hand-copied binaries. A deployment updated by scp drifts, and
+a stale binary is hard to notice: check `/api/version`, and if `git_hash` is `dev`
+the build carries no version information at all.
+
+## Operating notes
+
+- **Sync runs every 30s per network**, incrementally, from the highest stored
+  height. Restarts do not re-sync from scratch.
+- **A full first sync of a busy chain is expensive** in time and indexer requests.
+  Adding a network to an existing instance triggers one for that network only.
+- **Use a local indexer where you have one.** It is faster and avoids depending on
+  a public endpoint.
+- **The database grows with source code**, since full `.gno` file bodies are stored.
+  Expect tens of MB per busy network.
+- **WAL mode is on**, so back up the `-wal` and `-shm` files alongside the database,
+  or take the backup with the service stopped.
+
+## Health checks
+
+```bash
+curl -s localhost:8888/api/version    # which build
+curl -s localhost:8888/api/networks   # which chains
+curl -s localhost:8888/api/stats      # is data actually landing
+```
+
+In the logs, per-pass `synced N packages` lines with small counts mean incremental
+sync is working. Large counts on every pass mean it is re-syncing everything, which
+is the signature of a build predating incremental sync.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,93 @@
+# Development
+
+## Requirements
+
+Go, version per `go.mod`. Nothing else — `modernc.org/sqlite` is pure Go, so there
+is no CGO and no system SQLite, and the frontend needs no build step.
+
+## Loop
+
+```bash
+make run
+# http://localhost:8888
+```
+
+```bash
+make dev     # same, with hot reload via goloop
+```
+
+`make install` puts the binary on your `PATH`. `make test` runs `go test ./...`.
+
+Frontend changes are picked up on rebuild, since `frontend/` is embedded with
+`go:embed`. There is no watcher for it on its own — `make dev` restarting the
+binary is the whole story.
+
+## Pointing it somewhere
+
+By default it syncs the built-in default networks. To use one specific indexer:
+
+```bash
+go run . -indexer http://127.0.0.1:8546/graphql/query -network local
+```
+
+For more than one network, use a config file — see
+[`deployment.md`](deployment.md) for the format and the full flag list.
+
+To work against existing data without hitting an indexer at all:
+
+```bash
+go run . -db ./mygnoscan.db -sync=false
+```
+
+`-sync=false` is the flag to reach for when iterating on the frontend or on
+handlers: no background sync, no network traffic, stable data.
+
+## First sync
+
+A full sync of a busy chain takes a while and makes a lot of indexer requests. For
+day-to-day work, prefer a small testnet, or copy an existing database and run with
+`-sync=false`.
+
+## Tests
+
+```bash
+go test ./...
+go test ./... -run TestResolveConfig -v
+```
+
+Tests use temp SQLite files rather than mocks, and an `httptest` server in place of
+a real indexer. Table-driven where there is more than one case.
+
+## Before pushing
+
+```bash
+gofmt -l .        # must print nothing
+go vet ./...
+go test ./...
+```
+
+Same checks CI runs, plus `golangci-lint` and a multi-arch Docker build.
+
+## Poking at it
+
+```bash
+curl -s localhost:8888/api/networks          # which chains am I actually serving
+curl -s localhost:8888/api/version           # which build is this
+curl -s localhost:8888/api/stats | jq
+curl -s localhost:8888/api/sanity/overview | jq
+curl -N localhost:8888/api/live              # watch the SSE feed
+```
+
+`/api/networks` is the first thing to check when data looks wrong — a
+misconfigured instance syncs happily from a chain you did not intend.
+
+The database is ordinary SQLite:
+
+```bash
+sqlite3 mygnoscan.db 'SELECT network, COUNT(*) FROM packages GROUP BY network;'
+```
+
+## Layout
+
+See [AGENTS.md](../AGENTS.md) for file-by-file layout and the invariants to
+respect, and [architecture.md](architecture.md) for how the pieces interact.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,0 +1,76 @@
+# Specification
+
+What mygnoscan is, what it stores, and what it means.
+
+## Purpose
+
+A block explorer for [gno.land](https://gno.land) chains, focused on the thing
+generic explorers do badly: **what code is deployed, what it imports, and who
+calls it.** Transactions and blocks are table stakes; the dependency and usage
+graph between realms is the point.
+
+It tracks multiple networks in one instance and one database.
+
+## Scope
+
+mygnoscan reads from a [tx-indexer](https://github.com/gnolang/tx-indexer)
+GraphQL endpoint, and optionally from an RPC endpoint for state that the indexer
+does not carry (account balances). It never writes to a chain, holds keys, or
+signs anything.
+
+## Data model
+
+Every table below carries a `network` column that is part of its primary key or
+unique constraint. **Network scoping is the central invariant**: the same package
+path exists on multiple chains and means different things on each.
+
+| table | grain | notes |
+|---|---|---|
+| `packages` | one deployed package per network | `is_realm` distinguishes realms from pure packages |
+| `package_files` | one `.gno` file | full source body, stored verbatim |
+| `dependencies` | one import edge | `package_path` → `import_path` |
+| `calls` | one `MsgCall` message | caller, target path, function name |
+| `msg_runs` | one `MsgRun` message | full source of the run |
+| `bank_sends` | one `BankMsgSend` message | from, to, amount |
+| `transactions` | one transaction | height, time, gas used/wanted/fee, success |
+| `sync_state` | key/value | sync bookkeeping, keyed with the network in the key |
+
+Derived, not stored:
+
+- **Dependency graphs** are computed by walking `dependencies` recursively, in
+  both directions (imports, and dependents).
+- **MsgRun references** to a package are found by substring search over
+  `msg_runs.source`. A `MsgRun` has no structured import list, so this is a text
+  match, and it will match a mention inside a comment or string.
+- **Account activity** is aggregated across `calls`, `msg_runs` and `bank_sends`.
+- **Balances** are not stored. They are fetched live from RPC per request.
+
+## Semantics worth knowing
+
+- **`network` IDs are labels.** They name a configured network and key its rows.
+  They are not chain IDs and nothing enforces a relationship between the two — the
+  same chain can be configured under any ID, and renaming an ID orphans the rows
+  stored under the old one.
+- **Sync cursors are derived, not stored.** The next fetch starts from the highest
+  `block_height` already stored for that network. This means deleting rows rewinds
+  the cursor, and it means a chain that resets to a lower height needs explicit
+  handling.
+- **Chain identity is fingerprinted** by the chain ID and hash of block 1, stored
+  in `sync_state`. A network that resets keeps its chain ID and comes back with a
+  different block 1, so the hash is what distinguishes one chain instance from the
+  next.
+- **Failed transactions are stored**, with `success = false`. Statistics that
+  should exclude them must filter explicitly.
+- **Import extraction is regex-based**, not a Go parse. It is fast and dependency
+  free; it will not understand anything that requires type information.
+- **`?network=all`, or omitting the parameter, means no filter** — results span
+  every configured network. For anything address- or balance-related this is a
+  known source of confusion, because those resolve against a single network.
+
+## Non-goals
+
+- Writing to chains, custody, or signing.
+- Being a general-purpose indexer: mygnoscan is a cache over one, not a
+  replacement for it.
+- Historical state reconstruction. It stores what transactions say, not what state
+  was at a given height.


### PR DESCRIPTION
Closes #13.

Splits documentation by lifecycle. `AGENTS.md` and `CLAUDE.md` hold *how to work in this repo* — conventions and invariants, which should rarely change. `docs/*` holds *what the system is*, which changes every time behavior does. Those two were previously tangled in one 38-line `CLAUDE.md`.

## Added

| file | contents |
|---|---|
| `AGENTS.md` | the real agent-facing instructions: layout, invariants, conventions, gotchas |
| `CLAUDE.md` | reduced to a pointer at `AGENTS.md` and `docs/` |
| `CONTRIBUTING.md` | setup, make targets, pre-PR checks, commit conventions, code expectations |
| `docs/spec.md` | what mygnoscan is, the data model table by table, semantics, non-goals |
| `docs/architecture.md` | components, data flow, design decisions *and why*, known weak points |
| `docs/api.md` | full `/api/*` reference |
| `docs/development.md` | local loop, pointing at an indexer, working offline, debugging |
| `docs/deployment.md` | flags, config resolution, network IDs, reset-prone chains, systemd, Docker, operating notes |

`CLAUDE.md` is kept as a stub rather than deleted so existing sessions still find the pointer.

## The invariants are the point

`AGENTS.md` documents things that are currently only discoverable by reading `db.go`:

- **Everything is network-scoped**, and joining on package path alone silently mixes chains.
- **Sync cursors are derived** from the highest stored block height, not stored separately — so deleting rows rewinds the cursor.
- **Network IDs are labels, not chain IDs**, and renaming one orphans its rows.
- **The frontend builds DOM, never HTML strings**, because everything it renders is attacker-controlled chain data.

Known weak points are written down too (oversized `db.go`/`api.go`, error-swallowing aggregate readers, missing `network` in some analytics joins, the risky rebuild-tables migration path, N+1 block-time stamping). Better recorded than rediscovered.

## README

Its `Usage` block was actively wrong: it documented `-indexer` with a default value as though it worked standalone, and never mentioned `-config`, `-network`, or `-rpc`. Now lists the real flags, shows both single-network and multi-network invocations, and links the docs. The API table keeps the most-used endpoints and defers the rest to `docs/api.md` — the old one also omitted `/api/networks`, `/api/accounts`, `/api/analytics`, the whole `/api/timeseries/*` family and `/api/live`.

## Two things deliberately not done

**No `LICENSE`.** #13 suggested adding one, but which license this ships under is an ownership decision, not a docs cleanup — say the word and I will add it in a one-line follow-up.

**Merge order matters.** `docs/deployment.md` and `docs/development.md` describe the config behavior from #21 (`-indexer` alone works, `-config` plus flags is an error, startup logs the source) and the reset handling from #22 (block-1 fingerprinting). Those statements are accurate once those two are merged, and premature before. Merge #21 and #22 first, or expect the docs to lead the code by a few minutes.

This branch is docs-only, so `gofmt` is untouched here — but once #23 lands its formatting gate, this branch needs a rebase to pick up the `api.go`/`syncer.go` formatting fixes before its CI will pass.
