### PR TITLE
fix: stop the block counter flickering between networks in live mode

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3377,11 +3377,40 @@ function liveIncrStat(id) {
   }
 }
 
+// Live block heights, per network. Chains are at wildly different heights, so a
+// single shared counter written by whichever event arrived last just oscillates.
+const _liveTips = {};
+
+function renderLiveBlock() {
+  const blockEl = document.getElementById('stat-block');
+  if (!blockEl) return;
+  const net = getNetwork();
+
+  if (net && net !== 'all') {
+    if (_liveTips[net] > 0) blockEl.textContent = fmtNum(_liveTips[net]);
+    return;
+  }
+
+  // Across networks there is no single "current block". Show the highest so the
+  // number is stable and monotonic, and put the real per-network tips in the
+  // tooltip rather than flickering between them.
+  const entries = Object.entries(_liveTips).filter(([, h]) => h > 0);
+  if (!entries.length) return;
+  blockEl.textContent = fmtNum(Math.max(...entries.map(([, h]) => h)));
+  blockEl.title = entries
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([n, h]) => n + ': ' + fmtNum(h))
+    .join('\n');
+}
+
 function onLiveTx(tx) {
   _liveTxCount++;
-  // Update block height in home stats
-  const blockEl = document.getElementById('stat-block');
-  if (blockEl && tx.block_height > 0) blockEl.textContent = fmtNum(tx.block_height);
+  // Track the tip per network; the display decides what to show.
+  if (tx.block_height > 0) {
+    const net = tx.network || getNetwork();
+    if (!(_liveTips[net] > tx.block_height)) _liveTips[net] = tx.block_height;
+    renderLiveBlock();
+  }
 
   // Increment stat counters
   liveIncrStat('stat-txs');
@@ -3429,8 +3458,13 @@ function onLiveTx(tx) {
 
 function onLiveBlock(block, network) {
   _liveBlockCount++;
-  const blockEl = document.getElementById('stat-block');
-  if (blockEl) blockEl.textContent = fmtNum(block.height);
+  // Same per-network tracking as onLiveTx: block events arrive more often, so
+  // this was the main source of the flicker in all-networks mode.
+  if (block.height > 0) {
+    const net = network || getNetwork();
+    if (!(_liveTips[net] > block.height)) _liveTips[net] = block.height;
+    renderLiveBlock();
+  }
 
   // Prepend to blocks page if active
   const blocksList = document.getElementById('blocks-list');


### PR DESCRIPTION
Closes #36.

With "all networks" selected and live mode on, the block counter visibly flipped back and forth — one networks tip, then anothers, then back.

Both live handlers wrote the shared counter unconditionally with whatever event had just arrived:

```js
// onLiveTx
if (blockEl && tx.block_height > 0) blockEl.textContent = fmtNum(tx.block_height);
// onLiveBlock
if (blockEl) blockEl.textContent = fmtNum(block.height);
```

With independent SSE streams per network and chains at wildly different heights — topaz around 470k, gnoland1 around 3.14M — the display oscillated between them at whatever rate events arrived. `onLiveBlock` was the bigger offender, since block events are more frequent than transactions.

## Fix

Tips are tracked **per network** (`_liveTips`) and only ever move forward. What gets displayed is then a rendering decision:

- **One network selected** — that networks tip. Events from other networks are ignored rather than overwriting it.
- **All networks** — the highest tip, which is stable and monotonic, with the actual per-network tips in the tooltip. There is no single "current block" across chains, so showing one number and hiding that fact would be worse than showing the breakdown on hover.

## Verified in a browser

Interleaving events from two chains, as the feeds actually do:

| event | displayed before | displayed now |
|---|---|---|
| topaz 470100 | 470 100 | 470 100 |
| gnoland1 3162600 | 3 162 600 | 3 162 600 |
| topaz 470101 | **470 101** | 3 162 600 |
| gnoland1 3162601 | 3 162 601 | 3 162 601 |
| topaz 470102 | **470 102** | 3 162 601 |

Monotonic, with `gnoland1: 3 162 601 / topaz: 470 102` in the tooltip. With topaz selected, a gnoland1 event leaves the display untouched.

The other live counters (txs, calls, deploys, runs, sends) were already correct: they increment, and their baseline comes from `/api/stats` for the same network scope, so summing across networks is the right behavior there.