### PR TITLE
feat: make home stat tiles link to their pages

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,6 +34,9 @@ nav a:hover, nav a.active { color: var(--accent); text-decoration: none; }
 .stat { display: flex; flex-direction: column; }
 .stat .label { font-size: 11px; color: var(--fg2); text-transform: uppercase; letter-spacing: 1px; }
 .stat .value { font-size: 20px; font-weight: bold; color: var(--accent); }
+.stat-link { cursor: pointer; }
+.stat-link:hover .label { color: var(--accent); }
+.stat-link:hover .value { text-decoration: underline; }
 main { padding: 20px 0; }
 .section { margin-bottom: 32px; }
 .section-title { font-size: 14px; color: var(--fg2); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
@@ -182,14 +185,14 @@ footer a:hover { color: var(--accent); }
 <div class="container">
   <div class="view active" id="view-home">
     <div class="stats-bar">
-      <div class="stat"><span class="label">txs</span><span class="value" id="stat-txs">-</span></div>
-      <div class="stat"><span class="label">calls</span><span class="value" id="stat-calls">-</span></div>
-      <div class="stat"><span class="label">deploys</span><span class="value" id="stat-deploys">-</span></div>
-      <div class="stat"><span class="label">runs</span><span class="value" id="stat-runs">-</span></div>
-      <div class="stat"><span class="label">sends</span><span class="value" id="stat-sends">-</span></div>
-      <div class="stat"><span class="label">realms</span><span class="value" id="stat-realms">-</span></div>
-      <div class="stat"><span class="label">packages</span><span class="value" id="stat-packages">-</span></div>
-      <div class="stat"><span class="label">block</span><span class="value" id="stat-block">-</span></div>
+      <div class="stat stat-link" data-goto="/txs"><span class="label">txs</span><span class="value" id="stat-txs">-</span></div>
+      <div class="stat stat-link" data-goto="/txs" data-type="MsgCall"><span class="label">calls</span><span class="value" id="stat-calls">-</span></div>
+      <div class="stat stat-link" data-goto="/txs" data-type="MsgAddPackage"><span class="label">deploys</span><span class="value" id="stat-deploys">-</span></div>
+      <div class="stat stat-link" data-goto="/txs" data-type="MsgRun"><span class="label">runs</span><span class="value" id="stat-runs">-</span></div>
+      <div class="stat stat-link" data-goto="/txs" data-type="BankMsgSend"><span class="label">sends</span><span class="value" id="stat-sends">-</span></div>
+      <div class="stat stat-link" data-goto="/realms"><span class="label">realms</span><span class="value" id="stat-realms">-</span></div>
+      <div class="stat stat-link" data-goto="/packages"><span class="label">packages</span><span class="value" id="stat-packages">-</span></div>
+      <div class="stat stat-link" data-goto="/blocks"><span class="label">block</span><span class="value" id="stat-block">-</span></div>
     </div>
     <main>
       <div class="section"><div class="section-title">recent activity</div>
@@ -1078,6 +1081,7 @@ async function loadPackages(page) {
 }
 
 let _txsCache = null;
+let _pendingTxType = null; // set by a home stat tile, consumed by loadTxs
 let _txsFilterType = null; // null = all
 let _txsFilterStatus = null; // null = all, true = ok, false = fail
 let _txsPage = 0;
@@ -1093,7 +1097,9 @@ async function loadTxs() {
     const data = await api('txs?limit=0'); // fetch all
     _txsCache = data.items || [];
     _txsPage = 0;
-    _txsFilterType = null;
+    // Arriving from a home stat tile pre-selects that message type.
+    _txsFilterType = _pendingTxType;
+    _pendingTxType = null;
     _txsFilterStatus = null;
 
     // Compute type counts
@@ -3144,6 +3150,14 @@ document.addEventListener('mouseout', (e) => {
   const val = e.target.closest('[data-hl]')?.getAttribute('data-hl');
   if (!val) return;
   document.querySelectorAll('[data-hl="' + CSS.escape(val) + '"]').forEach(el => el.classList.remove('hl-active'));
+});
+
+// --- Home stat tiles navigate to the page behind the number ---
+document.querySelectorAll('.stat-link').forEach(tile => {
+  tile.addEventListener('click', () => {
+    _pendingTxType = tile.getAttribute('data-type') || null;
+    navigate(tile.getAttribute('data-goto') + netSuffix(getNetwork()));
+  });
 });
 
 // --- Init ---


### PR DESCRIPTION
Closes #32.

The stat tiles on the home page were static text — the most clickable-looking thing on the landing page did nothing.

Each tile now navigates to the page behind its number, carrying the selected network:

| tile | destination |
|---|---|
| txs | `/txs` |
| calls / deploys / runs / sends | `/txs`, pre-filtered to that message type |
| realms | `/realms` |
| packages | `/packages` |
| block | `/blocks` |

The type-filtered ones set a pending filter that `loadTxs` consumes on arrival, reusing the filter state the transactions page already has rather than adding a parallel mechanism. Hover shows the tile is interactive.

Verified in a browser: clicking the `calls` tile on `/?network=topaz` lands on `/txs?network=topaz` with the filter set to `MsgCall` and every rendered row of type `call`.