### PR TITLE
perf: write backfilled transactions in one batch

### DIFF
--- a/db.go
+++ b/db.go
@@ -508,6 +508,55 @@ func (d *DB) HeightsMissingBlockTime(network string, limit int) ([]int, error) {
 	return heights, rows.Err()
 }
 
+// TxRow is a transaction to be stored.
+type TxRow struct {
+	Hash        string
+	BlockHeight int
+	BlockTime   string
+	GasUsed     int
+	GasWanted   int
+	GasFee      int
+	Success     bool
+}
+
+// UpsertTransactions writes many transactions under a single lock and a single
+// SQLite transaction.
+//
+// Writing them one at a time takes and releases the write lock per row, and with
+// an application-level RWMutex over the database that means read requests queue
+// behind every individual insert — a backfill pass of 100 rows measurably slowed
+// the API while it ran.
+func (d *DB) UpsertTransactions(network string, rows []TxRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	tx, err := d.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(`
+		INSERT OR IGNORE INTO transactions
+			(network, tx_hash, block_height, block_time, gas_used, gas_wanted, gas_fee, success)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, r := range rows {
+		if _, err := stmt.Exec(network, r.Hash, r.BlockHeight, r.BlockTime,
+			r.GasUsed, r.GasWanted, r.GasFee, r.Success); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 // HeightsMissingTransactions returns block heights that have event rows with no
 // corresponding entry in the transactions table, newest first, capped at limit.
 //

--- a/db_test.go
+++ b/db_test.go
@@ -380,3 +380,45 @@ func TestGetGasStatsUsesStoredTransactions(t *testing.T) {
 		t.Errorf("type = %q, want MsgCall resolved from the call row", stats.TopTxs[0].Type)
 	}
 }
+
+func TestUpsertTransactionsIsBatchedAndIdempotent(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "batch.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	rows := []TxRow{
+		{Hash: "A", BlockHeight: 1, BlockTime: "t1", GasUsed: 10, GasWanted: 20, GasFee: 1, Success: true},
+		{Hash: "B", BlockHeight: 2, BlockTime: "t2", GasUsed: 30, GasWanted: 40, GasFee: 2, Success: false},
+	}
+	if err := db.UpsertTransactions("topaz", rows); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	var count, gas int
+	if err := db.db.QueryRow(
+		`SELECT COUNT(*), COALESCE(SUM(gas_used),0) FROM transactions WHERE network='topaz'`).
+		Scan(&count, &gas); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if count != 2 || gas != 40 {
+		t.Errorf("count/gas = %d/%d, want 2/40", count, gas)
+	}
+
+	// Re-running a backfill pass must not duplicate or corrupt rows.
+	if err := db.UpsertTransactions("topaz", rows); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if err := db.db.QueryRow(
+		`SELECT COUNT(*) FROM transactions WHERE network='topaz'`).Scan(&count); err != nil {
+		t.Fatalf("recount: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("count = %d after repeat, want 2", count)
+	}
+
+	if err := db.UpsertTransactions("topaz", nil); err != nil {
+		t.Errorf("empty batch should be a no-op, got %v", err)
+	}
+}

--- a/syncer.go
+++ b/syncer.go
@@ -211,10 +211,27 @@ func (s *Syncer) backfillTransactions(ctx context.Context) {
 	}
 
 	blockTimes := s.fetchBlockTimes(ctx, all)
+	rows := make([]TxRow, 0, len(all))
 	for _, tx := range all {
-		s.upsertTx(tx, blockTimes[tx.BlockHeight])
+		gasFee := 0
+		if tx.GasFee != nil {
+			gasFee = tx.GasFee.Amount
+		}
+		rows = append(rows, TxRow{
+			Hash:        tx.Hash,
+			BlockHeight: tx.BlockHeight,
+			BlockTime:   blockTimes[tx.BlockHeight],
+			GasUsed:     tx.GasUsed,
+			GasWanted:   tx.GasWanted,
+			GasFee:      gasFee,
+			Success:     tx.Success,
+		})
 	}
-	log.Printf("[%s] backfilled %d transactions across %d blocks", s.networkID, len(all), len(heights))
+	if err := s.db.UpsertTransactions(s.networkID, rows); err != nil {
+		log.Printf("[%s] transaction backfill: %v", s.networkID, err)
+		return
+	}
+	log.Printf("[%s] backfilled %d transactions across %d blocks", s.networkID, len(rows), len(heights))
 }
 
 // chainFingerprint identifies a specific chain instance by its first block.


### PR DESCRIPTION
Follow-up to #59, caught by measuring the live deployment right after it went out.

API latency got *worse* while the backfill ran:

| request | before backfill | during |
|---|---|---|
| `/api/gas?network=topaz` | 0.13s | 2.8s |
| `/api/txs?limit=20` | 1.0s | 3.3s |
| `/api/blocks` | 0.20s | 1.1s |

Not CPU — the process had used 1.4s total since restart. It was lock contention: `upsertTx` takes the database write lock **per row**, so a 100-row backfill pass acquired and released it a hundred times, and with an application-level `RWMutex` over the database every read request queued behind each one.

`UpsertTransactions` writes a whole batch under one lock and one SQLite transaction. Same rows, same `INSERT OR IGNORE` semantics, one hundredth of the lock churn.

Worth noting the underlying wart this exposes: the app-level `RWMutex` is largely redundant with SQLites own WAL locking and mostly serves to serialize writers against readers. Removing it is a bigger change than this, and is called out in `docs/architecture.md` as a known weak point.

Tests cover the batch writing correctly, being idempotent across repeated passes (a backfill retries the same window after a partial failure), and an empty batch being a no-op.