### PR TITLE
perf: query networks concurrently with a per-network circuit breaker

### DIFF
--- a/api.go
+++ b/api.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"sort"
 	"strconv"
@@ -19,10 +20,17 @@ type API struct {
 	clients  map[string]*IndexerClient
 	networks []NetworkConfig
 	analyzer *Analyzer
+	health   *healthTracker
 }
 
 func NewAPI(db *DB, clients map[string]*IndexerClient, networks []NetworkConfig, analyzer *Analyzer) *API {
-	return &API{db: db, clients: clients, networks: networks, analyzer: analyzer}
+	return &API{
+		db:       db,
+		clients:  clients,
+		networks: networks,
+		analyzer: analyzer,
+		health:   newHealthTracker(),
+	}
 }
 
 func jsonResponse(w http.ResponseWriter, data any) {
@@ -97,6 +105,130 @@ func stampBlockTimes(ctx context.Context, client *IndexerClient, txs []Transacti
 	for i := range txs {
 		txs[i].BlockTime = bt[txs[i].BlockHeight]
 	}
+}
+
+// perNetworkDeadline bounds how long a single network may hold up a merged
+// response. A configured-but-unreachable network — one that is down, or a
+// testnet configured ahead of its launch — must degrade to missing data rather
+// than to a hung page. The HTTP client's own timeout is far too long to serve
+// as this bound.
+const perNetworkDeadline = 8 * time.Second
+
+// Circuit breaker settings. Without one, a configured network that is down costs
+// every merged request the full perNetworkDeadline, forever. With one it costs
+// that once, then nothing until the cooldown expires and it is retried — so a
+// network can be configured before it launches and starts working on its own.
+const (
+	breakerThreshold = 2
+	breakerCooldown  = 60 * time.Second
+)
+
+// healthTracker trips a per-network breaker after repeated failures.
+type healthTracker struct {
+	mu    sync.Mutex
+	state map[string]*netHealth
+}
+
+type netHealth struct {
+	failures  int
+	skipUntil time.Time
+}
+
+func newHealthTracker() *healthTracker {
+	return &healthTracker{state: map[string]*netHealth{}}
+}
+
+// shouldSkip reports whether the breaker for this network is currently open.
+func (h *healthTracker) shouldSkip(id string) bool {
+	if h == nil {
+		return false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := h.state[id]
+	return s != nil && time.Now().Before(s.skipUntil)
+}
+
+// record updates the breaker after an attempt.
+func (h *healthTracker) record(id string, err error) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := h.state[id]
+	if s == nil {
+		s = &netHealth{}
+		h.state[id] = s
+	}
+	if err == nil {
+		if s.failures >= breakerThreshold {
+			log.Printf("[%s] reachable again, resuming", id)
+		}
+		s.failures, s.skipUntil = 0, time.Time{}
+		return
+	}
+	s.failures++
+	if s.failures >= breakerThreshold {
+		if s.skipUntil.IsZero() || time.Now().After(s.skipUntil) {
+			log.Printf("[%s] unreachable, pausing for %s: %v", id, breakerCooldown, err)
+		}
+		s.skipUntil = time.Now().Add(breakerCooldown)
+	}
+}
+
+// fanOut queries every configured network concurrently, returning results in
+// configured order. Networks that error or time out are skipped: a merged view
+// is best-effort by nature, and one bad network must not take the others down
+// with it.
+//
+// Sequential fan-out made an all-networks response cost the sum of every
+// network's latency, which is also what made adding an unreachable network
+// dangerous.
+func fanOut[T any](
+	ctx context.Context,
+	networks []NetworkConfig,
+	clients map[string]*IndexerClient,
+	health *healthTracker,
+	fn func(ctx context.Context, net NetworkConfig, client *IndexerClient) (T, error),
+) []T {
+	type slot struct {
+		val T
+		ok  bool
+	}
+	slots := make([]slot, len(networks))
+
+	var wg sync.WaitGroup
+	for i, n := range networks {
+		client := clients[n.ID]
+		if client == nil {
+			continue
+		}
+		if health.shouldSkip(n.ID) {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, n NetworkConfig, c *IndexerClient) {
+			defer wg.Done()
+			nctx, cancel := context.WithTimeout(ctx, perNetworkDeadline)
+			defer cancel()
+			v, err := fn(nctx, n, c)
+			health.record(n.ID, err)
+			if err != nil {
+				return
+			}
+			slots[i] = slot{val: v, ok: true}
+		}(i, n, client)
+	}
+	wg.Wait()
+
+	out := make([]T, 0, len(slots))
+	for _, s := range slots {
+		if s.ok {
+			out = append(out, s.val)
+		}
+	}
+	return out
 }
 
 // networkParam reads ?network from request. Returns "" for "all" (no filter), or specific network ID.
@@ -175,14 +307,15 @@ func (a *API) handleListPackages(w http.ResponseWriter, r *http.Request, realmOn
 
 	// All networks: fetch per-network, stamp block times, merge, sort by time
 	var merged []PackageInfo
-	for _, n := range a.networks {
-		items, err := a.db.ListPackages(n.ID, realmOnly, limit+offset, 0)
-		if err != nil {
-			continue
-		}
-		if client := a.clients[n.ID]; client != nil {
-			stampPackageTimes(r.Context(), client, items)
-		}
+	for _, items := range fanOut(r.Context(), a.networks, a.clients, a.health,
+		func(ctx context.Context, n NetworkConfig, c *IndexerClient) ([]PackageInfo, error) {
+			items, err := a.db.ListPackages(n.ID, realmOnly, limit+offset, 0)
+			if err != nil {
+				return nil, err
+			}
+			stampPackageTimes(ctx, c, items)
+			return items, nil
+		}) {
 		merged = append(merged, items...)
 	}
 	sort.Slice(merged, func(i, j int) bool {
@@ -241,13 +374,13 @@ func (a *API) HandleTx(w http.ResponseWriter, r *http.Request) {
 		Network   string `json:"network,omitempty"`
 	}
 
-	tryClient := func(netID string, client *IndexerClient) (*txDetail, error) {
-		tx, err := client.GetTransactionByHash(r.Context(), hash)
+	tryClient := func(ctx context.Context, netID string, client *IndexerClient) (*txDetail, error) {
+		tx, err := client.GetTransactionByHash(ctx, hash)
 		if err != nil {
 			return nil, err
 		}
 		resp := &txDetail{Transaction: tx, Network: netID}
-		if block, berr := client.GetBlock(r.Context(), tx.BlockHeight); berr == nil && block != nil {
+		if block, berr := client.GetBlock(ctx, tx.BlockHeight); berr == nil && block != nil {
 			resp.BlockTime = block.Time
 			resp.ChainID = block.ChainID
 		}
@@ -260,7 +393,7 @@ func (a *API) HandleTx(w http.ResponseWriter, r *http.Request) {
 			jsonError(w, "network not found", 404)
 			return
 		}
-		resp, err := tryClient(network, client)
+		resp, err := tryClient(r.Context(), network, client)
 		if err != nil {
 			jsonError(w, err.Error(), 404)
 			return
@@ -269,16 +402,15 @@ func (a *API) HandleTx(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Try all clients
-	for _, n := range a.networks {
-		client := a.clients[n.ID]
-		if client == nil {
-			continue
-		}
-		if resp, err := tryClient(n.ID, client); err == nil {
-			jsonResponse(w, resp)
-			return
-		}
+	// Ask every network at once; a hash lives on at most one, and the others
+	// answering "not found" should not be paid for serially.
+	found := fanOut(r.Context(), a.networks, a.clients, a.health,
+		func(ctx context.Context, n NetworkConfig, c *IndexerClient) (*txDetail, error) {
+			return tryClient(ctx, n.ID, c)
+		})
+	if len(found) > 0 {
+		jsonResponse(w, found[0])
+		return
 	}
 	jsonError(w, "transaction not found", 404)
 }
@@ -294,11 +426,11 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 	if limit > 0 {
 		need = offset + limit
 	}
-	fetch := func(c *IndexerClient) ([]Transaction, error) {
+	fetch := func(ctx context.Context, c *IndexerClient) ([]Transaction, error) {
 		if need > 0 {
-			return c.GetRecentTransactionsPage(r.Context(), need)
+			return c.GetRecentTransactionsPage(ctx, need)
 		}
-		return c.GetRecentTransactions(r.Context(), 0)
+		return c.GetRecentTransactions(ctx, 0)
 	}
 
 	if network != "" {
@@ -307,7 +439,7 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 			jsonError(w, "network not found", 404)
 			return
 		}
-		txs, err := fetch(client)
+		txs, err := fetch(r.Context(), client)
 		if err != nil {
 			jsonError(w, err.Error(), 500)
 			return
@@ -339,25 +471,30 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 	}
 	var merged []netTx
 	seen := make(map[string]bool)
-	for _, n := range a.networks {
-		client := a.clients[n.ID]
-		if client == nil {
-			continue
-		}
-		txs, err := fetch(client)
-		if err != nil {
-			continue
-		}
-		// Block times are needed before sorting: across networks, heights from
-		// different chains are not comparable and only the timestamp orders them.
-		stampBlockTimes(r.Context(), client, txs)
+	perNetwork := fanOut(r.Context(), a.networks, a.clients, a.health,
+		func(ctx context.Context, n NetworkConfig, c *IndexerClient) ([]netTx, error) {
+			txs, err := fetch(ctx, c)
+			if err != nil {
+				return nil, err
+			}
+			// Block times are needed before sorting: across networks, heights
+			// from different chains are not comparable and only the timestamp
+			// orders them.
+			stampBlockTimes(ctx, c, txs)
+			out := make([]netTx, 0, len(txs))
+			for _, tx := range txs {
+				tx.Network = n.ID
+				out = append(out, netTx{Transaction: tx, Network: n.ID})
+			}
+			return out, nil
+		})
+	for _, txs := range perNetwork {
 		for _, tx := range txs {
 			if seen[tx.Hash] {
 				continue
 			}
 			seen[tx.Hash] = true
-			tx.Network = n.ID
-			merged = append(merged, netTx{Transaction: tx, Network: n.ID})
+			merged = append(merged, tx)
 		}
 	}
 	sort.Slice(merged, func(i, j int) bool {
@@ -389,18 +526,19 @@ func (a *API) HandleAddress(w http.ResponseWriter, r *http.Request) {
 	var txs []Transaction
 	if network == "" {
 		seen := make(map[string]bool)
-		for _, n := range a.networks {
-			c := a.clients[n.ID]
-			if c == nil {
-				continue
-			}
-			netTxs, err := c.GetTransactionsByAddress(r.Context(), addr)
-			if err != nil {
-				continue
-			}
-			stampBlockTimes(r.Context(), c, netTxs)
+		for _, netTxs := range fanOut(r.Context(), a.networks, a.clients, a.health,
+			func(ctx context.Context, n NetworkConfig, c *IndexerClient) ([]Transaction, error) {
+				netTxs, err := c.GetTransactionsByAddress(ctx, addr)
+				if err != nil {
+					return nil, err
+				}
+				stampBlockTimes(ctx, c, netTxs)
+				for i := range netTxs {
+					netTxs[i].Network = n.ID
+				}
+				return netTxs, nil
+			}) {
 			for i := range netTxs {
-				netTxs[i].Network = n.ID
 				if !seen[netTxs[i].Hash] {
 					seen[netTxs[i].Hash] = true
 					txs = append(txs, netTxs[i])
@@ -585,18 +723,19 @@ func (a *API) HandleBlocks(w http.ResponseWriter, r *http.Request) {
 		Network string `json:"network,omitempty"`
 	}
 	var merged []netBlock
-	for _, n := range a.networks {
-		client := a.clients[n.ID]
-		if client == nil {
-			continue
-		}
-		blocks, err := client.GetRecentBlocks(r.Context(), limit)
-		if err != nil {
-			continue
-		}
-		for _, b := range blocks {
-			merged = append(merged, netBlock{Block: b, Network: n.ID})
-		}
+	for _, blocks := range fanOut(r.Context(), a.networks, a.clients, a.health,
+		func(ctx context.Context, n NetworkConfig, c *IndexerClient) ([]netBlock, error) {
+			blocks, err := c.GetRecentBlocks(ctx, limit)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]netBlock, 0, len(blocks))
+			for _, b := range blocks {
+				out = append(out, netBlock{Block: b, Network: n.ID})
+			}
+			return out, nil
+		}) {
+		merged = append(merged, blocks...)
 	}
 	sort.Slice(merged, func(i, j int) bool {
 		if merged[i].Time != "" && merged[j].Time != "" {

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testNetworks(ids ...string) ([]NetworkConfig, map[string]*IndexerClient) {
+	nets := make([]NetworkConfig, 0, len(ids))
+	clients := make(map[string]*IndexerClient, len(ids))
+	for _, id := range ids {
+		nets = append(nets, NetworkConfig{ID: id, IndexerURL: "http://example.invalid/graphql/query"})
+		clients[id] = NewIndexerClient("http://example.invalid/graphql/query")
+	}
+	return nets, clients
+}
+
+func TestFanOutRunsConcurrentlyAndKeepsOrder(t *testing.T) {
+	nets, clients := testNetworks("a", "b", "c")
+
+	// Each call blocks; if they ran sequentially the total would be 3x this.
+	const delay = 150 * time.Millisecond
+	start := time.Now()
+	got := fanOut(context.Background(), nets, clients, newHealthTracker(),
+		func(ctx context.Context, n NetworkConfig, c *IndexerClient) (string, error) {
+			time.Sleep(delay)
+			return n.ID, nil
+		})
+	elapsed := time.Since(start)
+
+	if len(got) != 3 {
+		t.Fatalf("got %d results, want 3", len(got))
+	}
+	// Results follow configured order regardless of completion order.
+	for i, want := range []string{"a", "b", "c"} {
+		if got[i] != want {
+			t.Errorf("result %d = %q, want %q", i, got[i], want)
+		}
+	}
+	if elapsed > 2*delay {
+		t.Errorf("took %s for 3 concurrent calls of %s — looks sequential", elapsed, delay)
+	}
+}
+
+func TestFanOutSkipsFailingNetworks(t *testing.T) {
+	nets, clients := testNetworks("good", "bad", "alsogood")
+
+	got := fanOut(context.Background(), nets, clients, newHealthTracker(),
+		func(ctx context.Context, n NetworkConfig, c *IndexerClient) (string, error) {
+			if n.ID == "bad" {
+				return "", errors.New("indexer down")
+			}
+			return n.ID, nil
+		})
+
+	// One bad network must not fail the others.
+	if len(got) != 2 {
+		t.Fatalf("got %v, want the two healthy networks", got)
+	}
+	if got[0] != "good" || got[1] != "alsogood" {
+		t.Errorf("got %v, want [good alsogood]", got)
+	}
+}
+
+func TestFanOutHonorsPerNetworkDeadline(t *testing.T) {
+	nets, clients := testNetworks("slow")
+
+	start := time.Now()
+	got := fanOut(context.Background(), nets, clients, newHealthTracker(),
+		func(ctx context.Context, n NetworkConfig, c *IndexerClient) (string, error) {
+			// Simulate a network that never answers: respect the deadline the
+			// fan-out imposes rather than hanging forever.
+			<-ctx.Done()
+			return "", ctx.Err()
+		})
+	elapsed := time.Since(start)
+
+	if len(got) != 0 {
+		t.Errorf("got %v, want no results from a timed-out network", got)
+	}
+	if elapsed > perNetworkDeadline+2*time.Second {
+		t.Errorf("took %s, expected to be cut off near %s", elapsed, perNetworkDeadline)
+	}
+}
+
+func TestCircuitBreakerStopsRetryingDeadNetwork(t *testing.T) {
+	nets, clients := testNetworks("good", "dead")
+	health := newHealthTracker()
+
+	var deadCalls atomic.Int32
+	call := func() []string {
+		return fanOut(context.Background(), nets, clients, health,
+			func(ctx context.Context, n NetworkConfig, c *IndexerClient) (string, error) {
+				if n.ID == "dead" {
+					deadCalls.Add(1)
+					return "", errors.New("connection refused")
+				}
+				return n.ID, nil
+			})
+	}
+
+	// Trip the breaker, then keep going.
+	for i := 0; i < breakerThreshold+3; i++ {
+		got := call()
+		if len(got) != 1 || got[0] != "good" {
+			t.Fatalf("call %d returned %v, want [good]", i, got)
+		}
+	}
+
+	// Once open, the dead network is not contacted again — that is the whole
+	// point: otherwise every request pays its timeout forever.
+	if n := deadCalls.Load(); n != breakerThreshold {
+		t.Errorf("dead network was called %d times, want %d (breaker should open after %d)",
+			n, breakerThreshold, breakerThreshold)
+	}
+}
+
+func TestCircuitBreakerRecoversAfterCooldown(t *testing.T) {
+	health := newHealthTracker()
+
+	for i := 0; i < breakerThreshold; i++ {
+		health.record("net", errors.New("down"))
+	}
+	if !health.shouldSkip("net") {
+		t.Fatal("breaker should be open after repeated failures")
+	}
+
+	// A network configured before launch has to start working on its own once
+	// it comes up, without a restart.
+	health.mu.Lock()
+	health.state["net"].skipUntil = time.Now().Add(-time.Second)
+	health.mu.Unlock()
+
+	if health.shouldSkip("net") {
+		t.Error("breaker should allow a retry once the cooldown has passed")
+	}
+	health.record("net", nil)
+	if health.shouldSkip("net") {
+		t.Error("breaker should be closed after a success")
+	}
+}
+
+func TestHealthTrackerIsConcurrencySafe(t *testing.T) {
+	health := newHealthTracker()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				health.record("net", errors.New("down"))
+			} else {
+				health.record("net", nil)
+			}
+			health.shouldSkip("net")
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Part of #34, and the groundwork for adding a network before it launches.

All-networks views queried each network **sequentially**, so a merged response cost the sum of every network's latency. Five handlers did this: package/realm lists, transaction lookup, transaction lists, address activity, and blocks.

Worse, the indexer HTTP client has a 30s timeout and nothing shorter bounded a request, so a single unreachable network could stall every merged page by half a minute.

## Changes

**`fanOut`** — one generic helper replacing the five hand-rolled loops. Queries every configured network concurrently and returns results in *configured* order, so output stays deterministic regardless of which network answers first. A network that errors is skipped rather than failing the response, matching the previous best-effort behavior.

**Per-network deadline** (8s) — no single network can hold a merged response longer than that, independent of the client's own timeout.

**Circuit breaker** — after 2 consecutive failures a network is skipped entirely for 60s, then retried. Without it, a configured-but-down network costs every request the full deadline, forever.

## Measurements

Three healthy networks, all-networks mode:

| request | before | after |
|---|---|---|
| `/api/txs?limit=20` | 1.76s | **0.77s** |
| `/api/blocks` | 0.25s | **0.18s** |

With a fourth, unreachable network configured:

| call | time |
|---|---|
| 1st | 8.0s (deadline) |
| 2nd | 8.0s (breaker trips) |
| 3rd onward | **0.77s** — skipped |
| `/api/blocks` | **0.18s** |

and in the log:

```
[sapphire] unreachable, pausing for 1m0s: context deadline exceeded
```

Before this, that fourth network would have added 30s to every single merged request.

## Why this matters beyond speed

It makes a network safe to configure **before it exists**. Sapphire launches tomorrow and its DNS already resolves (`indexer.sapphire.testnets.gno.land`, `rpc.sapphire.testnets.gno.land`) while nothing answers yet. With the breaker, configuring it early costs two 8s requests per minute and nothing else, and it starts serving on its own the moment the indexer comes up — no restart, no config change.

## Tests

`fanout_test.go`, with `-race`:
- concurrency is real (3×150ms calls complete in under 300ms, not 450ms) and results keep configured order
- one failing network does not remove the healthy ones from the response
- the per-network deadline actually cuts off a network that never answers
- the breaker stops contacting a dead network after exactly `breakerThreshold` attempts — the assertion counts calls, so losing the breaker fails the test
- it reopens after the cooldown and closes on success, which is what lets a pre-launch network self-heal
- the tracker is race-clean under concurrent use
