### PR TITLE
fix: reject API requests for unconfigured networks

### DIFF
--- a/api.go
+++ b/api.go
@@ -262,6 +262,33 @@ func (a *API) networkParam(r *http.Request) string {
 	return n
 }
 
+// rejectUnknownNetwork turns `?network=` naming an unconfigured network into a
+// 404, for API routes only.
+//
+// Left alone, an unconfigured network is not an error anywhere: handlers pass
+// the string straight through to the database, which still holds rows for every
+// network ever synced, and clientFor falls back to an arbitrary client for the
+// parts that need a live chain. A retired testnet therefore keeps answering with
+// stale local rows stamped with an unrelated chain's height — worse than a 404,
+// because it looks like data.
+//
+// Non-API routes are left alone so the SPA still loads on a stale bookmark and
+// can say so itself, rather than the browser being handed a JSON error.
+func rejectUnknownNetwork(networks []NetworkConfig, next http.Handler) http.Handler {
+	known := make(map[string]bool, len(networks))
+	for _, n := range networks {
+		known[n.ID] = true
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := r.URL.Query().Get("network")
+		if strings.HasPrefix(r.URL.Path, "/api/") && n != "" && n != "all" && !known[n] {
+			jsonError(w, "network not found", 404)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // clientFor returns the IndexerClient for a specific network, or the first available one if not found.
 func (a *API) clientFor(network string) *IndexerClient {
 	if network != "" {

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// rejectUnknownNetwork guards every API route at once, so it is tested against a
+// stand-in handler rather than the real mux: what matters is which requests
+// reach the other side, not what they would have returned.
+func TestRejectUnknownNetwork(t *testing.T) {
+	configured := []NetworkConfig{{ID: "gnoland1"}, {ID: "sapphire"}}
+
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+		wantPassed bool
+	}{
+		{
+			name:       "configured network passes",
+			path:       "/api/stats?network=sapphire",
+			wantStatus: 200,
+			wantPassed: true,
+		},
+		{
+			name:       "no network means all networks",
+			path:       "/api/stats",
+			wantStatus: 200,
+			wantPassed: true,
+		},
+		{
+			name:       "explicit all passes",
+			path:       "/api/stats?network=all",
+			wantStatus: 200,
+			wantPassed: true,
+		},
+		{
+			name: "retired network is rejected",
+			// topaz was removed from the config once its testnet went away. The
+			// database still holds its rows, so without this the endpoint answers
+			// 200 with stale data and an unrelated chain's block height.
+			path:       "/api/stats?network=topaz",
+			wantStatus: 404,
+			wantPassed: false,
+		},
+		{
+			name:       "never-configured network is rejected",
+			path:       "/api/txs?network=does-not-exist",
+			wantStatus: 404,
+			wantPassed: false,
+		},
+		{
+			name: "SPA is not guarded",
+			// A stale bookmark must still load the app, which can report the
+			// unknown network itself. Handing a browser a JSON 404 would not.
+			path:       "/?network=topaz",
+			wantStatus: 200,
+			wantPassed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			passed := false
+			h := rejectUnknownNetwork(configured, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				passed = true
+				w.WriteHeader(200)
+			}))
+
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest("GET", tt.path, nil))
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if passed != tt.wantPassed {
+				t.Errorf("reached the handler = %v, want %v", passed, tt.wantPassed)
+			}
+			if !tt.wantPassed {
+				var body struct {
+					Error string `json:"error"`
+				}
+				if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+					t.Fatalf("rejection body is not JSON: %v", err)
+				}
+				if body.Error == "" {
+					t.Error("rejection body carries no error message")
+				}
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -175,7 +175,7 @@ func run() error {
 
 	srv := &http.Server{
 		Addr:         *listenAddr,
-		Handler:      mux,
+		Handler:      rejectUnknownNetwork(cfg.Networks, mux),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}


### PR DESCRIPTION
Found while retiring topaz from the production config — its testnet is gone (`indexer.topaz.testnets.gno.land` and `rpc.topaz.testnets.gno.land` are both NXDOMAIN).

Removing a network from the config does not remove it from the API. The database still holds every row ever synced for it, so:

```
$ curl "…/api/stats?network=topaz"
{"total_txs":4101,"total_calls":2945,…,"latest_block":567812}   ← HTTP 200
```

topaz is no longer configured. It answers anyway.

Two separate mechanisms conspire:

- **Handlers pass the string straight to the database.** `networkParam` returns whatever came in on the query string; `GetStats` interpolates it into a `WHERE network = …`. Rows for a retired network are still rows.
- **`clientFor` falls back to an arbitrary client.** For an unknown network it returns the first entry of a Go map — iteration order, so effectively random. `HandleStats` then overwrites `latest_block` with *that* chain's height.

So a retired testnet keeps serving stale local rows stamped with an unrelated chain's block height. That is worse than an error, because it looks like data and nothing in the response says otherwise.

## Fix

One middleware wrapping the mux, rather than 29 edits at the `a.networkParam(r)` call sites — it also covers endpoints nobody has written yet:

```go
Handler: rejectUnknownNetwork(cfg.Networks, mux),
```

`?network=` naming something not in the config gets a 404. Empty and `all` still mean "every network".

**API routes only.** The SPA is deliberately left unguarded: someone with a `?network=topaz` bookmark should still get the app, which can report the unknown network itself, rather than a browser being handed a JSON 404.

## Tests

This is the repo's first HTTP-level test, so it brings `api_test.go` with it. The middleware is exercised against a stand-in handler that records whether it was reached — what matters is which requests get through, not what they would have returned. Six cases: configured passes, absent passes, `all` passes, retired rejected, never-configured rejected, SPA not guarded. Rejections are also checked for a JSON body with a non-empty `error`.

`gofmt`/`go vet`/`go test ./...` clean.

## Not fixed here: the aggregates

`?network=all` still counts rows from unconfigured networks, and this is measurable on production right now:

| | txs | realms |
| --- | ---: | ---: |
| unfiltered (`/api/stats`) | 659,092 | 436 |
| sum of the three configured networks | 654,991 | 249 |
| **difference** | **4,101** | **187** |

Exactly topaz. Every all-networks total on the site is inflated by a chain that no longer exists.

`GetStats` and its neighbours branch on `network != ""` and simply drop the `WHERE` clause for the unfiltered case, so they count everything in the table. Fixing it properly means either threading the configured list into the ~20 DB methods that have that branch, or purging rows for unconfigured networks. The second is data deletion and should not be a side effect of a config edit — a typo in the config file would be unrecoverable.

Filing separately rather than bolting a half-sweep onto this PR.