### PR TITLE
fix: abbreviate addresses in links across the UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -314,6 +314,7 @@ function proposerEl(addr) {
   if (moniker) {
     const a = link(moniker, () => navigate('/address/' + addr + netSuffix(getNetwork())));
     a.setAttribute('data-hl', addr);
+    a.title = addr;
     span.appendChild(a);
     span.appendChild(el('span', { className: 'block-ctx' }, ' ' + truncAddr(addr)));
   } else {
@@ -337,8 +338,12 @@ function addrLink(addr) {
   const label = KNOWN_ADDRS[addr];
   const span = el('span');
   span.setAttribute('data-hl', addr);
-  const a = link(label || addr, () => navigate('/address/' + addr + netSuffix(getNetwork())));
+  // Show the abbreviated form; a full 40-character address in every table cell
+  // crowds out the content beside it. The full value stays in the tooltip, and
+  // the link target is unchanged.
+  const a = link(label || truncAddr(addr), () => navigate('/address/' + addr + netSuffix(getNetwork())));
   a.setAttribute('data-hl', addr);
+  a.title = addr;
   span.appendChild(a);
   if (label) {
     span.appendChild(el('span', { className: 'block-ctx' }, ' ' + truncAddr(addr)));


### PR DESCRIPTION
Completes #29, which #40 only half-fixed.

#40 unified `truncAddr()` and routed the *context suffixes* and realm-path namespaces through it — but every address that appears as a link goes through `addrLink()`, which rendered `label || addr`, i.e. the **full 40-character address**. So the tables the user actually reads were untouched.

Visible on the home page: a transfer row was 80 characters of address before any other content, pushing the amount off the visible area entirely.

Before:
```
g18qhq2fl54lszhmxeyqlvxnwjzc3xpu4nnakclp > g1hxsz6mnhjx2n75xr2vpe6tytdk8jj4p49gcsug
```
After:
```
g18qhq2f…kclp > g1hxsz6m…csug   15 000 000 ugnot
```

`addrLink()` now shows the abbreviated form, with the **full address in the `title` attribute** so it is still one hover away, and an unchanged link target. Known-label addresses keep showing their label, as before; the proposer variant gets the same tooltip.

Deliberately unchanged: the address **detail** page renders the full address in its own header, separately from `addrLink`, so the canonical value is still displayed in full where you would go looking for it.

Verified in a browser against real topaz data.