### PR TITLE
fix: show transfer amounts in the table that actually renders them

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -549,24 +549,13 @@ function txDetailEl(msg) {
     case 'MsgRun':
       s.append('run by '); s.appendChild(addrLink(v.caller));
       return s;
-    case 'BankMsgSend':
-      s.appendChild(addrLink(v.from_address)); s.append(' > '); s.appendChild(addrLink(v.to_address));
-      return s;
-    default: return el('span', {}, v.__typename || '?');
-  }
-}
-function txDetail(msg) {
-  const v = msg?.value; if (!v) return '';
-  switch (v.__typename) {
-    case 'MsgAddPackage': return v.package?.path || '';
-    case 'MsgCall': return v.pkg_path + '::' + v.func;
-    case 'MsgRun': return 'run by ' + shortAddr(v.caller);
     case 'BankMsgSend': {
-      const move = shortAddr(v.from_address) + ' > ' + shortAddr(v.to_address);
+      s.appendChild(addrLink(v.from_address)); s.append(' > '); s.appendChild(addrLink(v.to_address));
       const amt = fmtCoins(v.amount);
-      return amt ? move + ' (' + amt + ')' : move;
+      if (amt) s.appendChild(el('span', { className: 'block-ctx' }, ' ' + amt));
+      return s;
     }
-    default: return '';
+    default: return el('span', {}, v.__typename || '?');
   }
 }
 function timeAgo(t) {


### PR DESCRIPTION
Completes #31, which I closed prematurely in #42.

There are two near-identical formatters: `txDetail(msg)` returning a string, and `txDetailEl(msg)` returning a DOM node. #42 added the amount to `txDetail` — but **`txDetail` was dead code**, never called from anywhere. All five tables that show transaction summaries use `txDetailEl`.

So the fix shipped, the issue closed, and the UI was unchanged. Caught while screenshotting the home page for the README: transfers still read `sender > recipient` with no amount.

This adds the amount to `txDetailEl`, dimmed via `block-ctx` so the addresses stay the primary content, and deletes the dead `txDetail` twin so the trap is not there for the next person.

Verified in a browser against real topaz data — recent activity rows now read:

```
g18qhq2f… > g1hxsz6m…   15 000 000 ugnot
g1cccz6z… > g1cccz6z…    4 998 492 ugnot
```

(the truncated addresses in that sample come from the sibling fix for #29, which had the same problem.)