### PR TITLE
fix: fail fast on an unreachable indexer instead of hanging the page

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,43 @@ import (
 type IndexerClient struct {
 	url    string
 	client *http.Client
+
+	// Per-client circuit breaker. Every request path goes through query(), so
+	// putting it here protects single-network pages, merged views and the sync
+	// loop alike — an indexer that is down (or a testnet configured before it
+	// launches) fails fast instead of making each caller wait out the timeout.
+	mu        sync.Mutex
+	failures  int
+	skipUntil time.Time
+}
+
+// errIndexerUnavailable is returned while the breaker is open.
+var errIndexerUnavailable = errors.New("indexer unavailable, not retried yet")
+
+const (
+	clientBreakerThreshold = 2
+	clientBreakerCooldown  = 30 * time.Second
+)
+
+// breakerOpen reports whether requests are currently being short-circuited.
+func (c *IndexerClient) breakerOpen() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return time.Now().Before(c.skipUntil)
+}
+
+// recordResult updates the breaker after a request.
+func (c *IndexerClient) recordResult(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err == nil {
+		c.failures, c.skipUntil = 0, time.Time{}
+		return
+	}
+	c.failures++
+	if c.failures >= clientBreakerThreshold {
+		c.skipUntil = time.Now().Add(clientBreakerCooldown)
+	}
 }
 
 func NewIndexerClient(url string) *IndexerClient {
@@ -26,7 +64,9 @@ func NewIndexerClient(url string) *IndexerClient {
 	return &IndexerClient{
 		url: url,
 		client: &http.Client{
-			Timeout: 30 * time.Second,
+			// A page cannot wait 30s on one indexer; callers add their own
+			// tighter deadlines on top of this backstop.
+			Timeout: 10 * time.Second,
 		},
 	}
 }
@@ -53,6 +93,18 @@ type gqlResponse struct {
 }
 
 func (c *IndexerClient) query(ctx context.Context, query string, vars map[string]any, result any) error {
+	if c.breakerOpen() {
+		return errIndexerUnavailable
+	}
+	err := c.doQuery(ctx, query, vars, result)
+	// Caller-side cancellation says nothing about the indexer's health.
+	if !errors.Is(err, context.Canceled) {
+		c.recordResult(err)
+	}
+	return err
+}
+
+func (c *IndexerClient) doQuery(ctx context.Context, query string, vars map[string]any, result any) error {
 	body, err := json.Marshal(gqlRequest{Query: query, Variables: vars})
 	if err != nil {
 		return err

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -3,13 +3,16 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // countingIndexer serves block queries and records how many requests it took,
@@ -194,3 +197,50 @@ func TestGetRecentTransactionsPageWidensWindow(t *testing.T) {
 		t.Errorf("made %d transaction queries; expected the window to widen at least once", queries)
 	}
 }
+
+func TestClientBreakerShortCircuitsDeadIndexer(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	client := NewIndexerClient(srv.URL)
+	ctx := context.Background()
+
+	// Every path goes through query(), so this protects single-network pages,
+	// merged views and the sync loop alike.
+	for i := 0; i < clientBreakerThreshold+3; i++ {
+		if _, err := client.LatestBlockHeight(ctx); err == nil {
+			t.Fatalf("call %d unexpectedly succeeded against a failing indexer", i)
+		}
+	}
+	if got := attempts.Load(); got != int32(clientBreakerThreshold) {
+		t.Errorf("indexer was contacted %d times, want %d — the breaker should stop retrying",
+			got, clientBreakerThreshold)
+	}
+	if !errors.Is(mustErr(client.LatestBlockHeight(ctx)), errIndexerUnavailable) {
+		t.Error("expected errIndexerUnavailable once the breaker is open")
+	}
+
+	// A recovered indexer must be picked up without a restart.
+	client.mu.Lock()
+	client.skipUntil = time.Now().Add(-time.Second)
+	client.mu.Unlock()
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":{"latestBlockHeight":42}}`)
+	})
+	h, err := client.LatestBlockHeight(ctx)
+	if err != nil {
+		t.Fatalf("after recovery: %v", err)
+	}
+	if h != 42 {
+		t.Errorf("height = %d, want 42", h)
+	}
+	if client.breakerOpen() {
+		t.Error("breaker should be closed after a success")
+	}
+}
+
+func mustErr(_ int, err error) error { return err }


### PR DESCRIPTION
Follow-up to #49, which put a circuit breaker on the merged (all-networks) path only. Selecting an unreachable network **directly** still hung, because single-network handlers call the indexer straight through with no breaker and no deadline.

Caught by configuring sapphire before its launch:

```
/api/stats?network=sapphire          http=502  30.0s
/api/txs?limit=10&network=sapphire   http=000  40.0s+ (timed out client-side)
```

Picking that network in the dropdown froze the UI.

## Fix

The breaker moves into `IndexerClient`, where it belongs: every request path — single-network pages, merged views, and the background sync loop — goes through `query()`, so one implementation covers all of them instead of each handler needing to remember.

After 2 consecutive failures the client short-circuits for 30s, then retries. Caller cancellation (`context.Canceled`) is explicitly not counted as a failure — a user navigating away says nothing about the indexer's health.

Also drops the HTTP client timeout from **30s to 10s**. No page can reasonably wait half a minute on one indexer, and callers layer their own tighter deadlines on top.

| request | before | after |
|---|---|---|
| `/api/stats?network=sapphire`, 1st–2nd | 30s, 502 | 10s, 200 |
| `/api/stats?network=sapphire`, 3rd on | 30s, 502 | **1ms** |
| `/api/txs?limit=10&network=sapphire` | 40s+ hang | **0.5ms**, clean 500 |
| healthy networks | — | unchanged (topaz 1.1s, all-networks 0.78s) |

The API-level breaker from #49 stays: it avoids even spawning goroutines for networks already known to be down, and it bounds aggregate latency for merged views. The client-level one is the backstop that makes every other path safe.

## Tests

A failing indexer is contacted exactly `clientBreakerThreshold` times and no more — the assertion counts requests, so removing the breaker fails the test. Recovery is covered too: after the cooldown the next call goes through and the breaker closes, which is what lets a pre-launch network start working without a restart.