### PR TITLE
fix: serve recent views from a capped window instead of failing

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -490,10 +490,17 @@ func (c *IndexerClient) GetRecentTransactions(ctx context.Context, maxResults in
 }
 
 // Window sizes for paged transaction fetches. The indexer has no limit argument,
-// so the only way to bound a query is by block height; cost tracks the number of
-// rows returned, not the width of the window, so widening is cheap.
+// so the only way to bound a query is by block height.
+//
+// Start small and widen. The two errors are not symmetric: overshooting costs a
+// payload that grows with the chain's density and is unbounded in practice —
+// a 20,000-block window on sapphire returns 45MB to serve a 20-row page, which
+// does not fit in the client's timeout — while undershooting costs one more
+// round trip against a chain sparse enough that round trips are cheap. gno.land
+// returns nothing at all for its most recent 20,000 blocks and has to widen
+// regardless, so a large starting window buys nothing there either.
 const (
-	initialTxWindow = 20000
+	initialTxWindow = 100
 	txWindowGrowth  = 8
 )
 
@@ -543,6 +550,19 @@ func (c *IndexerClient) recentTransactionsWindowed(
 		) { %s }
 	}`, from, extraWhere, txFieldsLight)
 		if err := c.query(ctx, q, nil, &result); err != nil {
+			// A capped result set is not a failure here, it is the answer.
+			//
+			// This query is DESC, so the rows the resolver kept before it stopped
+			// are the newest ones — exactly what a "recent" view is asking for.
+			// Widening the window would only reach further past a cap already hit.
+			//
+			// Mirror of the sync path: transactionsFromHeight walks ASC from a
+			// cursor, where truncation hides older rows and must be paged through.
+			// Here the walk is DESC from the tip, so truncation hides only rows the
+			// caller did not want.
+			if errors.Is(err, errQueryTooLarge) && len(result.GetTransactions) >= need {
+				return result.GetTransactions, nil
+			}
 			return nil, err
 		}
 

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -458,3 +458,106 @@ func TestSyncFetchersKeepTheirFilterAndOrder(t *testing.T) {
 		})
 	}
 }
+
+// sparseTxIndexer models a chain whose transactions are all old: nothing has
+// happened for the last `tip - lastTxHeight` blocks. gno.land looks like this —
+// it returns no rows at all for its most recent 20,000 blocks — so the widening
+// loop has to walk back before it finds anything.
+type sparseTxIndexer struct {
+	tip          int
+	lastTxHeight int
+
+	mu      sync.Mutex
+	windows []int // `from` bound of each transaction query, in order
+}
+
+func (f *sparseTxIndexer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	query := string(body)
+	w.Header().Set("Content-Type", "application/json")
+
+	if strings.Contains(query, "latestBlockHeight") {
+		fmt.Fprintf(w, `{"data":{"latestBlockHeight":%d}}`, f.tip)
+		return
+	}
+
+	from := 0
+	if gt := strings.Index(query, "gt:"); gt >= 0 {
+		fmt.Sscanf(strings.TrimSpace(query[gt+3:]), "%d", &from)
+	}
+
+	f.mu.Lock()
+	f.windows = append(f.windows, from)
+	f.mu.Unlock()
+
+	var rows []string
+	for h := f.lastTxHeight; h > from; h-- {
+		rows = append(rows, fmt.Sprintf(`{"hash":"tx-%d","block_height":%d}`, h, h))
+	}
+	fmt.Fprintf(w, `{"data":{"getTransactions":[%s]}}`, strings.Join(rows, ","))
+}
+
+func TestRecentPageWidensUntilItFindsRows(t *testing.T) {
+	// The initial window is deliberately small, so a chain with no recent
+	// activity must widen several times rather than give up and report nothing.
+	fake := &sparseTxIndexer{tip: 100000, lastTxHeight: 500}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	txs, err := NewIndexerClient(srv.URL).GetRecentTransactionsPage(context.Background(), 20)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(txs) < 20 {
+		t.Fatalf("got %d transactions, want at least the 20 asked for", len(txs))
+	}
+	if txs[0].BlockHeight != fake.lastTxHeight {
+		t.Errorf("newest row is height %d, want %d", txs[0].BlockHeight, fake.lastTxHeight)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.windows) < 2 {
+		t.Fatalf("only %d query issued, so the window never widened", len(fake.windows))
+	}
+	// Each widening must reach strictly further back than the last.
+	for i := 1; i < len(fake.windows); i++ {
+		if fake.windows[i] >= fake.windows[i-1] {
+			t.Errorf("window %d starts at %d, no further back than %d", i, fake.windows[i], fake.windows[i-1])
+		}
+	}
+}
+
+func TestRecentPageServesACappedWindow(t *testing.T) {
+	// A dense chain overflows the element cap inside the very first window. The
+	// query is DESC, so the rows the resolver kept are the newest ones — exactly
+	// what a "recent" view wants. Returning them beats failing the request, which
+	// is what used to happen and what took /api/txs down on sapphire.
+	fake := &truncatingTxIndexer{tip: 20000, txsPerBlock: 200}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	txs, err := NewIndexerClient(srv.URL).GetRecentTransactionsPage(context.Background(), 20)
+	if err != nil {
+		t.Fatalf("capped window should serve rows, not fail: %v", err)
+	}
+	if len(txs) != indexerElementCap {
+		t.Fatalf("got %d rows, want the full capped page of %d", len(txs), indexerElementCap)
+	}
+	if txs[0].BlockHeight != fake.tip {
+		t.Errorf("newest row is height %d, want the tip at %d", txs[0].BlockHeight, fake.tip)
+	}
+}
+
+func TestRecentPageStillFailsWhenCappedPageIsTooSmall(t *testing.T) {
+	// The cap only answers the question when it holds at least what was asked
+	// for. Beyond that the page is genuinely short and must not pass as complete.
+	fake := &truncatingTxIndexer{tip: 20000, txsPerBlock: 200}
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	_, err := NewIndexerClient(srv.URL).GetRecentTransactionsPage(context.Background(), indexerElementCap+1)
+	if !errors.Is(err, errQueryTooLarge) {
+		t.Fatalf("got %v, want errQueryTooLarge", err)
+	}
+}


### PR DESCRIPTION
Fixes the live breakage on `https://mygnoscan.moul.p2p.team/?network=sapphire`, which renders as an empty skeleton with every counter stuck on `-`. Closes #72.

## What the page actually does

No console errors, so nothing looks wrong from the outside. One request fails:

```
GET /api/networks                      → 200
GET /api/stats?network=sapphire        → 200
GET /api/realms?limit=10&…             → 200
GET /api/txs?limit=20&network=sapphire → 500   ← 10.1s
GET /api/blocks?limit=50&…             → 200
```

```json
{"error":"context deadline exceeded (Client.Timeout or context cancellation while reading body)"}
```

Reproduces on val1 against `localhost:8888`, so Caddy is not involved. Present on the deployed build (`7d27259`) and **still present after #65** — that PR only changed the error text, from `graphql error: max elements…` to `indexer result set hit the element cap`. Deploying it would not have fixed this.

## Two causes, both here

### 1. A capped window was treated as a failure

`recentTransactionsWindowed` propagated any query error, including the element cap. But this query is `DESC`, so the rows the resolver keeps before stopping are the **newest** ones — precisely what a "recent" view is asking for. The cap was answering the question and the answer was being thrown away.

This is the mirror image of the sync path. `transactionsFromHeight` walks `ASC` from a cursor, where truncation hides *older* rows and must be paged through — the argument in #65. Here the walk is `DESC` from the tip, so truncation hides only rows the caller never wanted. Same mechanism, opposite conclusion, which is why it needed doing deliberately rather than by copying.

Now a capped page is returned when it holds at least `need` rows, and still fails when it does not.

### 2. The initial window was far too wide

`initialTxWindow` was 20,000 blocks. Measured against sapphire with the real `txFieldsLight` field set — which is not light, it carries every `MsgCall`'s `args`:

| window | rows | payload | time |
| ---: | ---: | ---: | ---: |
| 20,000 | 10,000 (capped) | **45.8 MB** | 9.6 s |
| 2,000 | 3,802 | 20.7 MB | 3.7 s |
| 100 | 2,047 | 11.5 MB | 2.5 s |

**45 MB downloaded to serve a 20-row page**, against a 10-second client timeout. That is the timeout, and it is why the failure is a body-read deadline rather than a clean cap error.

The two errors are not symmetric. Overshooting costs a payload that scales with chain density and is unbounded in practice; undershooting costs one more round trip against a chain sparse enough that round trips are cheap. And a wide starting window buys nothing on sparse chains anyway — gno.land returns **zero rows** for its most recent 20,000 blocks (all 2,771 of its transactions are old), so it widens regardless.

So: start at 100 and let the existing 8x growth do the work.

## Result

Both endpoints measured end-to-end against the live indexers, fresh DB, `-sync=false`:

| request | before | after |
| --- | --- | --- |
| sapphire `limit=20` | **500** @ 10.0s | 200 @ **1.0s** |
| sapphire `limit=50&offset=20` | **500** @ 10.1s | 200 @ 1.2s |
| sapphire `limit=100` | **500** | 200 @ 1.4s |
| gno.land `limit=20` | 200 | 200 @ 0.55s |
| gno.land `limit=100` | 200 | 200 @ 0.70s |

No regression on the sparse chain, and the dense one goes from broken to a second.

## Tests

- `TestRecentPageServesACappedWindow` — a chain dense enough to overflow the cap in the first window serves the page instead of erroring, newest row first
- `TestRecentPageStillFailsWhenCappedPageIsTooSmall` — the cap is not allowed to pass a short page off as complete
- `TestRecentPageWidensUntilItFindsRows` — a new `sparseTxIndexer` models the gno.land shape (all transactions old); asserts the window widens and each step reaches strictly further back

`gofmt`/`go vet`/`go test ./...` clean.

## Not fixed here

Deep pagination past 10,000 rows still fails, because `total` is `len(txs)` and the cap bounds it — that is #46, server-side pagination, and the real answer is serving these views from local storage rather than re-fetching from the indexer per request. #73 (a cold sync of sapphire cannot get past `syncPackages`) is also still open and unrelated.