### PR TITLE
chore: tidy the error wrapping on the sync steps

### DIFF
--- a/syncer.go
+++ b/syncer.go
@@ -26,18 +26,21 @@ const fingerprintKeyPrefix = "chain_fingerprint:"
 // SyncAll fetches all data from the indexer and processes it.
 func (s *Syncer) SyncAll(ctx context.Context) error {
 	if err := s.checkChainReset(ctx); err != nil {
-		return fmt.Errorf("checkChainReset error: %w", err)
+		return fmt.Errorf("check chain reset: %w", err)
 	}
 	s.warnOnHeightRegression(ctx)
 	s.backfillBlockTimes(ctx)
 	s.backfillTransactions(ctx)
 	if err := s.syncPackages(ctx); err != nil {
-		return fmt.Errorf("syncPackages error: %w", err)
+		return fmt.Errorf("sync packages: %w", err)
 	}
 	if err := s.syncCalls(ctx); err != nil {
-		return fmt.Errorf("sync calls error: %w", err)
+		return fmt.Errorf("sync calls: %w", err)
 	}
-	return s.syncMsgRuns(ctx)
+	if err := s.syncMsgRuns(ctx); err != nil {
+		return fmt.Errorf("sync msg runs: %w", err)
+	}
+	return nil
 }
 
 func (s *Syncer) upsertTx(tx Transaction, blockTime string) {
@@ -390,7 +393,7 @@ func (s *Syncer) getLastRecentTransactionBlockHeight(ctx context.Context) (*int,
 func (s *Syncer) syncCalls(ctx context.Context) error {
 	lastHeight, err := s.getLastRecentTransactionBlockHeight(ctx)
 	if err != nil {
-		return fmt.Errorf("getLastRecentTransactionBlockHeight error : %w", err)
+		return fmt.Errorf("last synced call height: %w", err)
 	}
 
 	callCount, sendCount := 0, 0
@@ -435,7 +438,7 @@ func (s *Syncer) syncCalls(ctx context.Context) error {
 	})
 	log.Printf("[%s] synced %d calls, %d sends", s.networkID, callCount, sendCount)
 	if err != nil {
-		return fmt.Errorf("getTransactionsFromHeight error : %w", err)
+		return fmt.Errorf("walk transactions: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Follow-up to #65, which added `%w` wrapping to the `SyncAll` steps so a failure names the call that produced it. That was the right idea — keeping it, just tidying the strings.

Three things:

- **`error :` with a space before the colon**, in two places. Reads as a typo in the logs.
- **Function names as error text.** `getLastRecentTransactionBlockHeight error: ...` leaks an internal identifier into an operator-facing log line, and goes stale the moment the function is renamed — which #65 itself just did to its neighbour. Replaced with what the step was doing.
- **`syncMsgRuns` was the one step not wrapped**, so a failure there came back bare while its four siblings were labelled. Now consistent.

Before / after on a failing pass:

```
sync calls error: getTransactionsFromHeight error : graphql error: ...
sync calls: walk transactions: graphql error: ...
```

No behaviour change — same errors, same `%w` chains, same `errors.Is` targets. `gofmt`/`go vet`/`go test ./...` clean.