### PR TITLE
feat: show the indexer in use for the selected network

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -258,7 +258,7 @@ footer a:hover { color: var(--accent); }
 <footer>
   <div class="container">
     <span>mygnoscan — <a href="https://github.com/gnoverse/mygnoscan" target="_blank">github.com/gnoverse/mygnoscan</a> @ <a id="footer-hash" href="#" target="_blank">...</a></span>
-    <span>data from <a href="https://indexer.gno.land/graphql" target="_blank">tx-indexer</a></span>
+    <span id="footer-indexer">data from tx-indexer</span>
   </div>
 </footer>
 <script src="https://d3js.org/d3.v7.min.js"></script>
@@ -621,6 +621,7 @@ function onNetworkChange() {
   if (n && n !== 'all') { params.set('network', n); } else { params.delete('network'); }
   const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
   history.replaceState(null, '', newUrl);
+  renderFooterIndexer();
   route();
 }
 function netBadgeEl(networkId) {
@@ -637,9 +638,11 @@ function netSuffix(n) {
   const net = (n !== undefined ? n : null) || getNetwork();
   return (net && net !== 'all') ? '?network=' + net : '';
 }
+let _networks = [];
 async function initNetworkSelector() {
   try {
     const nets = await fetch('/api/networks').then(r => r.json());
+    _networks = nets || [];
     const sel = document.getElementById('network-select');
     sel.innerHTML = '';
     const all = document.createElement('option');
@@ -651,7 +654,31 @@ async function initNetworkSelector() {
       sel.appendChild(opt);
     }
     sel.value = getNetwork();
+    renderFooterIndexer();
   } catch(e) { console.error('network selector:', e); }
+}
+
+// The footer names the indexer the selected network actually reads from. In
+// all-networks mode several are in play, so naming one would be wrong.
+function renderFooterIndexer() {
+  const span = document.getElementById('footer-indexer');
+  if (!span) return;
+  span.textContent = '';
+  const net = getNetwork();
+  const cfg = _networks.find(n => n.id === net);
+  if (!net || net === 'all' || !cfg || !cfg.indexer) {
+    span.appendChild(document.createTextNode(
+      'select a single network to see which indexer is used'));
+    return;
+  }
+  span.appendChild(document.createTextNode('data from '));
+  // A loopback/private indexer is real but unreachable from a visitor's browser,
+  // so show it without pretending it is a working link.
+  if (/^https?:\/\/(localhost|127\.|0\.0\.0\.0|\[::1\]|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/i.test(cfg.indexer)) {
+    span.appendChild(el('span', { title: 'indexer is local to the server' }, cfg.indexer));
+  } else {
+    span.appendChild(el('a', { href: cfg.indexer, target: '_blank' }, cfg.indexer));
+  }
 }
 
 async function api(path) {

--- a/main.go
+++ b/main.go
@@ -103,11 +103,13 @@ func run() error {
 	})
 	mux.HandleFunc("GET /api/networks", func(w http.ResponseWriter, r *http.Request) {
 		type netInfo struct {
-			ID string `json:"id"`
+			ID      string `json:"id"`
+			Indexer string `json:"indexer,omitempty"`
+			RPC     string `json:"rpc,omitempty"`
 		}
 		var nets []netInfo
 		for _, n := range cfg.Networks {
-			nets = append(nets, netInfo{n.ID})
+			nets = append(nets, netInfo{ID: n.ID, Indexer: n.IndexerURL, RPC: n.RPCURL})
 		}
 		jsonResponse(w, nets)
 	})


### PR DESCRIPTION
Closes #28.

The footer hardcoded `data from tx-indexer` linking to `indexer.gno.land` — wrong on any instance not reading from the public gno.land indexer, which includes every self-hosted deployment.

It now names the indexer the selected network is actually configured with:

| selected network | footer |
|---|---|
| `topaz` | `data from https://indexer.topaz.testnets.gno.land/graphql/query` (link) |
| `gnoland1` | `data from https://indexer.gno.land/graphql/query` (link) |
| all networks | `select a single network to see which indexer is used` (no link) |

In all-networks mode several indexers are in play, so naming any one of them would be a lie — it degrades to plain text rather than picking arbitrarily.

`/api/networks` previously returned only `{id}`; it now also returns `indexer` and `rpc`, which the frontend needs to render this and which is genuinely useful for anyone integrating against the API.

**Loopback indexers render as text, not links.** A deployment can legitimately point a network at `http://127.0.0.1:8546` — that is the right configuration when the node runs on the same box — but linking it would give visitors a dead link to their own machine. Private ranges and localhost are detected and shown unlinked.

Verified in a browser across all three selections, and against an instance configured with a loopback indexer.