### PR TITLE
feat: show call, importer and dependency counts on the realms list

### DIFF
--- a/api.go
+++ b/api.go
@@ -293,10 +293,11 @@ func (a *API) handleListPackages(w http.ResponseWriter, r *http.Request, realmOn
 	if limit == 0 {
 		limit = 50
 	}
+	sortBy := r.URL.Query().Get("sort")
 	total, _ := a.db.CountPackages(network, realmOnly)
 
 	if network != "" {
-		items, err := a.db.ListPackages(network, realmOnly, limit, offset)
+		items, err := a.db.ListPackages(network, realmOnly, limit, offset, sortBy)
 		if err != nil {
 			jsonError(w, err.Error(), 500)
 			return
@@ -309,7 +310,7 @@ func (a *API) handleListPackages(w http.ResponseWriter, r *http.Request, realmOn
 	var merged []PackageInfo
 	for _, items := range fanOut(r.Context(), a.networks, a.clients, a.health,
 		func(ctx context.Context, n NetworkConfig, c *IndexerClient) ([]PackageInfo, error) {
-			items, err := a.db.ListPackages(n.ID, realmOnly, limit+offset, 0)
+			items, err := a.db.ListPackages(n.ID, realmOnly, limit+offset, 0, sortBy)
 			if err != nil {
 				return nil, err
 			}
@@ -318,18 +319,7 @@ func (a *API) handleListPackages(w http.ResponseWriter, r *http.Request, realmOn
 		}) {
 		merged = append(merged, items...)
 	}
-	sort.Slice(merged, func(i, j int) bool {
-		if merged[i].BlockTime != "" && merged[j].BlockTime != "" {
-			return merged[i].BlockTime > merged[j].BlockTime
-		}
-		if merged[i].BlockTime != "" {
-			return true
-		}
-		if merged[j].BlockTime != "" {
-			return false
-		}
-		return merged[i].BlockHeight > merged[j].BlockHeight
-	})
+	sortMergedPackages(merged, sortBy)
 	if offset >= len(merged) {
 		jsonResponse(w, map[string]any{"items": []PackageInfo{}, "total": total})
 		return
@@ -339,6 +329,33 @@ func (a *API) handleListPackages(w http.ResponseWriter, r *http.Request, realmOn
 		end = len(merged)
 	}
 	jsonResponse(w, map[string]any{"items": merged[offset:end], "total": total})
+}
+
+// sortMergedPackages orders a cross-network list. Block heights from different
+// chains are not comparable, so the default ordering is by timestamp with height
+// only as a tiebreaker within rows that have none.
+func sortMergedPackages(pkgs []PackageInfo, sortBy string) {
+	switch sortBy {
+	case "calls":
+		sort.SliceStable(pkgs, func(i, j int) bool { return pkgs[i].Calls > pkgs[j].Calls })
+	case "importers":
+		sort.SliceStable(pkgs, func(i, j int) bool { return pkgs[i].Importers > pkgs[j].Importers })
+	case "imports":
+		sort.SliceStable(pkgs, func(i, j int) bool { return pkgs[i].Imports > pkgs[j].Imports })
+	case "name":
+		sort.SliceStable(pkgs, func(i, j int) bool { return pkgs[i].Path < pkgs[j].Path })
+	default:
+		sort.SliceStable(pkgs, func(i, j int) bool {
+			ti, tj := pkgs[i].BlockTime, pkgs[j].BlockTime
+			if ti != "" && tj != "" {
+				return ti > tj
+			}
+			if ti != tj {
+				return ti != "" // rows with a timestamp sort ahead of rows without
+			}
+			return pkgs[i].BlockHeight > pkgs[j].BlockHeight
+		})
+	}
 }
 
 func (a *API) HandleRealms(w http.ResponseWriter, r *http.Request) {

--- a/db.go
+++ b/db.go
@@ -576,6 +576,9 @@ type PackageInfo struct {
 	TxHash      string `json:"tx_hash"`
 	IsRealm     bool   `json:"is_realm"`
 	NumFiles    int    `json:"num_files"`
+	Calls       int    `json:"calls"`
+	Importers   int    `json:"importers"`
+	Imports     int    `json:"imports"`
 }
 
 type PackageDetail struct {
@@ -623,17 +626,46 @@ func (d *DB) CountPackages(network string, realmOnly bool) (int, error) {
 }
 
 // ListPackages returns all packages, optionally filtered.
-func (d *DB) ListPackages(network string, realmOnly bool, limit, offset int) ([]PackageInfo, error) {
+// packageSortClause maps a sort key to SQL. Whitelisted rather than
+// interpolated: the value comes from a query parameter.
+func packageSortClause(sortBy string) string {
+	switch sortBy {
+	case "calls":
+		return "calls DESC, p.block_height DESC"
+	case "importers":
+		return "importers DESC, p.block_height DESC"
+	case "imports":
+		return "imports DESC, p.block_height DESC"
+	case "name":
+		return "p.path ASC"
+	case "oldest":
+		return "p.block_height ASC"
+	default: // newest
+		return "p.block_height DESC"
+	}
+}
+
+func (d *DB) ListPackages(network string, realmOnly bool, limit, offset int, sortBy string) ([]PackageInfo, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	q := `SELECT network, path, name, creator, block_height, tx_hash, is_realm, num_files FROM packages WHERE is_realm = ?`
+	// Usage counts come from correlated subqueries rather than joins: a join on
+	// path alone would mix networks together, and grouping four tables in one
+	// query multiplies rows against each other.
+	q := `SELECT p.network, p.path, p.name, p.creator, p.block_height, p.tx_hash, p.is_realm, p.num_files,
+		(SELECT COUNT(*) FROM calls c
+		   WHERE c.network = p.network AND c.pkg_path = p.path) AS calls,
+		(SELECT COUNT(*) FROM dependencies d
+		   WHERE d.network = p.network AND d.import_path = p.path) AS importers,
+		(SELECT COUNT(*) FROM dependencies d
+		   WHERE d.network = p.network AND d.package_path = p.path) AS imports
+		FROM packages p WHERE p.is_realm = ?`
 	args := []any{realmOnly}
 	if network != "" {
-		q += ` AND network = ?`
+		q += ` AND p.network = ?`
 		args = append(args, network)
 	}
-	q += ` ORDER BY block_height DESC`
+	q += ` ORDER BY ` + packageSortClause(sortBy)
 	if limit > 0 {
 		q += fmt.Sprintf(` LIMIT %d OFFSET %d`, limit, offset)
 	}
@@ -647,7 +679,8 @@ func (d *DB) ListPackages(network string, realmOnly bool, limit, offset int) ([]
 	var pkgs []PackageInfo
 	for rows.Next() {
 		var p PackageInfo
-		if err := rows.Scan(&p.Network, &p.Path, &p.Name, &p.Creator, &p.BlockHeight, &p.TxHash, &p.IsRealm, &p.NumFiles); err != nil {
+		if err := rows.Scan(&p.Network, &p.Path, &p.Name, &p.Creator, &p.BlockHeight, &p.TxHash,
+			&p.IsRealm, &p.NumFiles, &p.Calls, &p.Importers, &p.Imports); err != nil {
 			return nil, err
 		}
 		pkgs = append(pkgs, p)
@@ -930,7 +963,8 @@ func (d *DB) Search(network, q string) ([]PackageInfo, error) {
 	var pkgs []PackageInfo
 	for rows.Next() {
 		var p PackageInfo
-		if err := rows.Scan(&p.Network, &p.Path, &p.Name, &p.Creator, &p.BlockHeight, &p.TxHash, &p.IsRealm, &p.NumFiles); err != nil {
+		if err := rows.Scan(&p.Network, &p.Path, &p.Name, &p.Creator, &p.BlockHeight, &p.TxHash,
+			&p.IsRealm, &p.NumFiles, &p.Calls, &p.Importers, &p.Imports); err != nil {
 			return nil, err
 		}
 		pkgs = append(pkgs, p)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -203,7 +203,12 @@ footer a:hover { color: var(--accent); }
     </main>
   </div>
   <div class="view" id="view-realms"><main><div id="realms-stats" class="stats-bar" style="display:none"></div><div class="section"><div class="section-title">all realms</div>
-    <table><thead><tr><th>path</th><th>creator</th><th>block</th><th>files</th></tr></thead><tbody id="realms-list"></tbody></table></div></main></div>
+    <table><thead><tr><th>path</th><th>creator</th>
+      <th class="rs" data-sort="calls">calls</th>
+      <th class="rs" data-sort="importers">importers</th>
+      <th class="rs" data-sort="imports">imports</th>
+      <th class="rs" data-sort="newest">block</th>
+      <th>files</th></tr></thead><tbody id="realms-list"></tbody></table></div></main></div>
   <div class="view" id="view-packages"><main><div id="packages-stats" class="stats-bar" style="display:none"></div><div class="section"><div class="section-title">all packages</div>
     <table><thead><tr><th>path</th><th>creator</th><th>block</th><th>files</th></tr></thead><tbody id="packages-list"></tbody></table></div></main></div>
   <div class="view" id="view-txs"><main>
@@ -394,6 +399,11 @@ function realmPathEl(fullPath, network) {
   return span;
 }
 function statusBadge(s) { return s ? badge('ok', 'ok') : badge('fail', 'fail'); }
+// Dim zeroes so the counts that carry information stand out in a dense table.
+function countCell(n) {
+  const v = n || 0;
+  return el('span', v ? {} : { style: { color: 'var(--fg2)', opacity: '0.5' } }, fmtNum(v));
+}
 function fmtNum(n) { return typeof n === 'number' ? n.toLocaleString() : String(n); }
 function fmtUgnot(amount, denom) {
   return fmtNum(amount) + ' ' + (denom || 'ugnot');
@@ -1069,15 +1079,24 @@ async function loadHome() {
   } catch (err) { console.error('home:', err); }
 }
 
+let _realmsSort = 'newest';
 async function loadRealms(page) {
   page = page || 0;
   const section = document.querySelector('#view-realms .section');
   const tbody = clear('realms-list');
-  skeletonRows(tbody, 4, 10);
+  skeletonRows(tbody, 7, 10);
   section.querySelectorAll('.pager').forEach(p => p.remove());
   const statsBar = document.getElementById('realms-stats');
+  // Sorting is server-side: ordering only the current page would rank 50 rows
+  // out of hundreds and quietly answer a different question.
+  document.querySelectorAll('#view-realms th.rs').forEach(th => {
+    const key = th.getAttribute('data-sort');
+    th.classList.toggle('sort-desc', _realmsSort === key);
+    th.classList.add('sortable');
+    th.onclick = () => { _realmsSort = key; loadRealms(0); };
+  });
   try {
-    const data = await api('realms?limit=' + PAGE_SIZE + '&offset=' + (page * PAGE_SIZE));
+    const data = await api('realms?limit=' + PAGE_SIZE + '&offset=' + (page * PAGE_SIZE) + '&sort=' + _realmsSort);
     if (page === 0) {
       const creators = new Set((data.items || []).map(r => r.creator));
       statsBar.textContent = ''; statsBar.style.display = 'flex';
@@ -1089,6 +1108,9 @@ async function loadRealms(page) {
       list.appendChild(el('tr', {},
         el('td', {}, realmPathEl(r.path, r.network)),
         el('td', {}, addrLink(r.creator)),
+        el('td', {}, countCell(r.calls)),
+        el('td', {}, countCell(r.importers)),
+        el('td', {}, countCell(r.imports)),
         el('td', {}, blockLink(r.block_height, r.network)), el('td', {}, String(r.num_files))
       ));
     }


### PR DESCRIPTION
Closes #47.

The realms list showed path, creator, block and file count — nothing about whether a realm is actually *used*. Answering "what matters here" meant opening realms one at a time.

Adds three sortable columns:

| column | meaning |
|---|---|
| **calls** | `MsgCall` transactions against the realm |
| **importers** | realms that depend on it |
| **imports** | realms it depends on |

On topaz this immediately surfaces the shape of the chain:

```
sort=calls        /r/gnoswap/common          calls=505  importers=9   imports=3
sort=importers    /r/gnoswap/access          calls=0    importers=24  imports=3
sort=imports      /r/aib/ibc/apps/transfer   calls=0    importers=1   imports=36
```

Note how different the three answers are — the most-called realm and the most-depended-upon realm are not the same, and `access` is load-bearing for 24 realms while never being called directly.

## Implementation notes

**Sorting is server-side.** Ordering the current page client-side would rank 50 rows out of hundreds and quietly answer a different question than the header implies. The `sort` parameter is whitelisted onto SQL rather than interpolated.

**Counts come from correlated subqueries, not joins.** A join on `pkg_path` alone would mix networks — the exact double-counting hazard flagged in #11 — and grouping four tables in one query multiplies rows against each other. Each subquery matches on `(network, path)`.

**Cross-network merge respects the sort too.** With no network selected the merged list is re-sorted by the same key; the default stays timestamp-first, since block heights from different chains are not comparable (#35).

**Zeroes are dimmed** so the counts carrying information stand out in a dense table.

Verified in a browser against real topaz data, and via the API across all four sort modes.