### PR TITLE
perf: read block times from storage instead of the indexer

### DIFF
--- a/api.go
+++ b/api.go
@@ -83,8 +83,14 @@ func stampPackageTimes(ctx context.Context, client *IndexerClient, pkgs []Packag
 	}
 }
 
-// stampBlockTimes fetches block times for the given transactions and sets BlockTime on each.
-func stampBlockTimes(ctx context.Context, client *IndexerClient, txs []Transaction) {
+// stampBlockTimes sets BlockTime on each transaction, preferring stored times.
+//
+// Asking the indexer for each block is the dominant cost of list endpoints — a
+// public indexer answers in roughly a quarter second, so a page spanning 50
+// distinct blocks spends over a second on timestamps alone. The syncer already
+// stores block_time, so the indexer is only consulted for whatever is not
+// already known locally.
+func (a *API) stampBlockTimes(ctx context.Context, network string, client *IndexerClient, txs []Transaction) {
 	if len(txs) == 0 {
 		return
 	}
@@ -98,10 +104,26 @@ func stampBlockTimes(ctx context.Context, client *IndexerClient, txs []Transacti
 			heights = append(heights, tx.BlockHeight)
 		}
 	}
-	bt, err := client.GetBlockTimesForHeights(ctx, heights)
-	if err != nil {
-		return
+
+	bt, err := a.db.BlockTimesForHeights(network, heights)
+	if err != nil || bt == nil {
+		bt = make(map[int]string, len(heights))
 	}
+
+	missing := heights[:0:0]
+	for _, h := range heights {
+		if bt[h] == "" {
+			missing = append(missing, h)
+		}
+	}
+	if len(missing) > 0 && client != nil {
+		if fetched, err := client.GetBlockTimesForHeights(ctx, missing); err == nil {
+			for h, t := range fetched {
+				bt[h] = t
+			}
+		}
+	}
+
 	for i := range txs {
 		txs[i].BlockTime = bt[txs[i].BlockHeight]
 	}
@@ -463,7 +485,7 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 		}
 		total := len(txs)
 		if limit <= 0 {
-			stampBlockTimes(r.Context(), client, txs)
+			a.stampBlockTimes(r.Context(), network, client, txs)
 			jsonResponse(w, map[string]any{"items": txs, "total": total})
 			return
 		}
@@ -476,7 +498,7 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 		}
 		page := txs[offset:end]
 		// Stamp only what is being returned, not everything that was fetched.
-		stampBlockTimes(r.Context(), client, page)
+		a.stampBlockTimes(r.Context(), network, client, page)
 		jsonResponse(w, map[string]any{"items": page, "total": total})
 		return
 	}
@@ -497,7 +519,7 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 			// Block times are needed before sorting: across networks, heights
 			// from different chains are not comparable and only the timestamp
 			// orders them.
-			stampBlockTimes(ctx, c, txs)
+			a.stampBlockTimes(ctx, n.ID, c, txs)
 			out := make([]netTx, 0, len(txs))
 			for _, tx := range txs {
 				tx.Network = n.ID
@@ -549,7 +571,7 @@ func (a *API) HandleAddress(w http.ResponseWriter, r *http.Request) {
 				if err != nil {
 					return nil, err
 				}
-				stampBlockTimes(ctx, c, netTxs)
+				a.stampBlockTimes(ctx, n.ID, c, netTxs)
 				for i := range netTxs {
 					netTxs[i].Network = n.ID
 				}

--- a/db.go
+++ b/db.go
@@ -508,6 +508,52 @@ func (d *DB) HeightsMissingBlockTime(network string, limit int) ([]int, error) {
 	return heights, rows.Err()
 }
 
+// BlockTimesForHeights returns known block times for the given heights, read
+// from stored transactions.
+//
+// Stamping list responses by asking the indexer for each block is the dominant
+// cost of those endpoints: a public indexer answers in roughly a quarter second,
+// so a page touching 50 distinct blocks spends over a second on timestamps alone.
+// The syncer already records block_time on every transaction it writes, so for
+// anything already synced this is a local lookup instead.
+func (d *DB) BlockTimesForHeights(network string, heights []int) (map[int]string, error) {
+	if len(heights) == 0 {
+		return nil, nil
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(heights)), ",")
+	args := make([]any, 0, len(heights)+1)
+	q := `SELECT block_height, block_time FROM transactions
+	      WHERE block_time IS NOT NULL AND block_time != ''`
+	if network != "" {
+		q += ` AND network = ?`
+		args = append(args, network)
+	}
+	q += ` AND block_height IN (` + placeholders + `) GROUP BY block_height`
+	for _, h := range heights {
+		args = append(args, h)
+	}
+
+	rows, err := d.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[int]string, len(heights))
+	for rows.Next() {
+		var h int
+		var t string
+		if err := rows.Scan(&h, &t); err != nil {
+			return nil, err
+		}
+		out[h] = t
+	}
+	return out, rows.Err()
+}
+
 // TxRow is a transaction to be stored.
 type TxRow struct {
 	Hash        string

--- a/db_test.go
+++ b/db_test.go
@@ -422,3 +422,43 @@ func TestUpsertTransactionsIsBatchedAndIdempotent(t *testing.T) {
 		t.Errorf("empty batch should be a no-op, got %v", err)
 	}
 }
+
+func TestBlockTimesForHeights(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "times.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.UpsertTransactions("topaz", []TxRow{
+		{Hash: "A", BlockHeight: 10, BlockTime: "2026-01-01T00:00:00Z"},
+		{Hash: "B", BlockHeight: 11, BlockTime: ""}, // synced before times were known
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := db.UpsertTransactions("gnoland1", []TxRow{
+		{Hash: "C", BlockHeight: 10, BlockTime: "OTHER-NETWORK"},
+	}); err != nil {
+		t.Fatalf("seed other: %v", err)
+	}
+
+	got, err := db.BlockTimesForHeights("topaz", []int{10, 11, 12})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if got[10] != "2026-01-01T00:00:00Z" {
+		t.Errorf("height 10 = %q, want the stored time", got[10])
+	}
+	// Heights with no usable time are absent, so the caller knows to ask the
+	// indexer for exactly those rather than for everything.
+	if _, ok := got[11]; ok {
+		t.Errorf("height 11 should be absent (empty stored time), got %q", got[11])
+	}
+	if _, ok := got[12]; ok {
+		t.Errorf("height 12 should be absent (not stored), got %q", got[12])
+	}
+
+	if _, err := db.BlockTimesForHeights("topaz", nil); err != nil {
+		t.Errorf("empty height list should be a no-op, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #34.

After the earlier fixes, list endpoints were still slow against the live deployment:

```
/api/txs?limit=50&network=topaz    6.3s
/api/txs?limit=100&network=topaz   4.3s
```

Measuring rather than guessing found it was not our box — mygnoscan had used 4.3s of CPU total since restart, and the local indexer answered in **1ms**. It was upstream: the public topaz indexer answers in **~0.25s per request**, and `stampBlockTimes` asks it once per distinct block. A page spanning 50 blocks therefore spends well over a second on timestamps alone, and that is the whole difference.

The syncer has been storing `block_time` on every transaction it writes all along, and after #55 and #59 that coverage extends to historical rows too. So the indexer never needed to be asked for most of them.

`stampBlockTimes` now reads from `transactions` first and only queries the indexer for heights it does not already know — typically the handful of blocks newer than the last sync pass. For a fully-synced network that is **zero** indexer round trips where there used to be one per block.

Being a method on `API` rather than a free function is what gives it database access; the network is passed explicitly so the lookup stays network-scoped.

## Tests

`BlockTimesForHeights` returns stored times, scopes to the network, and — the important part — **omits** heights with an empty or missing time rather than returning a blank string. That is what lets the caller ask the indexer for exactly the gap instead of assuming it has everything.

## Note

Absolute numbers on the deployment are noisy at the moment: the box is running a validator at ~100% CPU, and the public topaz indexers own latency varies by 5x between samples. The structural change — one query instead of N network round trips — is what matters here, and it is what remained of #34.