### PR TITLE
fix: migrate databases created before the block_time column

### DIFF
--- a/db.go
+++ b/db.go
@@ -40,12 +40,85 @@ func NewDB(path string) (*DB, error) {
 		}
 	}
 
+	// Migrate: add block_time to tables created before it existed. Must run
+	// before initSchema, which builds indexes on that column.
+	if err := migrateAddBlockTime(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate block_time: %w", err)
+	}
+
 	if err := initSchema(db); err != nil {
 		db.Close()
 		return nil, err
 	}
 
 	return &DB{db: db}, nil
+}
+
+// blockTimeTables are the tables carrying a block_time column.
+var blockTimeTables = []string{"packages", "calls", "msg_runs", "bank_sends", "transactions"}
+
+// migrateAddBlockTime adds block_time to tables that predate it.
+//
+// CREATE TABLE IF NOT EXISTS cannot add a column to a table that already exists,
+// and initSchema creates indexes on block_time, so without this a database
+// written by a build older than the time-series work fails at startup with
+// "no such column: block_time" and the process exits.
+func migrateAddBlockTime(db *sql.DB) error {
+	for _, table := range blockTimeTables {
+		exists, err := tableExists(db, table)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			// initSchema will create it, block_time included.
+			continue
+		}
+		has, err := columnExists(db, table, "block_time")
+		if err != nil {
+			return err
+		}
+		if has {
+			continue
+		}
+		// Table names come from the constant above, never from input.
+		if _, err := db.Exec(fmt.Sprintf(`ALTER TABLE %s ADD COLUMN block_time TEXT`, table)); err != nil {
+			return fmt.Errorf("add block_time to %s: %w", table, err)
+		}
+	}
+	return nil
+}
+
+func tableExists(db *sql.DB, name string) (bool, error) {
+	var count int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, name,
+	).Scan(&count)
+	return count > 0, err
+}
+
+func columnExists(db *sql.DB, table, column string) (bool, error) {
+	// PRAGMA does not accept bound parameters; table comes from a constant.
+	rows, err := db.Query(fmt.Sprintf(`PRAGMA table_info(%s)`, table))
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid, notnull, pk int
+			name, ctype      string
+			dflt             sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 func migrateAddNetworkColumn(db *sql.DB) error {

--- a/db_test.go
+++ b/db_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// oldSchemaNoBlockTime is the schema as it existed after the network column was
+// added but before the time-series work introduced block_time. Databases in this
+// shape exist in the wild, and opening one used to fail at startup.
+const oldSchemaNoBlockTime = `
+CREATE TABLE packages (
+	network TEXT NOT NULL DEFAULT 'gnoland1',
+	path TEXT NOT NULL,
+	name TEXT NOT NULL,
+	creator TEXT NOT NULL,
+	block_height INTEGER NOT NULL,
+	tx_hash TEXT NOT NULL,
+	is_realm BOOLEAN NOT NULL,
+	num_files INTEGER NOT NULL,
+	created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (network, path)
+);
+CREATE TABLE package_files (
+	network TEXT NOT NULL DEFAULT 'gnoland1',
+	package_path TEXT NOT NULL,
+	file_name TEXT NOT NULL,
+	body TEXT NOT NULL,
+	PRIMARY KEY (network, package_path, file_name)
+);
+CREATE TABLE dependencies (
+	network TEXT NOT NULL DEFAULT 'gnoland1',
+	package_path TEXT NOT NULL,
+	import_path TEXT NOT NULL,
+	PRIMARY KEY (network, package_path, import_path)
+);
+CREATE TABLE calls (
+	tx_hash TEXT NOT NULL,
+	block_height INTEGER NOT NULL,
+	caller TEXT NOT NULL,
+	pkg_path TEXT NOT NULL,
+	func_name TEXT NOT NULL,
+	success BOOLEAN NOT NULL,
+	created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+	network TEXT NOT NULL DEFAULT 'gnoland1',
+	UNIQUE(network, tx_hash, pkg_path, func_name)
+);
+CREATE TABLE msg_runs (
+	tx_hash TEXT NOT NULL,
+	block_height INTEGER NOT NULL,
+	caller TEXT NOT NULL,
+	source TEXT NOT NULL,
+	success BOOLEAN NOT NULL,
+	created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+	network TEXT NOT NULL DEFAULT 'gnoland1',
+	UNIQUE(network, tx_hash, caller)
+);
+CREATE TABLE bank_sends (
+	tx_hash TEXT NOT NULL,
+	block_height INTEGER NOT NULL,
+	from_address TEXT NOT NULL,
+	to_address TEXT NOT NULL,
+	amount TEXT NOT NULL,
+	success BOOLEAN NOT NULL,
+	network TEXT NOT NULL DEFAULT 'gnoland1',
+	UNIQUE(network, tx_hash, from_address, to_address)
+);
+`
+
+func TestNewDBMigratesDatabaseWithoutBlockTime(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "old.db")
+
+	// Build a database in the pre-block_time shape and put a row in it, so the
+	// migration is proven to preserve data and not just to succeed.
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	if _, err := raw.Exec(oldSchemaNoBlockTime); err != nil {
+		t.Fatalf("create old schema: %v", err)
+	}
+	if _, err := raw.Exec(
+		`INSERT INTO packages (network, path, name, creator, block_height, tx_hash, is_realm, num_files)
+		 VALUES ('gnoland1', 'gno.land/r/demo/foo', 'foo', 'g1creator', 4242, 'TXHASH', 1, 1)`,
+	); err != nil {
+		t.Fatalf("seed package: %v", err)
+	}
+	if _, err := raw.Exec(
+		`INSERT INTO calls (tx_hash, block_height, caller, pkg_path, func_name, success, network)
+		 VALUES ('TXHASH', 4242, 'g1caller', 'gno.land/r/demo/foo', 'Bar', 1, 'gnoland1')`,
+	); err != nil {
+		t.Fatalf("seed call: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw db: %v", err)
+	}
+
+	// This used to fail with "no such column: block_time", because initSchema
+	// builds indexes on a column that CREATE TABLE IF NOT EXISTS cannot add.
+	db, err := NewDB(path)
+	if err != nil {
+		t.Fatalf("open old database: %v", err)
+	}
+	defer db.Close()
+
+	for _, table := range blockTimeTables {
+		has, err := columnExists(db.db, table, "block_time")
+		if err != nil {
+			t.Fatalf("inspect %s: %v", table, err)
+		}
+		if !has {
+			t.Errorf("%s is still missing block_time", table)
+		}
+	}
+
+	// Existing rows survive, and the sync cursor with them: it is derived from
+	// the highest stored block height, so losing rows would trigger a re-sync.
+	var height int
+	if err := db.db.QueryRow(
+		`SELECT block_height FROM packages WHERE path = 'gno.land/r/demo/foo'`,
+	).Scan(&height); err != nil {
+		t.Fatalf("read migrated package: %v", err)
+	}
+	if height != 4242 {
+		t.Errorf("block_height = %d after migration, want 4242", height)
+	}
+
+	var callers int
+	if err := db.db.QueryRow(`SELECT COUNT(*) FROM calls`).Scan(&callers); err != nil {
+		t.Fatalf("count calls: %v", err)
+	}
+	if callers != 1 {
+		t.Errorf("calls = %d after migration, want 1", callers)
+	}
+
+	// The migration must be idempotent: every start runs it again.
+	if err := migrateAddBlockTime(db.db); err != nil {
+		t.Errorf("second migration pass: %v", err)
+	}
+}
+
+func TestNewDBOnEmptyDatabase(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "fresh.db"))
+	if err != nil {
+		t.Fatalf("open fresh database: %v", err)
+	}
+	defer db.Close()
+
+	for _, table := range networkScopedTables {
+		exists, err := tableExists(db.db, table)
+		if err != nil {
+			t.Fatalf("inspect %s: %v", table, err)
+		}
+		if !exists {
+			t.Errorf("%s was not created", table)
+		}
+	}
+	for _, table := range blockTimeTables {
+		has, err := columnExists(db.db, table, "block_time")
+		if err != nil {
+			t.Fatalf("inspect %s: %v", table, err)
+		}
+		if !has {
+			t.Errorf("%s is missing block_time on a fresh database", table)
+		}
+	}
+}
+
+func TestNewDBIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reopen.db")
+
+	db, err := NewDB(path)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := db.UpsertPackage("topaz", "gno.land/r/demo/foo", "foo", "g1c", "TX", 7, "", true, 1); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	db.Close()
+
+	// Reopening runs the whole migration path again over real data, which is
+	// what happens on every restart and every deploy.
+	db2, err := NewDB(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer db2.Close()
+
+	height, err := db2.MaxBlockHeight("topaz")
+	if err != nil {
+		t.Fatalf("max block height: %v", err)
+	}
+	if height != 0 {
+		// UpsertPackage does not write to transactions, so 0 is expected here;
+		// the point is that reopening did not destroy anything.
+		t.Logf("max block height from transactions: %d", height)
+	}
+
+	var count int
+	if err := db2.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE network = 'topaz'`).Scan(&count); err != nil {
+		t.Fatalf("count packages: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("packages = %d after reopen, want 1", count)
+	}
+}


### PR DESCRIPTION
Found the hard way: upgrading a real deployment from an older build, the process refused to start.

```
error: init db: SQL logic error: no such column: block_time (1)
mygnoscan.service: Main process exited, code=exited, status=1/FAILURE
mygnoscan.service: Scheduled restart job, restart counter is at 2.
```

Restart loop, service down, no recovery without hand-editing the database.

## Cause

`block_time` was added to `packages`, `calls`, `msg_runs` and `bank_sends` by the time-series work, and `initSchema` creates indexes on it:

```sql
CREATE INDEX IF NOT EXISTS idx_calls_block_time ON calls(network, block_time);
```

But `CREATE TABLE IF NOT EXISTS` does nothing when the table already exists, so it never adds the column to an existing database. The migration path in `NewDB` handles two older shapes — dropping pre-`UNIQUE` tables, and rebuilding `packages` to add `network` — and neither covers `block_time`.

So **any database written by a build after the `network` migration but before the time-series work fails permanently at startup.** The affected database had exactly that shape:

```
packages    [network, path, name, creator, block_height, tx_hash, is_realm, num_files, created_at]
calls       [tx_hash, block_height, caller, pkg_path, func_name, success, created_at, network]
```

`network` present, `block_time` absent. The second migration is skipped because `packages` already has `network`, and then index creation fails.

## Fix

`migrateAddBlockTime` runs before `initSchema` and adds the column where a table exists without it:

- Skips tables that do not exist yet — `initSchema` creates those with the column already.
- Skips tables that already have it, so it is idempotent. It re-runs on every start.
- Covers `transactions` too, which has the same exposure for anyone whose database has that table without `block_time`.

Adds two small helpers, `tableExists` and `columnExists`, since the existing checks pattern-match against `sqlite_master` SQL text with `strings.Contains` — workable for `network`, but it would false-positive on `block_time` if any index or other table mentioned it.

## Tests

`db_test.go` builds a database in the exact pre-`block_time` shape, seeds a package and a call into it, then opens it with `NewDB`.

Verified as a real reproduction — with the migration call removed, the test fails with the production error verbatim:

```
--- FAIL: TestNewDBMigratesDatabaseWithoutBlockTime
    db_test.go:103: open old database: SQL logic error: no such column: block_time (1)
```

It asserts the column lands on every table, that the seeded rows survive, and that a second migration pass is clean. Row survival matters more than it looks: sync cursors are derived from the highest stored block height, so a migration that dropped rows would silently trigger a full re-sync.

Two more cases cover the paths that run on every deploy — a fresh database, and reopening an existing one.

This is the migration risk called out in #14, now with the first tests on it. Worth noting that the surviving untested part is the older `packages` table-rebuild path (`migrateAddNetworkColumn`), which is the more dangerous of the two since it copies data between tables.
