### PR TITLE
perf: fetch only the requested page of transactions

### DIFF
--- a/api.go
+++ b/api.go
@@ -80,22 +80,19 @@ func stampBlockTimes(ctx context.Context, client *IndexerClient, txs []Transacti
 	if len(txs) == 0 {
 		return
 	}
-	minH, maxH := txs[0].BlockHeight, txs[0].BlockHeight
+	// Deduplicate: many transactions share a block, and a naive min..max range
+	// over a sparse set would pull every block in between.
+	seen := make(map[int]bool, len(txs))
+	heights := make([]int, 0, len(txs))
 	for _, tx := range txs {
-		if tx.BlockHeight < minH {
-			minH = tx.BlockHeight
-		}
-		if tx.BlockHeight > maxH {
-			maxH = tx.BlockHeight
+		if !seen[tx.BlockHeight] {
+			seen[tx.BlockHeight] = true
+			heights = append(heights, tx.BlockHeight)
 		}
 	}
-	blocks, err := client.GetBlocksInRange(ctx, minH, maxH)
+	bt, err := client.GetBlockTimesForHeights(ctx, heights)
 	if err != nil {
 		return
-	}
-	bt := make(map[int]string, len(blocks))
-	for _, b := range blocks {
-		bt[b.Height] = b.Time
 	}
 	for i := range txs {
 		txs[i].BlockTime = bt[txs[i].BlockHeight]
@@ -291,19 +288,33 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
+	// With a limit we only need enough rows to fill the page. Without one the
+	// caller is asking for everything, which stays expensive by definition.
+	need := 0
+	if limit > 0 {
+		need = offset + limit
+	}
+	fetch := func(c *IndexerClient) ([]Transaction, error) {
+		if need > 0 {
+			return c.GetRecentTransactionsPage(r.Context(), need)
+		}
+		return c.GetRecentTransactions(r.Context(), 0)
+	}
+
 	if network != "" {
 		client := a.clientFor(network)
 		if client == nil {
 			jsonError(w, "network not found", 404)
 			return
 		}
-		txs, err := client.GetRecentTransactions(r.Context(), 0)
+		txs, err := fetch(client)
 		if err != nil {
 			jsonError(w, err.Error(), 500)
 			return
 		}
 		total := len(txs)
 		if limit <= 0 {
+			stampBlockTimes(r.Context(), client, txs)
 			jsonResponse(w, map[string]any{"items": txs, "total": total})
 			return
 		}
@@ -314,7 +325,10 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 		if end > total {
 			end = total
 		}
-		jsonResponse(w, map[string]any{"items": txs[offset:end], "total": total})
+		page := txs[offset:end]
+		// Stamp only what is being returned, not everything that was fetched.
+		stampBlockTimes(r.Context(), client, page)
+		jsonResponse(w, map[string]any{"items": page, "total": total})
 		return
 	}
 
@@ -330,10 +344,12 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 		if client == nil {
 			continue
 		}
-		txs, err := client.GetRecentTransactions(r.Context(), 0)
+		txs, err := fetch(client)
 		if err != nil {
 			continue
 		}
+		// Block times are needed before sorting: across networks, heights from
+		// different chains are not comparable and only the timestamp orders them.
 		stampBlockTimes(r.Context(), client, txs)
 		for _, tx := range txs {
 			if seen[tx.Hash] {

--- a/indexer.go
+++ b/indexer.go
@@ -364,6 +364,56 @@ func (c *IndexerClient) GetRecentTransactions(ctx context.Context, maxResults in
 	return result.GetTransactions, err
 }
 
+// Window sizes for paged transaction fetches. The indexer has no limit argument,
+// so the only way to bound a query is by block height; cost tracks the number of
+// rows returned, not the width of the window, so widening is cheap.
+const (
+	initialTxWindow = 20000
+	txWindowGrowth  = 8
+)
+
+// GetRecentTransactionsPage fetches at least `need` of the most recent
+// transactions by querying a bounded height window, widening it until enough are
+// found or the chain start is reached.
+//
+// The unbounded alternative (`where: {}`) downloads every transaction the chain
+// has ever had — 14MB and 4.5s on a modest testnet — because the indexer exposes
+// no limit or pagination argument. Bounding by height is the only lever there is.
+func (c *IndexerClient) GetRecentTransactionsPage(ctx context.Context, need int) ([]Transaction, error) {
+	if need <= 0 {
+		return c.GetRecentTransactions(ctx, 0)
+	}
+	tip, err := c.LatestBlockHeight(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for window := initialTxWindow; ; window *= txWindowGrowth {
+		from := tip - window
+		if from < 0 {
+			from = 0
+		}
+
+		var result struct {
+			GetTransactions []Transaction `json:"getTransactions"`
+		}
+		q := fmt.Sprintf(`{
+		getTransactions(
+			where: { block_height: { gt: %d } }
+			order: { heightAndIndex: DESC }
+		) { %s }
+	}`, from, txFieldsLight)
+		if err := c.query(ctx, q, nil, &result); err != nil {
+			return nil, err
+		}
+
+		// Enough rows, or we have already reached genesis and there are no more.
+		if len(result.GetTransactions) >= need || from == 0 {
+			return result.GetTransactions, nil
+		}
+	}
+}
+
 func (c *IndexerClient) GetRecentTransactionsFromHeight(ctx context.Context, lastHeight *int) ([]Transaction, error) {
 	var result struct {
 		GetTransactions []Transaction `json:"getTransactions"`
@@ -549,6 +599,48 @@ func (c *IndexerClient) GetBlocksInRange(ctx context.Context, fromHeight, toHeig
 	}`, fromHeight-1, toHeight+1, blockFields)
 	err := c.query(ctx, q, nil, &result)
 	return result.GetBlocks, err
+}
+
+// rangeStampDensity decides between one range query and one query per height.
+//
+// A range query returns every block in the span, not just the wanted ones, so it
+// only pays off when the heights are dense. Measured against a live indexer: 20
+// transactions spread over 20k blocks cost 4.5s and 579KB as a range (10k blocks
+// returned) versus 0.3s fetched individually and concurrently. Densities near 1
+// invert that — consecutive blocks are one cheap query instead of N.
+const rangeStampDensity = 2
+
+// GetBlockTimesForHeights returns a height→time map for the given heights.
+//
+// One range query when the heights are dense, one query per height when they are
+// scattered. Getting this backwards is expensive in both directions.
+func (c *IndexerClient) GetBlockTimesForHeights(ctx context.Context, heights []int) (map[int]string, error) {
+	if len(heights) == 0 {
+		return nil, nil
+	}
+	lo, hi := heights[0], heights[0]
+	for _, h := range heights {
+		if h < lo {
+			lo = h
+		}
+		if h > hi {
+			hi = h
+		}
+	}
+	if span := hi - lo + 1; span > rangeStampDensity*len(heights) {
+		return c.GetBlocksByHeights(ctx, heights)
+	}
+
+	blocks, err := c.GetBlocksInRange(ctx, lo, hi)
+	if err != nil {
+		// A failed range query is not fatal: the per-height path still works.
+		return c.GetBlocksByHeights(ctx, heights)
+	}
+	times := make(map[int]string, len(blocks))
+	for _, b := range blocks {
+		times[b.Height] = b.Time
+	}
+	return times, nil
 }
 
 // GetBlocksByHeights fetches blocks for a specific set of heights and returns a height→time map.

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// countingIndexer serves block queries and records how many requests it took,
+// which is the whole point of the density heuristic under test.
+type countingIndexer struct {
+	mu       sync.Mutex
+	requests int
+	blocks   int // total block records served
+}
+
+func (f *countingIndexer) counts() (int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.requests, f.blocks
+}
+
+func (f *countingIndexer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	query := string(body)
+
+	f.mu.Lock()
+	f.requests++
+	f.mu.Unlock()
+
+	var lo, hi int
+	switch {
+	case strings.Contains(query, "eq:"):
+		fmt.Sscanf(query[strings.Index(query, "eq:"):], "eq: %d", &hi)
+		if hi == 0 {
+			fmt.Sscanf(query[strings.Index(query, "eq:"):], "eq:%d", &hi)
+		}
+		lo = hi
+	default:
+		// Range form: gt: X, lt: Y — serve everything strictly between.
+		gt := strings.Index(query, "gt:")
+		lt := strings.Index(query, "lt:")
+		if gt < 0 || lt < 0 {
+			http.Error(w, "unexpected query", 400)
+			return
+		}
+		fmt.Sscanf(strings.TrimSpace(query[gt+3:]), "%d", &lo)
+		fmt.Sscanf(strings.TrimSpace(query[lt+3:]), "%d", &hi)
+		lo, hi = lo+1, hi-1
+	}
+
+	type blk struct {
+		Hash    string `json:"hash"`
+		Height  int    `json:"height"`
+		ChainID string `json:"chain_id"`
+		Time    string `json:"time"`
+	}
+	var blocks []blk
+	for h := lo; h <= hi; h++ {
+		blocks = append(blocks, blk{
+			Hash:    fmt.Sprintf("hash-%d", h),
+			Height:  h,
+			ChainID: "testchain",
+			Time:    fmt.Sprintf("2026-01-01T00:%02d:00Z", h%60),
+		})
+	}
+
+	f.mu.Lock()
+	f.blocks += len(blocks)
+	f.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"data": map[string]any{"getBlocks": blocks},
+	})
+}
+
+func newCountingIndexer(t *testing.T) (*IndexerClient, *countingIndexer) {
+	t.Helper()
+	fake := &countingIndexer{}
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+	return NewIndexerClient(srv.URL), fake
+}
+
+func TestGetBlockTimesForHeights(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("dense heights use a single range query", func(t *testing.T) {
+		client, fake := newCountingIndexer(t)
+
+		heights := []int{100, 101, 102, 103, 104}
+		times, err := client.GetBlockTimesForHeights(ctx, heights)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, h := range heights {
+			if times[h] == "" {
+				t.Errorf("height %d has no time", h)
+			}
+		}
+		if reqs, _ := fake.counts(); reqs != 1 {
+			t.Errorf("made %d requests for 5 consecutive heights, want 1", reqs)
+		}
+	})
+
+	t.Run("sparse heights are fetched individually", func(t *testing.T) {
+		client, fake := newCountingIndexer(t)
+
+		// 5 transactions scattered over 20k blocks. As a range this would pull
+		// every block in between — the regression this heuristic exists to stop.
+		heights := []int{450000, 455000, 460000, 465000, 470000}
+		times, err := client.GetBlockTimesForHeights(ctx, heights)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, h := range heights {
+			if times[h] == "" {
+				t.Errorf("height %d has no time", h)
+			}
+		}
+		reqs, blocks := fake.counts()
+		if reqs != len(heights) {
+			t.Errorf("made %d requests, want one per height (%d)", reqs, len(heights))
+		}
+		// The point of the heuristic: only the wanted blocks are transferred.
+		if blocks != len(heights) {
+			t.Errorf("served %d block records for %d heights — the range path was taken", blocks, len(heights))
+		}
+	})
+
+	t.Run("no heights makes no requests", func(t *testing.T) {
+		client, fake := newCountingIndexer(t)
+		if _, err := client.GetBlockTimesForHeights(ctx, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if reqs, _ := fake.counts(); reqs != 0 {
+			t.Errorf("made %d requests for an empty height list, want 0", reqs)
+		}
+	})
+}
+
+func TestGetRecentTransactionsPageWidensWindow(t *testing.T) {
+	// The indexer has no limit argument, so the page fetch bounds by height and
+	// widens until it has enough. Verify it widens rather than giving up, and
+	// that it stops instead of looping once it reaches genesis.
+	var mu sync.Mutex
+	queries := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		query := string(body)
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(query, "latestBlockHeight") {
+			fmt.Fprint(w, `{"data":{"latestBlockHeight":1000000}}`)
+			return
+		}
+
+		mu.Lock()
+		queries++
+		n := queries
+		mu.Unlock()
+
+		// Nothing in the first window; results only once it has widened.
+		if n == 1 {
+			fmt.Fprint(w, `{"data":{"getTransactions":[]}}`)
+			return
+		}
+		fmt.Fprint(w, `{"data":{"getTransactions":[
+			{"hash":"A","block_height":999999},
+			{"hash":"B","block_height":999998},
+			{"hash":"C","block_height":999997}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	txs, err := NewIndexerClient(srv.URL).GetRecentTransactionsPage(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(txs) != 3 {
+		t.Errorf("got %d transactions, want 3", len(txs))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if queries < 2 {
+		t.Errorf("made %d transaction queries; expected the window to widen at least once", queries)
+	}
+}


### PR DESCRIPTION
Addresses #33 and the block-stamping half of #34.

`/api/txs?limit=20` took 4s because `limit` was applied *after* downloading the whole chain. The handler called `GetRecentTransactions(ctx, 0)` — `getTransactions(where: {})`, unbounded — then sliced 20 rows out of 14MB in Go.

## Bounding the fetch

The indexer has no `limit`/`first`/pagination argument (only `where` and `order`), so the only lever is block height. `GetRecentTransactionsPage` queries a height window and widens it (×8) until it has enough rows or reaches genesis. Cost tracks rows returned, not window width, so widening is nearly free — measured on topaz: a 20k-block window and a 500k-block window both answer in well under a second.

The handler now fetches `offset+limit` rows instead of everything, and stamps block times only on the page being returned. `limit=0` still means "everything" and is unchanged.

## The part that was not obvious

The first attempt was still 4s. `stampBlockTimes` uses one range query over min..max height — cheap when transactions are adjacent, catastrophic when they are not, because **a range returns every block in the span, not the ones you asked for**. Timestamping 20 transactions spread across 20k blocks was pulling 10,000 block records:

| strategy, 20 txs over 20k blocks | time | transferred |
|---|---|---|
| one range query | 4.5s | 579 KB (10,000 blocks) |
| one query per height, concurrent | 0.3s | 20 blocks |

So the choice is about **density, not span**. `GetBlockTimesForHeights` uses a range only when `span <= 2 × len(heights)` and otherwise fetches per height concurrently. Dense pages still cost one query; sparse ones stop over-fetching.

## Results

Against the live indexers:

| request | before | after |
|---|---|---|
| `/api/txs?limit=20&network=topaz` | 4.0s | **1.09s** |
| `/api/txs?limit=50&network=topaz` | 4.2s / 14 MB | **0.62s / 178 KB** |
| `/api/txs?limit=20` (all networks) | 6.8s | **1.53s** |
| `/api/txs?limit=20&network=gnoland1` | — | **0.32s** |

Also fixes a real gap: the single-network path never called `stampBlockTimes` at all, so those responses came back with empty `block_time` on every row. They are populated now (verified: 20/20 rows).

## Tests

`indexer_test.go` counts requests against a fake indexer, because this is exactly the kind of thing that regresses silently — my own first version did:
- dense heights → **1** request
- sparse heights → one request per height, and only the wanted blocks transferred (asserted, so reverting to a range fails the test)
- empty input → no requests
- the page fetch widens its window instead of returning short, and terminates at genesis

## Not in this PR

The transactions **page** still loads slowly, because the frontend requests `limit=0` to build its type/status filter counts client-side. Fixing that means server-side counts and paging — the filter bar needs a redesign, and large pages are their own problem (`limit=200` all-networks is 15s, since more rows means more scattered block-time lookups). Follow-up issue to come; this PR makes every paged caller fast, including the `?limit=20` URL that prompted it.
