### PR TITLE
perf: bound the events query to recent transactions

### DIFF
--- a/api.go
+++ b/api.go
@@ -471,6 +471,14 @@ func (a *API) HandleSearch(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, results)
 }
 
+// Event listing bounds. `limit=-1` still means "everything" for callers that
+// genuinely want it; the default keeps the events page from pulling the whole
+// chain's event history on load.
+const (
+	defaultEventTxs = 200
+	maxEventTxs     = 2000
+)
+
 func (a *API) HandleAllEvents(w http.ResponseWriter, r *http.Request) {
 	network := a.networkParam(r)
 	client := a.clientFor(network)
@@ -478,11 +486,22 @@ func (a *API) HandleAllEvents(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "no client available", 500)
 		return
 	}
-	// Recent transactions that have GnoEvents
-	txs, err := client.GetRecentTransactionsWithEvents(r.Context())
+	// Recent transactions that have GnoEvents. Bounded by default: unbounded,
+	// this returns every event-emitting transaction the chain ever had.
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	if limit == 0 {
+		limit = defaultEventTxs
+	}
+	if limit > maxEventTxs {
+		limit = maxEventTxs
+	}
+	txs, err := client.GetRecentTransactionsWithEvents(r.Context(), limit)
 	if err != nil {
 		jsonError(w, err.Error(), 500)
 		return
+	}
+	if limit > 0 && len(txs) > limit {
+		txs = txs[:limit]
 	}
 	type EventResult struct {
 		TxHash      string    `json:"tx_hash"`

--- a/indexer.go
+++ b/indexer.go
@@ -380,8 +380,22 @@ const (
 // has ever had — 14MB and 4.5s on a modest testnet — because the indexer exposes
 // no limit or pagination argument. Bounding by height is the only lever there is.
 func (c *IndexerClient) GetRecentTransactionsPage(ctx context.Context, need int) ([]Transaction, error) {
-	if need <= 0 {
+	return c.recentTransactionsWindowed(ctx, need, "", func() ([]Transaction, error) {
 		return c.GetRecentTransactions(ctx, 0)
+	})
+}
+
+// recentTransactionsWindowed is the shared widening-window fetch. extraWhere is
+// an optional additional filter fragment merged into the where clause; unbounded
+// falls back to the caller's own full-fetch.
+func (c *IndexerClient) recentTransactionsWindowed(
+	ctx context.Context,
+	need int,
+	extraWhere string,
+	unbounded func() ([]Transaction, error),
+) ([]Transaction, error) {
+	if need <= 0 {
+		return unbounded()
 	}
 	tip, err := c.LatestBlockHeight(ctx)
 	if err != nil {
@@ -399,10 +413,10 @@ func (c *IndexerClient) GetRecentTransactionsPage(ctx context.Context, need int)
 		}
 		q := fmt.Sprintf(`{
 		getTransactions(
-			where: { block_height: { gt: %d } }
+			where: { block_height: { gt: %d } %s }
 			order: { heightAndIndex: DESC }
 		) { %s }
-	}`, from, txFieldsLight)
+	}`, from, extraWhere, txFieldsLight)
 		if err := c.query(ctx, q, nil, &result); err != nil {
 			return nil, err
 		}
@@ -778,18 +792,22 @@ func (c *IndexerClient) GetGasUsageForRealm(ctx context.Context, pkgPath string)
 }
 
 // GetRecentTransactionsWithEvents fetches recent transactions that have GnoEvents.
-func (c *IndexerClient) GetRecentTransactionsWithEvents(ctx context.Context) ([]Transaction, error) {
-	var result struct {
-		GetTransactions []Transaction `json:"getTransactions"`
-	}
-	q := fmt.Sprintf(`{
+func (c *IndexerClient) GetRecentTransactionsWithEvents(ctx context.Context, need int) ([]Transaction, error) {
+	return c.recentTransactionsWindowed(ctx, need,
+		"response: { events: { GnoEvent: {} } }",
+		func() ([]Transaction, error) {
+			var result struct {
+				GetTransactions []Transaction `json:"getTransactions"`
+			}
+			q := fmt.Sprintf(`{
 		getTransactions(
 			where: { response: { events: { GnoEvent: {} } } }
 			order: { heightAndIndex: DESC }
 		) { %s }
 	}`, txFieldsLight)
-	err := c.query(ctx, q, nil, &result)
-	return result.GetTransactions, err
+			err := c.query(ctx, q, nil, &result)
+			return result.GetTransactions, err
+		})
 }
 
 // GetEventsByPkgPath fetches transactions that emitted GnoEvents for a package.


### PR DESCRIPTION
Part of #34, and a prerequisite for #37.

`/api/allevents` measured **4.6s returning 10.4 MB** on topaz. `GetRecentTransactionsWithEvents` filtered on `response: { events: { GnoEvent: {} } }` but had no height bound, so "recent events" meant *every event-emitting transaction the chain has ever had*.

Reuses the widening-window fetch added in #45, generalized into `recentTransactionsWindowed` with an optional extra `where` fragment, so the events query and the transactions query share one implementation instead of two copies of the same loop.

`/api/allevents` now takes `limit` (default 200, capped at 2000). `limit=-1` still fetches everything for callers that genuinely want it.

| request | before | after |
|---|---|---|
| `/api/allevents?network=topaz` | 4.6s / 10.4 MB | **1.7s / 1.96 MB** |
| `/api/allevents?limit=50&network=topaz` | — | **1.14s / 410 KB** |

Bounding is unambiguously correct here: the page is titled "RECENT EVENTS" and the function was already named for recency. Contrast `/api/gas`, which has the same unbounded pattern (4.8s) but presents its numbers as all-time totals — bounding that one would silently understate them, so it needs the local-database path instead and is deliberately left alone here.

The events page still needs pagination and a usable type filter (#37); this makes its data source affordable first.