### PR TITLE
fix: hide network badge when a single network is selected

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -604,6 +604,8 @@ function onNetworkChange() {
 }
 function netBadgeEl(networkId) {
   if (!networkId) return document.createTextNode('');
+  // Redundant when one network is selected: everything on screen belongs to it.
+  if (getNetwork() !== 'all') return document.createTextNode('');
   const span = document.createElement('span');
   span.className = 'net-badge net-' + networkId;
   span.textContent = networkId;


### PR DESCRIPTION
Closes #30.

With a specific network selected, rows still carried the network badge next to block numbers — most visibly in "latest realms" on the home page. Every row said `topaz` on a page that is entirely topaz.

The badge only carries information in all-networks mode. Gating it inside `netBadgeEl()` fixes all three call sites at once and keeps the callers unchanged.