### PR TITLE
fix: backfill block_time on rows written before the column existed

### DIFF
--- a/db.go
+++ b/db.go
@@ -462,6 +462,95 @@ func (d *DB) DeleteNetworkData(network string) (int64, error) {
 	return total, nil
 }
 
+// blockTimeTables lists tables whose rows carry a block_time worth backfilling.
+// package_files and dependencies have no height of their own.
+var backfillTables = []string{"packages", "calls", "msg_runs", "bank_sends", "transactions"}
+
+// HeightsMissingBlockTime returns block heights that have rows with no
+// block_time, oldest first, capped at limit.
+//
+// Rows written before block_time existed never got one, and incremental sync
+// only ever moves forward from the cursor, so nothing fills them in. Without a
+// timestamp a row cannot be ordered against another chain's rows, and list
+// endpoints have to ask the indexer at request time instead of reading storage.
+func (d *DB) HeightsMissingBlockTime(network string, limit int) ([]int, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var parts []string
+	for _, t := range backfillTables {
+		// Table names come from the constant above, never from input.
+		parts = append(parts, fmt.Sprintf(
+			`SELECT DISTINCT block_height FROM %s WHERE network = ? AND (block_time IS NULL OR block_time = '')`, t))
+	}
+	query := strings.Join(parts, " UNION ") + " ORDER BY block_height DESC LIMIT ?"
+
+	args := make([]any, 0, len(backfillTables)+1)
+	for range backfillTables {
+		args = append(args, network)
+	}
+	args = append(args, limit)
+
+	rows, err := d.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var heights []int
+	for rows.Next() {
+		var h int
+		if err := rows.Scan(&h); err != nil {
+			return nil, err
+		}
+		heights = append(heights, h)
+	}
+	return heights, rows.Err()
+}
+
+// SetBlockTimes fills in block_time for rows at the given heights that lack it.
+// Existing values are left alone: this repairs history, it does not rewrite it.
+func (d *DB) SetBlockTimes(network string, times map[int]string) (int64, error) {
+	if len(times) == 0 {
+		return 0, nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	tx, err := d.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	var updated int64
+	for _, table := range backfillTables {
+		stmt, err := tx.Prepare(fmt.Sprintf(
+			`UPDATE %s SET block_time = ? WHERE network = ? AND block_height = ? AND (block_time IS NULL OR block_time = '')`, table))
+		if err != nil {
+			return 0, fmt.Errorf("prepare %s: %w", table, err)
+		}
+		for height, t := range times {
+			if t == "" {
+				continue
+			}
+			res, err := stmt.Exec(t, network, height)
+			if err != nil {
+				stmt.Close()
+				return 0, fmt.Errorf("update %s: %w", table, err)
+			}
+			if n, err := res.RowsAffected(); err == nil {
+				updated += n
+			}
+		}
+		stmt.Close()
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return updated, nil
+}
+
 // MaxBlockHeight returns the highest block height stored for a network, or 0 if
 // the network has no data yet.
 func (d *DB) MaxBlockHeight(network string) (int, error) {

--- a/db_test.go
+++ b/db_test.go
@@ -205,3 +205,79 @@ func TestNewDBIsIdempotent(t *testing.T) {
 		t.Errorf("packages = %d after reopen, want 1", count)
 	}
 }
+
+func TestBackfillBlockTimes(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "backfill.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	// Rows as an older build would have left them: no block_time anywhere.
+	seedNetwork(t, db, "gnoland1", 100)
+	seedNetwork(t, db, "topaz", 100)
+	for _, table := range backfillTables {
+		if _, err := db.db.Exec(
+			`UPDATE ` + table + ` SET block_time = '' WHERE network = 'gnoland1'`); err != nil {
+			t.Fatalf("clear block_time on %s: %v", table, err)
+		}
+	}
+	// topaz stands in for an already-healthy network: every row has a time.
+	for _, table := range backfillTables {
+		if _, err := db.db.Exec(
+			`UPDATE ` + table + ` SET block_time = 'ALREADY-SET' WHERE network = 'topaz'`); err != nil {
+			t.Fatalf("seed topaz %s: %v", table, err)
+		}
+	}
+
+	heights, err := db.HeightsMissingBlockTime("gnoland1", 200)
+	if err != nil {
+		t.Fatalf("find heights: %v", err)
+	}
+	if len(heights) != 1 || heights[0] != 100 {
+		t.Fatalf("heights = %v, want [100]", heights)
+	}
+
+	// Other networks are not reported as needing repair.
+	if h, err := db.HeightsMissingBlockTime("topaz", 200); err != nil || len(h) != 0 {
+		t.Errorf("topaz heights = %v (err %v), want none", h, err)
+	}
+
+	updated, err := db.SetBlockTimes("gnoland1", map[int]string{100: "2026-01-01T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("set block times: %v", err)
+	}
+	if updated != int64(len(backfillTables)) {
+		t.Errorf("updated %d rows, want %d (one per table)", updated, len(backfillTables))
+	}
+
+	for _, table := range backfillTables {
+		var got string
+		if err := db.db.QueryRow(
+			`SELECT block_time FROM ` + table + ` WHERE network = 'gnoland1'`).Scan(&got); err != nil {
+			t.Fatalf("read %s: %v", table, err)
+		}
+		if got != "2026-01-01T00:00:00Z" {
+			t.Errorf("%s block_time = %q, want the backfilled value", table, got)
+		}
+	}
+
+	// Nothing left to do, and the repair is idempotent.
+	if h, err := db.HeightsMissingBlockTime("gnoland1", 200); err != nil || len(h) != 0 {
+		t.Errorf("after backfill heights = %v (err %v), want none", h, err)
+	}
+
+	// An existing timestamp is never overwritten — this repairs history, it
+	// does not rewrite it.
+	if _, err := db.SetBlockTimes("topaz", map[int]string{100: "2099-01-01T00:00:00Z"}); err != nil {
+		t.Fatalf("set block times on topaz: %v", err)
+	}
+	var topaz string
+	if err := db.db.QueryRow(
+		`SELECT block_time FROM calls WHERE network = 'topaz'`).Scan(&topaz); err != nil {
+		t.Fatalf("read topaz: %v", err)
+	}
+	if topaz != "ALREADY-SET" {
+		t.Errorf("topaz block_time = %q, want it left untouched", topaz)
+	}
+}

--- a/syncer.go
+++ b/syncer.go
@@ -28,6 +28,7 @@ func (s *Syncer) SyncAll(ctx context.Context) error {
 		return err
 	}
 	s.warnOnHeightRegression(ctx)
+	s.backfillBlockTimes(ctx)
 	if err := s.syncPackages(ctx); err != nil {
 		return err
 	}
@@ -102,6 +103,49 @@ func (s *Syncer) syncPackages(ctx context.Context) error {
 	}
 	log.Printf("[%s] synced %d packages", s.networkID, count)
 	return nil
+}
+
+// backfillBatch bounds how many block heights are repaired per sync pass. The
+// work is spread across passes rather than done in one burst so a large gap
+// cannot stall startup or hammer a public indexer.
+const backfillBatch = 200
+
+// backfillBlockTimes fills in block_time for rows written before that column
+// existed.
+//
+// Incremental sync only moves forward from the cursor, so historical rows would
+// otherwise never get a timestamp. That matters twice over: rows without a
+// timestamp cannot be ordered against another chain's rows in a merged view, and
+// list endpoints have to ask the indexer for block times at request time instead
+// of reading what is already stored.
+//
+// Best-effort by design — failures are logged and retried on the next pass
+// rather than failing the sync.
+func (s *Syncer) backfillBlockTimes(ctx context.Context) {
+	heights, err := s.db.HeightsMissingBlockTime(s.networkID, backfillBatch)
+	if err != nil {
+		log.Printf("[%s] backfill: %v", s.networkID, err)
+		return
+	}
+	if len(heights) == 0 {
+		return
+	}
+
+	times, err := s.client.GetBlockTimesForHeights(ctx, heights)
+	if err != nil {
+		log.Printf("[%s] backfill: fetching %d block times: %v", s.networkID, len(heights), err)
+		return
+	}
+	if len(times) == 0 {
+		return
+	}
+
+	updated, err := s.db.SetBlockTimes(s.networkID, times)
+	if err != nil {
+		log.Printf("[%s] backfill: %v", s.networkID, err)
+		return
+	}
+	log.Printf("[%s] backfilled block_time on %d rows across %d blocks", s.networkID, updated, len(times))
 }
 
 // chainFingerprint identifies a specific chain instance by its first block.


### PR DESCRIPTION
Closes the data half of #35, and unblocks #34 and #51.

`block_time` was added by the time-series work, but incremental sync only ever moves forward from the cursor, so rows written by an older build never got one and nothing was ever going to fill them in. On a live instance:

| table | rows (gnoland1) | missing `block_time` |
|---|---|---|
| `bank_sends` | 2562 | **2562** |
| `packages` | 93 | 89 |
| `calls` | 96 | 63 |
| `msg_runs` | 24 | 24 |

That is not cosmetic. It is why two other things are broken:

- **Cross-network ordering is impossible.** Heights from different chains are not comparable — topaz is at ~470k while gnoland1 is at ~3.14M — so a merged list can only be ordered by timestamp, and most of these rows have none.
- **List endpoints re-fetch block times from the indexer on every request** (#34) purely to paper over the gap, which is where a good chunk of the remaining latency lives.

## How it works

A bounded repair pass runs at the start of each sync cycle:

1. `HeightsMissingBlockTime` finds distinct heights with untimed rows, newest first, capped at 200 per pass.
2. Those times are fetched with `GetBlockTimesForHeights`, which already picks between a range query and per-height fetches by density (#45).
3. `SetBlockTimes` writes them in one transaction, scoped to the network.

Deliberate choices:

- **Bounded per pass**, so a large gap cannot stall startup or hammer a public indexer. It converges over a few minutes and then costs one cheap query per cycle.
- **Never overwrites an existing value** — the `UPDATE` is guarded by `block_time IS NULL OR block_time = `. This repairs history; it does not rewrite it.
- **Best-effort**: failures are logged and retried next pass rather than failing the sync.
- **Newest first**, so the rows a user is most likely to look at are fixed first.

A plain re-sync would not have worked: the inserts are `INSERT OR IGNORE`, so existing rows are silently skipped.

## Verified against real data

Ran against a snapshot of the live database, real indexer:

```
[gnoland1] backfilled block_time on 197 rows across 197 blocks
[gnoland1] backfilled block_time on 196 rows across 196 blocks
[gnoland1] backfilled block_time on 195 rows across 195 blocks
[gnoland1] backfilled block_time on 173 rows across 173 blocks
```

`bank_sends` went from 2562 missing to 1825 in four passes; it converges in roughly ten more.

## Tests

`TestBackfillBlockTimes` covers the repair on a database in the broken shape, that other networks are untouched, that one pass fixes every table, that it is idempotent, and — the one that matters most — that an existing timestamp is **not** overwritten. The test caught a wrong assumption of mine on first run.

Still open in #35: making timestamp the actual sort key in merged views, which this makes possible.