### PR TITLE
test: cover gno.land import extraction

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// ExtractImports feeds the dependency graph, which is what the realm/package
+// views are drawn from. It needs no database, so it tests as a pure function.
+func TestExtractImports(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []MemFile
+		want  []string
+	}{
+		{
+			name:  "no files",
+			files: nil,
+			want:  nil,
+		},
+		{
+			name: "single import",
+			files: []MemFile{
+				{Name: "a.gno", Body: `import "gno.land/p/demo/avl"`},
+			},
+			want: []string{"gno.land/p/demo/avl"},
+		},
+		{
+			name: "grouped import block",
+			files: []MemFile{{Name: "a.gno", Body: `
+				import (
+					"std"
+					"strings"
+					"gno.land/p/demo/avl"
+					"gno.land/r/demo/users"
+				)
+			`}},
+			// Stdlib imports carry no gno.land prefix and are not dependencies
+			// this graph tracks.
+			want: []string{"gno.land/p/demo/avl", "gno.land/r/demo/users"},
+		},
+		{
+			name: "duplicates collapse across files, first-seen order wins",
+			files: []MemFile{
+				{Name: "b.gno", Body: `import "gno.land/p/demo/ufmt"`},
+				{Name: "a.gno", Body: `import "gno.land/p/demo/avl"`},
+				{Name: "c.gno", Body: `import "gno.land/p/demo/ufmt"`},
+			},
+			want: []string{"gno.land/p/demo/ufmt", "gno.land/p/demo/avl"},
+		},
+		{
+			name: "non-gno files are skipped",
+			files: []MemFile{
+				{Name: "README.md", Body: `see "gno.land/r/demo/boards"`},
+				{Name: "gno.mod", Body: `require "gno.land/p/demo/avl"`},
+				{Name: "a.gno", Body: `import "gno.land/p/demo/avl"`},
+			},
+			want: []string{"gno.land/p/demo/avl"},
+		},
+		{
+			name: "test files are skipped",
+			files: []MemFile{
+				{Name: "a_test.gno", Body: `import "gno.land/p/demo/testutils"`},
+				{Name: "a.gno", Body: `import "gno.land/p/demo/avl"`},
+			},
+			// A package's tests are not part of what it depends on at runtime.
+			want: []string{"gno.land/p/demo/avl"},
+		},
+		{
+			name: "only test files leaves nothing",
+			files: []MemFile{
+				{Name: "a_test.gno", Body: `import "gno.land/p/demo/testutils"`},
+			},
+			want: nil,
+		},
+		{
+			name: "no gno.land imports",
+			files: []MemFile{
+				{Name: "a.gno", Body: `import ("std"; "strings")`},
+			},
+			want: nil,
+		},
+	}
+
+	a := NewAnalyzer(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := a.ExtractImports(tt.files)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractImports() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractImportsMatchesAnyQuotedPath pins a known limitation rather than
+// endorsing it: extraction is a regex over the file body, not a parse of the
+// import block, so any quoted gno.land path anywhere in the source is reported
+// as a dependency — including ones in comments, in string literals, and in
+// imports that were commented out.
+//
+// The effect is a dependency graph that over-reports. It never misses a real
+// import, which is why this is tolerable, but a realm that merely mentions a
+// path in a string gets an edge it does not have. Changing it means parsing the
+// source properly; this test exists so that change is visible when it happens.
+func TestExtractImportsMatchesAnyQuotedPath(t *testing.T) {
+	files := []MemFile{{Name: "a.gno", Body: `
+		package main
+
+		// import "gno.land/r/demo/commented"
+		import "gno.land/p/demo/avl"
+
+		const link = "gno.land/r/demo/mentioned"
+	`}}
+
+	got := NewAnalyzer(nil).ExtractImports(files)
+	want := []string{
+		"gno.land/r/demo/commented",
+		"gno.land/p/demo/avl",
+		"gno.land/r/demo/mentioned",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractImports() = %v, want %v", got, want)
+	}
+}
+
+// ExtractMsgRunImports delegates to ExtractImports today. MsgRun source arrives
+// as a single unnamed-or-arbitrary file, so the .gno suffix filter is the part
+// that matters: a MsgRun body that is not named *.gno yields nothing.
+func TestExtractMsgRunImports(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []MemFile
+		want  []string
+	}{
+		{
+			name:  "gno-suffixed body is scanned",
+			files: []MemFile{{Name: "main.gno", Body: `import "gno.land/p/demo/avl"`}},
+			want:  []string{"gno.land/p/demo/avl"},
+		},
+		{
+			name:  "body without a .gno name is skipped",
+			files: []MemFile{{Name: "main", Body: `import "gno.land/p/demo/avl"`}},
+			want:  nil,
+		},
+	}
+
+	a := NewAnalyzer(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := a.ExtractMsgRunImports(tt.files)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractMsgRunImports() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Picks off the top item of #14. `analyzer.go` was the last pure-logic file with no coverage — 89 lines, no database, and the whole dependency graph is drawn from it.

13 cases across three tests, table-driven per `AGENTS.md`:

- grouped import blocks, with stdlib imports correctly ignored
- dedup across files, first-seen order preserved
- non-`.gno` files skipped (`README.md`, `gno.mod`)
- `_test.gno` skipped — a package's tests are not its runtime dependencies
- the empty cases: no files, only test files, no `gno.land` imports

## One test pins a bug rather than a feature

`TestExtractImportsMatchesAnyQuotedPath` asserts current behaviour, which is wrong:

```go
var importRegex = regexp.MustCompile(`"(gno\.land/[^"]+)"`)
```

That is a regex over the whole file body, not a parse of the import block. Any quoted `gno.land` path anywhere in the source is reported as a dependency:

```gno
// import "gno.land/r/demo/commented"     ← reported
import "gno.land/p/demo/avl"              ← reported, correctly
const link = "gno.land/r/demo/mentioned"  ← reported
```

All three come back as imports. So the dependency graph **over-reports**: a realm that merely names a path in a string literal gets an edge it does not have, and cross-realm paths in string literals are common enough in gno that this is not hypothetical.

It never *misses* a real import, which is why it has gone unnoticed and why I am not fixing it here — the fix is to parse the source properly, and that belongs in its own PR with its own argument about what to do with `gno.mod`. The test is written to fail loudly when someone does fix it, with a comment saying so, rather than leaving the next person to guess whether the behaviour was intended.

Filed as a follow-up issue.

`gofmt`/`go vet`/`go test ./...` clean.