### PR TITLE
fix: stop backfills retrying genesis rows forever

### DIFF
--- a/db.go
+++ b/db.go
@@ -480,8 +480,10 @@ func (d *DB) HeightsMissingBlockTime(network string, limit int) ([]int, error) {
 	var parts []string
 	for _, t := range backfillTables {
 		// Table names come from the constant above, never from input.
+		// Genesis rows have no block to read a time from; excluding them keeps
+		// the repair from re-querying an unanswerable height on every pass.
 		parts = append(parts, fmt.Sprintf(
-			`SELECT DISTINCT block_height FROM %s WHERE network = ? AND (block_time IS NULL OR block_time = '')`, t))
+			`SELECT DISTINCT block_height FROM %s WHERE network = ? AND block_height > 0 AND (block_time IS NULL OR block_time = '')`, t))
 	}
 	query := strings.Join(parts, " UNION ") + " ORDER BY block_height DESC LIMIT ?"
 
@@ -615,9 +617,13 @@ func (d *DB) HeightsMissingTransactions(network string, limit int) ([]int, error
 
 	var parts []string
 	for _, t := range []string{"packages", "calls", "msg_runs", "bank_sends"} {
+		// Height 0 is genesis: those packages were loaded with the chain rather
+		// than deployed by a transaction, so no transaction row will ever exist
+		// for them. Including them made the backfill retry the same query every
+		// pass, forever, finding nothing.
 		parts = append(parts, fmt.Sprintf(`
 			SELECT DISTINCT e.block_height FROM %s e
-			WHERE e.network = ?
+			WHERE e.network = ? AND e.block_height > 0
 			  AND NOT EXISTS (
 			    SELECT 1 FROM transactions t
 			    WHERE t.network = e.network AND t.tx_hash = e.tx_hash)`, t))

--- a/db_test.go
+++ b/db_test.go
@@ -462,3 +462,45 @@ func TestBlockTimesForHeights(t *testing.T) {
 		t.Errorf("empty height list should be a no-op, got %v", err)
 	}
 }
+
+func TestBackfillSkipsGenesisRows(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "genesis.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	// Genesis-loaded packages: height 0, no transaction, no block, ever.
+	if err := db.UpsertPackage("gnoland1", "gno.land/r/gen", "gen", "g1c", "", 0, "", true, 1); err != nil {
+		t.Fatalf("seed genesis package: %v", err)
+	}
+	// A real deployment that genuinely needs repair.
+	if err := db.UpsertPackage("gnoland1", "gno.land/r/real", "real", "g1c", "TX", 42, "", true, 1); err != nil {
+		t.Fatalf("seed package: %v", err)
+	}
+
+	// Both backfills must ignore height 0, or they re-query an unanswerable
+	// height on every sync pass for the life of the process.
+	txHeights, err := db.HeightsMissingTransactions("gnoland1", 100)
+	if err != nil {
+		t.Fatalf("transaction gaps: %v", err)
+	}
+	for _, h := range txHeights {
+		if h == 0 {
+			t.Error("transaction backfill returned genesis height 0")
+		}
+	}
+	if len(txHeights) != 1 || txHeights[0] != 42 {
+		t.Errorf("transaction gaps = %v, want [42]", txHeights)
+	}
+
+	timeHeights, err := db.HeightsMissingBlockTime("gnoland1", 100)
+	if err != nil {
+		t.Fatalf("block time gaps: %v", err)
+	}
+	for _, h := range timeHeights {
+		if h == 0 {
+			t.Error("block time backfill returned genesis height 0")
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #55 and #59, found by watching the backfill on the live deployment: it converged from ~2700 rows down to exactly **78 and then stopped**, retrying every 30 seconds, silently, indefinitely.

All 78 are at **block height 0**:

```
packages  [(0, 77)]
msg_runs  [(0, 1)]
calls     []
bank_sends []
```

Those are genesis-loaded packages — they came with the chain rather than being deployed by a transaction. There is no transaction to fetch and no block 0 to read a time from, so the gap can never close. Each sync pass queried for them, got nothing back, and returned without even logging (the `len(all) == 0` early exit), so it was invisible in the logs.

Harmless in effect but permanent: a pointless query against the indexer every 30s per network, for the life of the process, and a "backfill is incomplete" state that never resolves.

Both backfills now exclude height 0.

## Tests

`TestBackfillSkipsGenesisRows` seeds one genesis package and one real deployment, and asserts neither backfill reports height 0 while the real one is still found. Without the fix the transaction gap query returns `[0, 42]` and the test fails.