### PR TITLE
fix: render sort arrows using CSS escapes instead of JS syntax

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -81,9 +81,10 @@ pre { background: var(--bg2); border: 1px solid var(--border); border-radius: 4p
 /* Sortable headers */
 th.sortable { cursor: pointer; user-select: none; }
 th.sortable:hover { color: var(--accent); }
-th.sortable::after { content: ' \u2195'; font-size: 10px; opacity: 0.4; }
-th.sort-asc::after { content: ' \u2191'; opacity: 1; }
-th.sort-desc::after { content: ' \u2193'; opacity: 1; }
+/* CSS string escapes are bare hex; \u2195 is JS syntax and renders as "u2195". */
+th.sortable::after { content: ' \2195'; font-size: 10px; opacity: 0.4; }
+th.sort-asc::after { content: ' \2191'; opacity: 1; }
+th.sort-desc::after { content: ' \2193'; opacity: 1; }
 /* Total row */
 tr.total-row { border-top: 2px solid var(--border); }
 tr.total-row td { font-weight: bold; color: var(--accent); }


### PR DESCRIPTION
Closes #26.

Every sortable table header displayed `U2195` as literal text next to its label — `BLOCK U2195`, `REALM U2195`, `TYPE U2195`.

`content: ' ↕'` is JavaScript escape syntax. CSS string escapes are bare hex, so the `u` was taken as a literal character and the rest of the digits followed it. Changed to `\2195` / `\2191` / `\2193`.

Verified in a browser rather than by eye — the computed `::after` content is now a single code point 8597 (`↕`) preceded by a space, where it previously produced the five characters `u2195`.