### PR TITLE
fix: give the sync loop its own request budget

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -67,19 +67,43 @@ func (c *IndexerClient) recordResult(err error) {
 	}
 }
 
+// Request budgets. Serving a page and running a background sync have nothing in
+// common: one has a browser waiting on it, the other is catching up on history
+// and is measured against the size of the chain.
+//
+// Sharing one budget meant the sync inherited the page's. A cold sync of
+// sapphire asks for every MsgAddPackage with full file bodies — 32s and 12MB for
+// 368 rows — which cannot fit in ten seconds, so SyncAll failed on its first
+// step and retried the identical request every 30s forever.
+const (
+	serveClientTimeout = 10 * time.Second
+	syncClientTimeout  = 2 * time.Minute
+)
+
+// NewIndexerClient returns a client for request paths that have a caller
+// waiting. Callers add their own tighter deadlines on top of this backstop.
 func NewIndexerClient(url string) *IndexerClient {
+	return newIndexerClient(url, serveClientTimeout)
+}
+
+// NewSyncIndexerClient returns a client for the background sync loop.
+//
+// Deliberately a separate client, not just a longer timeout: the breaker is
+// per-client, so a sync struggling against a slow indexer no longer opens the
+// breaker that page queries share, and vice versa.
+func NewSyncIndexerClient(url string) *IndexerClient {
+	return newIndexerClient(url, syncClientTimeout)
+}
+
+func newIndexerClient(url string, timeout time.Duration) *IndexerClient {
 	// Normalize URL: ensure it ends with /query
 	url = strings.TrimRight(url, "/")
 	if strings.HasSuffix(url, "/graphql") {
 		url += "/query"
 	}
 	return &IndexerClient{
-		url: url,
-		client: &http.Client{
-			// A page cannot wait 30s on one indexer; callers add their own
-			// tighter deadlines on top of this backstop.
-			Timeout: 10 * time.Second,
-		},
+		url:    url,
+		client: &http.Client{Timeout: timeout},
 	}
 }
 
@@ -139,6 +163,14 @@ func (c *IndexerClient) doQuery(ctx context.Context, query string, vars map[stri
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
+	}
+
+	// Report a refused request as what it is. A rate-limited indexer answers with
+	// an HTML error page, which otherwise surfaces as "invalid character '<'" and
+	// sends the reader looking for a bug in the query rather than at the status
+	// code. Sync catch-up is exactly the traffic that earns a 403.
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("indexer returned %s: %s", resp.Status, string(respBody[:min(200, len(respBody))]))
 	}
 
 	var gqlResp gqlResponse

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -561,3 +561,47 @@ func TestRecentPageStillFailsWhenCappedPageIsTooSmall(t *testing.T) {
 		t.Fatalf("got %v, want errQueryTooLarge", err)
 	}
 }
+
+func TestClientTimeoutsAreSeparate(t *testing.T) {
+	// A page has a browser waiting on it; a sync is catching up on history and is
+	// measured against the size of the chain. Sharing one budget is what made a
+	// cold sync of sapphire impossible.
+	serve := NewIndexerClient("http://example.invalid/graphql")
+	sync := NewSyncIndexerClient("http://example.invalid/graphql")
+
+	if serve.client.Timeout != serveClientTimeout {
+		t.Errorf("serve timeout = %v, want %v", serve.client.Timeout, serveClientTimeout)
+	}
+	if sync.client.Timeout != syncClientTimeout {
+		t.Errorf("sync timeout = %v, want %v", sync.client.Timeout, syncClientTimeout)
+	}
+	if sync.client.Timeout <= serve.client.Timeout {
+		t.Errorf("sync budget %v does not exceed the serve budget %v", sync.client.Timeout, serve.client.Timeout)
+	}
+	// URL normalisation must survive the split.
+	if serve.url != sync.url || serve.url != "http://example.invalid/graphql/query" {
+		t.Errorf("urls diverged: serve=%q sync=%q", serve.url, sync.url)
+	}
+}
+
+func TestRefusedRequestNamesTheStatus(t *testing.T) {
+	// A rate-limited indexer answers with an HTML error page. Decoding it as
+	// GraphQL reports "invalid character '<'", which points at the query instead
+	// of at the status code — this cost real debugging time against sapphire.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, "<html>\n<head><title>403 Forbidden</title></head>\n</html>")
+	}))
+	defer srv.Close()
+
+	_, err := NewIndexerClient(srv.URL).LatestBlockHeight(context.Background())
+	if err == nil {
+		t.Fatal("a 403 should be an error")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error does not name the status: %v", err)
+	}
+	if strings.Contains(err.Error(), "invalid character") {
+		t.Errorf("error still reads as a decode failure: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -53,10 +53,13 @@ func run() error {
 	}
 	log.Printf("networks %v (from %s)", cfg.IDs(), cfgSource)
 
-	// Create per-network clients
+	// Create per-network clients. The sync loop gets its own, on a budget sized
+	// for catching up on history rather than for answering a page.
 	clients := make(map[string]*IndexerClient)
+	syncClients := make(map[string]*IndexerClient)
 	for _, n := range cfg.Networks {
 		clients[n.ID] = NewIndexerClient(n.IndexerURL)
+		syncClients[n.ID] = NewSyncIndexerClient(n.IndexerURL)
 	}
 
 	// Initialize analyzer
@@ -69,7 +72,7 @@ func run() error {
 	if *syncOnStart {
 		for _, n := range cfg.Networks {
 			go func(net NetworkConfig) {
-				syncer := NewSyncer(clients[net.ID], db, analyzer, net.ID)
+				syncer := NewSyncer(syncClients[net.ID], db, analyzer, net.ID)
 				log.Printf("[%s] starting initial sync...", net.ID)
 				if err := syncer.SyncAll(ctx); err != nil {
 					log.Printf("[%s] sync error: %v", net.ID, err)


### PR DESCRIPTION
Fixes #73. A cold sync of sapphire could never get past its first step.

## The problem

`SyncAll` runs `syncPackages` first, which asks for every `MsgAddPackage` with full file bodies. On sapphire that is **32 seconds and 12 MB for 368 rows**. The client allowed ten:

```go
client: &http.Client{
    // A page cannot wait 30s on one indexer; callers add their own
    // tighter deadlines on top of this backstop.
    Timeout: 10 * time.Second,
},
```

`SyncAll` returns on that error, so `syncCalls` and `syncMsgRuns` never ran, and the identical request went out again 30 seconds later, forever. Same permanent-loop shape as #64 — a cursor derived from stored rows, nothing stored because the request failed.

That comment is reasoning about **page requests**, where a browser is waiting. Sync is a background job catching up on history; its budget should be measured against the size of the chain. They were sharing one number that cannot suit both.

## The fix

Two clients per network instead of one. `NewIndexerClient` keeps the 10s serve budget; `NewSyncIndexerClient` gets two minutes, and the sync loop uses it.

Deliberately a separate client rather than just a longer timeout: the circuit breaker is per-client, so a sync struggling against a slow indexer no longer opens the breaker that page queries share, and a flapping page query no longer stalls the sync.

## Verified against sapphire

Cold sync, empty database, live indexer:

```
[sapphire] starting initial sync...
[sapphire] synced 377 packages          ← 43s. Previously: timeout, every pass, forever.
[sapphire] synced 20051 calls, 2363 sends
```

The step that could never complete now completes, and the #65 paging walk runs behind it — 20,051 calls across several 10,000-row pages, with progress persisted so each 30-second pass resumes from the new cursor rather than restarting.

## Also here: name a refused request

The run above eventually stopped with `indexer unavailable, not retried yet`. The breaker was right — the indexer had started returning **403 Forbidden**, having rate-limited me for hammering it with back-to-back 45 MB queries during testing. Production was unaffected throughout (different IP, still syncing, page healthy).

Finding that took longer than it should have, because a 403 arrives as an HTML error page and `doQuery` went straight to JSON-decoding it:

```
decode response: invalid character '<' looking for beginning of value
```

which points at the query rather than at the status code. `doQuery` now checks the status first and says `indexer returned 403 Forbidden: <html>…`.

Worth flagging for #73's remaining half: **sync catch-up is exactly the traffic that earns a rate limit.** A full cold sync of sapphire is roughly 65 consecutive 10,000-row pages at ~45 MB each. It converges — ~20k transactions per pass, so ~30 passes — but a public indexer may well push back before it finishes. Reducing the payload (not fetching package file bodies during sync, which is the 12 MB, and trimming `txFieldsLight` which is not light) matters for more than latency. Left out of scope here; this PR is the part that unblocks the walk.

## Tests

- `TestClientTimeoutsAreSeparate` — the two constructors produce different budgets, sync exceeds serve, and URL normalisation survives the split
- `TestRefusedRequestNamesTheStatus` — a 403 serving HTML reports the status, not a decode failure

`gofmt`/`go vet`/`go test ./...` clean.
