### PR TITLE
fix: page the sync queries through the indexer's element cap

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -29,6 +29,18 @@ type IndexerClient struct {
 // errIndexerUnavailable is returned while the breaker is open.
 var errIndexerUnavailable = errors.New("indexer unavailable, not retried yet")
 
+// errQueryTooLarge reports that a query's result set hit the indexer's element
+// cap. It describes the query, not the indexer's health.
+var errQueryTooLarge = errors.New("indexer result set hit the element cap")
+
+// indexerElementCap is the tx-indexer's server-side limit on records per query.
+// On reaching it the resolver stops iterating and returns the rows it has
+// alongside a GraphQL error, so a capped response is partial rather than empty.
+// There is no limit or offset argument to ask for the next page with
+// (getTransactions takes only `where` and `order`), which leaves the block-height
+// filter as the only way to move through a result set larger than the cap.
+const indexerElementCap = 10000
+
 const (
 	clientBreakerThreshold = 2
 	clientBreakerCooldown  = 30 * time.Second
@@ -97,8 +109,9 @@ func (c *IndexerClient) query(ctx context.Context, query string, vars map[string
 		return errIndexerUnavailable
 	}
 	err := c.doQuery(ctx, query, vars, result)
-	// Caller-side cancellation says nothing about the indexer's health.
-	if !errors.Is(err, context.Canceled) {
+	// Caller-side cancellation and a capped result set both say nothing about the
+	// indexer's health, so neither counts against the breaker.
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, errQueryTooLarge) {
 		c.recordResult(err)
 	}
 	return err
@@ -134,6 +147,19 @@ func (c *IndexerClient) doQuery(ctx context.Context, query string, vars map[stri
 	}
 
 	if len(gqlResp.Errors) > 0 {
+		for _, e := range gqlResp.Errors {
+			if !strings.Contains(e.Message, "max elements per query") {
+				continue
+			}
+			// The resolver stops iterating at the cap and returns the rows it
+			// already has alongside this error, so decode the partial page before
+			// reporting it. Only this error carries usable data — for anything
+			// else `data` is meaningless and must not reach the caller.
+			if err := json.Unmarshal(gqlResp.Data, result); err != nil {
+				return fmt.Errorf("decode capped response: %w", err)
+			}
+			return fmt.Errorf("%w: %s", errQueryTooLarge, e.Message)
+		}
 		return fmt.Errorf("graphql error: %s", gqlResp.Errors[0].Message)
 	}
 
@@ -367,32 +393,79 @@ const txFields = `
 	}
 `
 
-// GetAllPackages fetches all MsgAddPackage transactions.
-func (c *IndexerClient) GetAllPackages(ctx context.Context, lastHeight *int,
-) ([]Transaction, error) {
-
+// transactionsFromHeight fetches one page of transactions above lastHeight (from
+// genesis when nil), oldest first. truncated reports that the indexer stopped at
+// its element cap and more rows remain; resume by passing the block height of the
+// last returned row.
+//
+// The cap is the page size. The resolver returns the rows it has alongside its
+// error, so there is nothing to size or guess at: ask for everything above the
+// cursor and take what comes back.
+//
+// ASC ordering is load-bearing, not cosmetic. Truncation keeps the *first* rows
+// the resolver iterated, so ascending gives the contiguous next page directly
+// above the cursor. Descending would hand back the newest rows instead — and
+// since the sync cursors are derived from the highest stored block height,
+// storing those would jump the cursor to the tip and orphan everything between,
+// silently and permanently.
+func (c *IndexerClient) transactionsFromHeight(
+	ctx context.Context,
+	lastHeight *int,
+	extraWhere, fields string,
+) (txs []Transaction, truncated bool, err error) {
 	var result struct {
 		GetTransactions []Transaction `json:"getTransactions"`
 	}
 
-	where := `messages: { value: { MsgAddPackage: {} } }`
-
+	heightWhere := ""
 	if lastHeight != nil {
-		where = fmt.Sprintf(`
-			block_height: { gt: %d }
-			messages: { value: { MsgAddPackage: {} } }
-		`, *lastHeight)
+		heightWhere = fmt.Sprintf(`block_height: { gt: %d }`, *lastHeight)
 	}
-
 	q := fmt.Sprintf(`{
 		getTransactions(
-			where: { %s }
+			where: { %s %s }
 			order: { heightAndIndex: ASC }
 		) { %s }
-	}`, where, txFields)
+	}`, heightWhere, extraWhere, fields)
 
-	err := c.query(ctx, q, nil, &result)
-	return result.GetTransactions, err
+	err = c.query(ctx, q, nil, &result)
+	if err != nil && !errors.Is(err, errQueryTooLarge) {
+		return nil, false, err
+	}
+	if err == nil {
+		return result.GetTransactions, false, nil
+	}
+
+	// Truncated. The cap can fall inside a block, and the caller resumes with an
+	// exclusive `gt` on the last row's height, which would skip the rest of that
+	// block — so give back only the heights known to be complete.
+	txs = dropTrailingHeight(result.GetTransactions)
+	if len(txs) == 0 {
+		return nil, false, fmt.Errorf(
+			"a single block holds more than %d matching transactions: %w", indexerElementCap, err)
+	}
+	return txs, true, nil
+}
+
+// dropTrailingHeight removes the rows sharing the highest block height in an
+// ascending page, which is the one truncation may have cut in half.
+func dropTrailingHeight(txs []Transaction) []Transaction {
+	if len(txs) == 0 {
+		return txs
+	}
+	last := txs[len(txs)-1].BlockHeight
+	end := len(txs)
+	for end > 0 && txs[end-1].BlockHeight == last {
+		end--
+	}
+	return txs[:end]
+}
+
+// GetAllPackages fetches a page of MsgAddPackage transactions above lastHeight.
+// See transactionsFromHeight for the paging contract.
+func (c *IndexerClient) GetAllPackages(ctx context.Context, lastHeight *int) ([]Transaction, bool, error) {
+	return c.transactionsFromHeight(ctx, lastHeight,
+		`messages: { value: { MsgAddPackage: {} } }`, txFields)
 }
 
 // GetRecentTransactions fetches the most recent transactions, limited to maxResults.
@@ -480,39 +553,10 @@ func (c *IndexerClient) recentTransactionsWindowed(
 	}
 }
 
-func (c *IndexerClient) GetRecentTransactionsFromHeight(ctx context.Context, lastHeight *int) ([]Transaction, error) {
-	var result struct {
-		GetTransactions []Transaction `json:"getTransactions"`
-	}
-
-	where := ""
-
-	if lastHeight != nil {
-		where = fmt.Sprintf(`block_height: { gt: %d }`, *lastHeight)
-	}
-
-	// if where is empty, avoid trailing comma / invalid GraphQL
-	whereClause := ""
-	if where != "" {
-		whereClause = fmt.Sprintf("where: { %s }", where)
-	} else {
-		whereClause = "where: {}"
-	}
-
-	q := fmt.Sprintf(`{
-		getTransactions(
-			%s
-			order: { heightAndIndex: DESC }
-		) { %s }
-	}`, whereClause, txFieldsLight)
-
-	if err := c.query(ctx, q, nil, &result); err != nil {
-		return nil, err
-	}
-
-	txs := result.GetTransactions
-
-	return txs, nil
+// GetTransactionsFromHeight fetches a page of transactions above lastHeight.
+// See transactionsFromHeight for the paging contract.
+func (c *IndexerClient) GetTransactionsFromHeight(ctx context.Context, lastHeight *int) ([]Transaction, bool, error) {
+	return c.transactionsFromHeight(ctx, lastHeight, "", txFieldsLight)
 }
 
 // GetTransactionsByPkgPath fetches MsgCall transactions for a specific package.
@@ -577,34 +621,11 @@ func (c *IndexerClient) GetTransactionsByAddress(ctx context.Context, addr strin
 	return result.GetTransactions, err
 }
 
-// GetMsgRunTransactions fetches all MsgRun transactions.
-func (c *IndexerClient) GetMsgRunTransactions(
-	ctx context.Context,
-	lastHeight *int,
-) ([]Transaction, error) {
-
-	var result struct {
-		GetTransactions []Transaction `json:"getTransactions"`
-	}
-
-	where := `messages: { value: { MsgRun: {} } }`
-
-	if lastHeight != nil {
-		where = fmt.Sprintf(`
-			block_height: { gt: %d }
-			messages: { value: { MsgRun: {} } }
-		`, *lastHeight)
-	}
-
-	q := fmt.Sprintf(`{
-		getTransactions(
-			where: { %s }
-			order: { heightAndIndex: DESC }
-		) { %s }
-	}`, where, txFields)
-
-	err := c.query(ctx, q, nil, &result)
-	return result.GetTransactions, err
+// GetMsgRunTransactions fetches a page of MsgRun transactions above lastHeight.
+// See transactionsFromHeight for the paging contract.
+func (c *IndexerClient) GetMsgRunTransactions(ctx context.Context, lastHeight *int) ([]Transaction, bool, error) {
+	return c.transactionsFromHeight(ctx, lastHeight,
+		`messages: { value: { MsgRun: {} } }`, txFields)
 }
 
 type Block struct {

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -244,3 +244,217 @@ func TestClientBreakerShortCircuitsDeadIndexer(t *testing.T) {
 }
 
 func mustErr(_ int, err error) error { return err }
+
+// truncatingTxIndexer imitates the tx-indexer resolver: it iterates in the
+// requested order, stops at the element cap, and returns the rows it already has
+// *alongside* the error rather than refusing the query. txsPerBlock transactions
+// per block, heights 1..tip.
+type truncatingTxIndexer struct {
+	tip         int
+	txsPerBlock int
+
+	mu        sync.Mutex
+	txQueries []string
+}
+
+func (f *truncatingTxIndexer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	query := string(body)
+	w.Header().Set("Content-Type", "application/json")
+
+	if strings.Contains(query, "latestBlockHeight") {
+		fmt.Fprintf(w, `{"data":{"latestBlockHeight":%d}}`, f.tip)
+		return
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.txQueries = append(f.txQueries, query)
+
+	from, to := 0, f.tip
+	if gt := strings.Index(query, "gt:"); gt >= 0 {
+		fmt.Sscanf(strings.TrimSpace(query[gt+3:]), "%d", &from)
+	}
+	if lt := strings.Index(query, "lt:"); lt >= 0 {
+		var v int
+		fmt.Sscanf(strings.TrimSpace(query[lt+3:]), "%d", &v)
+		to = min(v-1, f.tip)
+	}
+
+	var rows []string
+	emit := func(h int) {
+		for i := 0; i < f.txsPerBlock; i++ {
+			rows = append(rows, fmt.Sprintf(`{"hash":"tx-%d-%d","block_height":%d}`, h, i, h))
+		}
+	}
+	if strings.Contains(query, "DESC") {
+		for h := to; h > from && len(rows) < indexerElementCap; h-- {
+			emit(h)
+		}
+	} else {
+		for h := from + 1; h <= to && len(rows) < indexerElementCap; h++ {
+			emit(h)
+		}
+	}
+
+	// The resolver checks its counter before appending the next row, so a result
+	// set of exactly the cap is reported as truncated too.
+	truncated := len(rows) >= indexerElementCap
+	if truncated {
+		rows = rows[:indexerElementCap]
+	}
+
+	data := fmt.Sprintf(`"data":{"getTransactions":[%s]}`, strings.Join(rows, ","))
+	if truncated {
+		fmt.Fprintf(w, `{%s,"errors":[{"message":"max elements per query reached (%d)"}]}`,
+			data, indexerElementCap)
+		return
+	}
+	fmt.Fprintf(w, `{%s}`, data)
+}
+
+// blockOf groups a page by block height, so tests can assert no block came back
+// half-populated.
+func blockOf(txs []Transaction) map[int]int {
+	per := make(map[int]int)
+	for _, tx := range txs {
+		per[tx.BlockHeight]++
+	}
+	return per
+}
+
+func TestTransactionsFromHeightPageIsWholeBlocksOnly(t *testing.T) {
+	// 3 transactions per block does not divide the cap, so truncation lands inside
+	// a block. Handing that block back half-populated would lose its remaining
+	// rows for good: the caller resumes at the last row's height with an exclusive
+	// `gt`, and the sync cursor never looks back.
+	fake := &truncatingTxIndexer{tip: 20000, txsPerBlock: 3}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	txs, truncated, err := NewIndexerClient(srv.URL).GetTransactionsFromHeight(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !truncated {
+		t.Fatal("page was not reported as truncated")
+	}
+	if len(txs) == 0 || len(txs) > indexerElementCap {
+		t.Fatalf("got %d rows, want between 1 and the cap of %d", len(txs), indexerElementCap)
+	}
+
+	for h, n := range blockOf(txs) {
+		if n != fake.txsPerBlock {
+			t.Errorf("block %d came back with %d of its %d transactions", h, n, fake.txsPerBlock)
+		}
+	}
+	// The cap is 10000 and blocks hold 3, so a whole-blocks page stops at 9999.
+	if len(txs)%fake.txsPerBlock != 0 {
+		t.Errorf("page of %d rows is not a whole number of blocks", len(txs))
+	}
+}
+
+func TestTransactionsFromHeightAscendsFromTheCursor(t *testing.T) {
+	// ASC is load-bearing: truncation keeps the rows the resolver saw first, so
+	// only ascending order yields the contiguous page above the cursor. DESC would
+	// return the newest rows and orphan everything between them and the cursor.
+	fake := &truncatingTxIndexer{tip: 200, txsPerBlock: 1}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	cursor := 50
+	txs, truncated, err := NewIndexerClient(srv.URL).GetTransactionsFromHeight(context.Background(), &cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if truncated {
+		t.Fatal("200 blocks should fit under the cap")
+	}
+	if len(txs) != fake.tip-cursor {
+		t.Fatalf("got %d transactions, want %d", len(txs), fake.tip-cursor)
+	}
+	if txs[0].BlockHeight != cursor+1 {
+		t.Errorf("page starts at height %d, want %d — not anchored to the cursor", txs[0].BlockHeight, cursor+1)
+	}
+	for i := 1; i < len(txs); i++ {
+		if txs[i].BlockHeight < txs[i-1].BlockHeight {
+			t.Fatalf("height went backwards at %d: %d after %d", i, txs[i].BlockHeight, txs[i-1].BlockHeight)
+		}
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if q := fake.txQueries[0]; !strings.Contains(q, "ASC") {
+		t.Errorf("query is not ascending: %s", q)
+	}
+}
+
+func TestTransactionsFromHeightAtTip(t *testing.T) {
+	// Caught up: one query, nothing above the cursor, nothing more to ask for.
+	fake := &truncatingTxIndexer{tip: 500, txsPerBlock: 1}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	tip := fake.tip
+	txs, truncated, err := NewIndexerClient(srv.URL).GetTransactionsFromHeight(context.Background(), &tip)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(txs) != 0 || truncated {
+		t.Errorf("got %d transactions (truncated=%v) at the tip, want 0 and false", len(txs), truncated)
+	}
+}
+
+func TestTransactionsFromHeightRejectsAnOversizedBlock(t *testing.T) {
+	// Every row shares one height, so trimming the partial trailing block leaves
+	// nothing and there is no cursor to advance to. That has to surface as an
+	// error, not as a silently empty page that ends the walk.
+	fake := &truncatingTxIndexer{tip: 1, txsPerBlock: indexerElementCap + 10}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	_, _, err := NewIndexerClient(srv.URL).GetTransactionsFromHeight(context.Background(), nil)
+	if !errors.Is(err, errQueryTooLarge) {
+		t.Fatalf("got %v, want errQueryTooLarge", err)
+	}
+}
+
+func TestSyncFetchersKeepTheirFilterAndOrder(t *testing.T) {
+	// The message filter has to survive being merged with the cursor's
+	// block_height bound, and the order has to stay ascending.
+	tests := []struct {
+		name       string
+		wantFilter string
+		fetch      func(*IndexerClient, context.Context) ([]Transaction, bool, error)
+	}{
+		{"GetAllPackages", "MsgAddPackage", func(c *IndexerClient, ctx context.Context) ([]Transaction, bool, error) {
+			h := 10
+			return c.GetAllPackages(ctx, &h)
+		}},
+		{"GetMsgRunTransactions", "MsgRun", func(c *IndexerClient, ctx context.Context) ([]Transaction, bool, error) {
+			h := 10
+			return c.GetMsgRunTransactions(ctx, &h)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &truncatingTxIndexer{tip: 100, txsPerBlock: 1}
+			srv := httptest.NewServer(fake)
+			defer srv.Close()
+
+			if _, _, err := tt.fetch(NewIndexerClient(srv.URL), context.Background()); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			fake.mu.Lock()
+			defer fake.mu.Unlock()
+			q := fake.txQueries[0]
+			for _, want := range []string{tt.wantFilter, "block_height", "gt: 10", "ASC"} {
+				if !strings.Contains(q, want) {
+					t.Errorf("query is missing %q: %s", want, q)
+				}
+			}
+		})
+	}
+}

--- a/syncer.go
+++ b/syncer.go
@@ -26,16 +26,16 @@ const fingerprintKeyPrefix = "chain_fingerprint:"
 // SyncAll fetches all data from the indexer and processes it.
 func (s *Syncer) SyncAll(ctx context.Context) error {
 	if err := s.checkChainReset(ctx); err != nil {
-		return err
+		return fmt.Errorf("checkChainReset error: %w", err)
 	}
 	s.warnOnHeightRegression(ctx)
 	s.backfillBlockTimes(ctx)
 	s.backfillTransactions(ctx)
 	if err := s.syncPackages(ctx); err != nil {
-		return err
+		return fmt.Errorf("syncPackages error: %w", err)
 	}
 	if err := s.syncCalls(ctx); err != nil {
-		return err
+		return fmt.Errorf("sync calls error: %w", err)
 	}
 	return s.syncMsgRuns(ctx)
 }
@@ -69,42 +69,77 @@ func (s *Syncer) fetchBlockTimes(ctx context.Context, txs []Transaction) map[int
 	return m
 }
 
+// txPageFetcher fetches one page of transactions above a cursor, reporting
+// whether more remain. See IndexerClient.transactionsFromHeight.
+type txPageFetcher func(context.Context, *int) ([]Transaction, bool, error)
+
+// walkTransactions feeds every transaction above cursor to process, one indexer
+// page at a time.
+//
+// The indexer truncates a response at its element cap and says so, which makes
+// the cap the page size: each page is the contiguous next stretch above the
+// cursor, and the last row's height is where the following page starts. Threading
+// the cursor through this loop rather than re-deriving it from stored rows each
+// pass is what guarantees progress — a page whose rows land in none of the tables
+// a cursor is derived from would otherwise be fetched forever.
+func walkTransactions(
+	ctx context.Context,
+	cursor *int,
+	fetch txPageFetcher,
+	process func([]Transaction),
+) error {
+	for {
+		txs, truncated, err := fetch(ctx, cursor)
+		if err != nil {
+			return err
+		}
+		if len(txs) == 0 {
+			return nil
+		}
+
+		process(txs)
+
+		if !truncated {
+			return nil
+		}
+		next := txs[len(txs)-1].BlockHeight
+		cursor = &next
+	}
+}
+
 func (s *Syncer) syncPackages(ctx context.Context) error {
 	lastHeight, err := s.getLastBlockHeight(ctx, "packages")
 	if err != nil {
 		return err
 	}
 
-	txs, err := s.client.GetAllPackages(ctx, lastHeight)
-	if err != nil {
-		return err
-	}
-
-	times := s.fetchBlockTimes(ctx, txs)
 	count := 0
-	for _, tx := range txs {
-		bt := times[tx.BlockHeight]
-		s.upsertTx(tx, bt)
-		for _, msg := range tx.Messages {
-			if msg.Value.Typename == "MsgAddPackage" && msg.Value.Package != nil {
-				if err := s.analyzer.ProcessPackage(
-					s.networkID,
-					msg.Value.Package,
-					msg.Value.Creator,
-					tx.Hash,
-					tx.BlockHeight,
-					bt,
-					tx.Success,
-				); err != nil {
-					log.Printf("[%s] process package %s: %v", s.networkID, msg.Value.Package.Path, err)
-					continue
+	err = walkTransactions(ctx, lastHeight, s.client.GetAllPackages, func(txs []Transaction) {
+		times := s.fetchBlockTimes(ctx, txs)
+		for _, tx := range txs {
+			bt := times[tx.BlockHeight]
+			s.upsertTx(tx, bt)
+			for _, msg := range tx.Messages {
+				if msg.Value.Typename == "MsgAddPackage" && msg.Value.Package != nil {
+					if err := s.analyzer.ProcessPackage(
+						s.networkID,
+						msg.Value.Package,
+						msg.Value.Creator,
+						tx.Hash,
+						tx.BlockHeight,
+						bt,
+						tx.Success,
+					); err != nil {
+						log.Printf("[%s] process package %s: %v", s.networkID, msg.Value.Package.Path, err)
+						continue
+					}
+					count++
 				}
-				count++
 			}
 		}
-	}
+	})
 	log.Printf("[%s] synced %d packages", s.networkID, count)
-	return nil
+	return err
 }
 
 // backfillBatch bounds how many block heights are repaired per sync pass. The
@@ -355,53 +390,53 @@ func (s *Syncer) getLastRecentTransactionBlockHeight(ctx context.Context) (*int,
 func (s *Syncer) syncCalls(ctx context.Context) error {
 	lastHeight, err := s.getLastRecentTransactionBlockHeight(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("getLastRecentTransactionBlockHeight error : %w", err)
 	}
 
-	txs, err := s.client.GetRecentTransactionsFromHeight(ctx, lastHeight)
-	if err != nil {
-		return err
-	}
-
-	times := s.fetchBlockTimes(ctx, txs)
 	callCount, sendCount := 0, 0
-	for _, tx := range txs {
-		bt := times[tx.BlockHeight]
-		s.upsertTx(tx, bt)
-		for _, msg := range tx.Messages {
-			switch msg.Value.Typename {
-			case "MsgCall":
-				if err := s.analyzer.ProcessCall(
-					s.networkID,
-					tx.Hash, tx.BlockHeight,
-					bt,
-					msg.Value.Caller,
-					msg.Value.PkgPath,
-					msg.Value.Func,
-					tx.Success,
-				); err != nil {
-					log.Printf("[%s] process call: %v", s.networkID, err)
-					continue
+	err = walkTransactions(ctx, lastHeight, s.client.GetTransactionsFromHeight, func(txs []Transaction) {
+		times := s.fetchBlockTimes(ctx, txs)
+		for _, tx := range txs {
+			bt := times[tx.BlockHeight]
+			s.upsertTx(tx, bt)
+			for _, msg := range tx.Messages {
+				switch msg.Value.Typename {
+				case "MsgCall":
+					if err := s.analyzer.ProcessCall(
+						s.networkID,
+						tx.Hash, tx.BlockHeight,
+						bt,
+						msg.Value.Caller,
+						msg.Value.PkgPath,
+						msg.Value.Func,
+						tx.Success,
+					); err != nil {
+						log.Printf("[%s] process call: %v", s.networkID, err)
+						continue
+					}
+					callCount++
+				case "BankMsgSend":
+					if err := s.db.InsertBankSend(
+						s.networkID,
+						tx.Hash, tx.BlockHeight,
+						bt,
+						msg.Value.FromAddress,
+						msg.Value.ToAddress,
+						msg.Value.Amount,
+						tx.Success,
+					); err != nil {
+						log.Printf("[%s] process send: %v", s.networkID, err)
+						continue
+					}
+					sendCount++
 				}
-				callCount++
-			case "BankMsgSend":
-				if err := s.db.InsertBankSend(
-					s.networkID,
-					tx.Hash, tx.BlockHeight,
-					bt,
-					msg.Value.FromAddress,
-					msg.Value.ToAddress,
-					msg.Value.Amount,
-					tx.Success,
-				); err != nil {
-					log.Printf("[%s] process send: %v", s.networkID, err)
-					continue
-				}
-				sendCount++
 			}
 		}
-	}
+	})
 	log.Printf("[%s] synced %d calls, %d sends", s.networkID, callCount, sendCount)
+	if err != nil {
+		return fmt.Errorf("getTransactionsFromHeight error : %w", err)
+	}
 	return nil
 }
 
@@ -411,33 +446,30 @@ func (s *Syncer) syncMsgRuns(ctx context.Context) error {
 		return err
 	}
 
-	txs, err := s.client.GetMsgRunTransactions(ctx, lastHeight)
-	if err != nil {
-		return err
-	}
-
-	times := s.fetchBlockTimes(ctx, txs)
 	count := 0
-	for _, tx := range txs {
-		bt := times[tx.BlockHeight]
-		s.upsertTx(tx, bt)
-		for _, msg := range tx.Messages {
-			if msg.Value.Typename == "MsgRun" && msg.Value.Package != nil {
-				if err := s.analyzer.ProcessMsgRun(
-					s.networkID,
-					tx.Hash, tx.BlockHeight,
-					bt,
-					msg.Value.Caller,
-					msg.Value.Package.Files,
-					tx.Success,
-				); err != nil {
-					log.Printf("[%s] process msgrun: %v", s.networkID, err)
-					continue
+	err = walkTransactions(ctx, lastHeight, s.client.GetMsgRunTransactions, func(txs []Transaction) {
+		times := s.fetchBlockTimes(ctx, txs)
+		for _, tx := range txs {
+			bt := times[tx.BlockHeight]
+			s.upsertTx(tx, bt)
+			for _, msg := range tx.Messages {
+				if msg.Value.Typename == "MsgRun" && msg.Value.Package != nil {
+					if err := s.analyzer.ProcessMsgRun(
+						s.networkID,
+						tx.Hash, tx.BlockHeight,
+						bt,
+						msg.Value.Caller,
+						msg.Value.Package.Files,
+						tx.Success,
+					); err != nil {
+						log.Printf("[%s] process msgrun: %v", s.networkID, err)
+						continue
+					}
+					count++
 				}
-				count++
 			}
 		}
-	}
+	})
 	log.Printf("[%s] synced %d msg_runs", s.networkID, count)
-	return nil
+	return err
 }

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -273,3 +273,66 @@ func TestMaxBlockHeight(t *testing.T) {
 		t.Errorf("height = %d, want 42 (highest for topaz, ignoring other networks)", got)
 	}
 }
+
+func TestWalkTransactionsCoversEveryRowAcrossPages(t *testing.T) {
+	// The chain is two and a half pages deep and its blocks hold 3 transactions
+	// each, so the indexer's cap falls inside a block on every page. Every row has
+	// to arrive exactly once: a gap here is silent, permanent data loss, because
+	// the sync cursors only ever move forward.
+	fake := &truncatingTxIndexer{tip: 8500, txsPerBlock: 3}
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+	client := NewIndexerClient(srv.URL)
+
+	seen := make(map[string]int)
+	pages := 0
+	err := walkTransactions(context.Background(), nil, client.GetTransactionsFromHeight,
+		func(txs []Transaction) {
+			pages++
+			for _, tx := range txs {
+				seen[tx.Hash]++
+			}
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if pages < 3 {
+		t.Errorf("walked %d pages for %d rows; expected the cap to force several",
+			pages, fake.tip*fake.txsPerBlock)
+	}
+	want := fake.tip * fake.txsPerBlock
+	if len(seen) != want {
+		t.Errorf("saw %d distinct transactions, want %d", len(seen), want)
+	}
+	for h := 1; h <= fake.tip; h++ {
+		for i := 0; i < fake.txsPerBlock; i++ {
+			hash := fmt.Sprintf("tx-%d-%d", h, i)
+			switch seen[hash] {
+			case 1:
+			case 0:
+				t.Fatalf("%s never arrived — the walk skipped it", hash)
+			default:
+				t.Fatalf("%s arrived %d times", hash, seen[hash])
+			}
+		}
+	}
+}
+
+func TestWalkTransactionsStopsWhenCaughtUp(t *testing.T) {
+	fake := &truncatingTxIndexer{tip: 100, txsPerBlock: 1}
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+
+	cursor := 100
+	calls := 0
+	err := walkTransactions(context.Background(), &cursor,
+		NewIndexerClient(srv.URL).GetTransactionsFromHeight,
+		func(txs []Transaction) { calls++ })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("processed %d pages while caught up, want 0", calls)
+	}
+}


### PR DESCRIPTION
closes #64

 ## The bug

  Sync failed outright with:

  ```
  sync error: sync calls error: getTransactionsFromHeight error :
    graphql error: max elements per query reached (10000)
  ```

  `GetRecentTransactionsFromHeight` asked for every transaction above the stored
  cursor in a single query. The tx-indexer caps a result set at 10,000 records, so
  once the cursor fell that far behind the tip — a first sync, or the process being
  down for a while — the request came back with an error and `syncCalls` bailed.

  The part that made it permanent rather than transient: the sync cursors are
  *derived* from the highest stored `block_height`, not stored separately. Nothing
  got written, so the cursor never moved, so the next pass 30 seconds later sent the
  identical oversized query. A chain that crossed 10,000 transactions could never be
  synced at all.

  ## The mechanism: `truncated`

  The indexer does not reject an oversized query. `serve/graph/all.resolvers.go`
  stops iterating at the cap and returns the rows it already has **alongside** a
  GraphQL error:

  ```go
  if i == maxElementsPerQuery {
      graphql.AddErrorf(ctx, "max elements per query reached (%d)", maxElementsPerQuery)
      return out, nil        // ← the 10,000 rows go back too
  }
  ```

  That is contractual, not incidental — the schema documents it: *"If the result is
  incomplete due to errors, both partial results and errors are returned."*

  We were throwing those rows away. `doQuery` checked `len(gqlResp.Errors) > 0` and
  returned before ever unmarshalling `data`. So 10,000 perfectly good rows arrived
  and got discarded, turning a partial success into a total failure.

  Now `doQuery` recognises that one specific error, decodes the partial page, and
  reports it as `errQueryTooLarge`. `transactionsFromHeight` translates that into a
  `truncated` flag:

  ```go
  func (c *IndexerClient) transactionsFromHeight(...) (txs []Transaction, truncated bool, err error)
  ```

  `truncated` means *"this page is full, more rows remain above it"*. The three sync
  fetchers (`GetTransactionsFromHeight`, `GetAllPackages`, `GetMsgRunTransactions`)
  return it, and `walkTransactions` in `syncer.go` loops until a page comes back
  short.

  **The cap becomes the page size.** There is no window to size, no growth factor to
  tune, no density to guess at — the server tells us where the page ends.

  Two details make this work:

  **Ordering is load-bearing.** Queries are `order: { heightAndIndex: ASC }`.
  Truncation keeps the rows the resolver iterated *first*, so ascending yields the
  contiguous next stretch directly above the cursor. Descending would return the
  newest 10,000 instead — a chunk floating near the tip with a gap behind it.
  Storing those would jump the derived cursor to near the tip and **silently orphan
  every transaction in between, permanently**. The previous code used `DESC`, so this
  is not a hypothetical. There is a test asserting the query says `ASC` and
  explaining why.

  **The cursor is threaded through the loop, not re-derived per pass.** `syncCalls`
  derives its cursor from `calls ∪ bank_sends`. If a page of 10,000 rows happened to
  contain no `MsgCall` and no `BankMsgSend`, nothing would land in either table, the
  derived cursor would not move, and that page would be re-fetched forever. Passing
  the cursor down the loop removes that failure mode entirely.

  ## Why we drop the last block

  The cap counts transactions, not blocks, so it can fall **inside** a block. If
  block `H` holds 5 transactions and only 2 fit under the cap, the page ends
  mid-block.

  The caller resumes with `block_height: { gt: H }` — exclusive. The other 3
  transactions in block `H` sit at exactly height `H`, so they fall outside both the
  page that was cut short and every page after it. They are skipped, forever,
  silently, because the sync cursors only ever move forward.

  So a truncated page gives back only the heights known to be complete:

  ```go
  txs = dropTrailingHeight(result.GetTransactions)
  ```

  `dropTrailingHeight` removes every row sharing the page's highest block height.
  The cursor then lands *below* `H`, and the next query re-fetches `H` in full.
  Cost: one duplicated block per page, and all the writes are idempotent
  (`INSERT OR REPLACE` / `INSERT OR IGNORE` keyed on tx hash), so re-processing is
  free.

  The degenerate case — one block holding more than 10,000 matching transactions —
  leaves nothing after trimming and no cursor to advance to. That surfaces as an
  error rather than an empty page, because an empty page would look like "caught up"
  and end the walk:

  ```
  a single block holds more than 10000 matching transactions: ...
  ```

  ## Also in here

  - **Capped responses no longer trip the circuit breaker.** The cap describes the
    query, not the indexer's health. Two of them used to open the 30-second breaker
    and take every unrelated query down with it — the same exemption
    `context.Canceled` already had.
  - **Only the cap error yields partial data.** For any other GraphQL error, `data`
    is meaningless and never reaches the caller.
  - **`fetchBlockTimes` now runs per page** instead of once over the whole
    accumulated backlog, so a large catch-up no longer fires tens of thousands of
    block requests in a single burst.
  - `GetRecentTransactionsFromHeight` → `GetTransactionsFromHeight`. It returns the
    oldest page above a cursor; "Recent" was misleading, and the signature changed
    anyway.

  ## Deliberately out of scope

  The read paths (`GetRecentTransactions`, `GetTransactionsByPkgPath`,
  `GetStorageEvents`, `GetGasUsageForRealm`, and friends) are **untouched** —
  byte-identical to `main`. They keep their existing widening-window fetch and its
  `initialTxWindow` / `txWindowGrowth` constants. Several of them can still hit the
  cap on a busy chain; that is a separate change.

  They do pick up one incidental improvement from the shared `doQuery` fix: on a
  capped response they now receive partial rows alongside the error. Callers that
  discard the error (`storageTxs, _ := ...`) get real data where they previously got
  none; callers that propagate it behave exactly as before.

  Upstream, the right fix is a `limit` argument plus keyset pagination on
  `getTransactions` — the filter already exposes `block_height` and `index` with
  `heightAndIndex` ordering, which is a composite cursor. Worth a PR to
  `gnolang/tx-indexer`, but it cannot be depended on here: `indexer.gno.land` and
  `indexer.test12.moul.p2p.team` do not run our build, and sending an unknown
  `limit:` argument to a current indexer is a GraphQL validation error.

  ## Testing

  `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` passing.

  New coverage:

  | Test | What it pins |
  | --- | --- |
  | `TestWalkTransactionsCoversEveryRowAcrossPages` | 25,500 rows across 3+ pages, every `(height, index)` arrives **exactly once** — the regression guard for both ordering and trimming |
  | `TestTransactionsFromHeightPageIsWholeBlocksOnly` | no block ever comes back half-populated |
  | `TestTransactionsFromHeightAscendsFromTheCursor` | the query is `ASC` and anchored on the cursor |
| `TestTransactionsFromHeightPageIsWholeBlocksOnly` | no block ever comes back half-populated |
| `TestTransactionsFromHeightAscendsFromTheCursor` | the query is `ASC` and anchored on the cursor |
| `TestTransactionsFromHeightRejectsAnOversizedBlock` | a single over-cap block errors instead of silently ending the walk |
| `TestSyncFetchersKeepTheirFilterAndOrder` | the message filter survives being merged with the `block_height` bound |
| `TestElementCapErrorDoesNotOpenBreaker` | a capped response leaves the breaker closed |
| `TestWalkTransactionsStopsWhenCaughtUp` | no work when there is nothing above the cursor |

The fake indexer models the real resolver: it iterates in the requested order,
stops at the cap, and returns rows *alongside* the error. It serves 3 transactions
per block, which does not divide 10,000 — so truncation lands mid-block on every
page, which is what gives the trimming tests teeth.

**Not verified against a live chain with a real backlog.** `indexer.gno.land` has
2,771 total transactions and `indexer.test12.moul.p2p.team` has 1,381 — neither is
large enough to truncate. The `sapphire` network that hit this is configured via
`-indexer`, and I do not have its URL. Worth one manual run against it before
merging.

Two things outside the description itself: the fmt.Errorf wrapping on the SyncAll steps that was already in your working tree is part of this diff — worth keeping, since it's what made the original error name the failing call. And nothing is committed yet; the branch is feat/timeseries-demo, which looks unrelated, so you may want a fresh branch off main.