### PR TITLE
fix: bound the realm-scoped indexer filters by block height

### DIFF
--- a/api.go
+++ b/api.go
@@ -683,6 +683,20 @@ const (
 	maxEventTxs     = 2000
 )
 
+// eventTxLimit reads the caller's `limit`, falling back to a default and capped
+// at a maximum. Every event view goes through it so none of them can ask the
+// indexer for a chain's entire history.
+func eventTxLimit(r *http.Request) int {
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	if limit <= 0 {
+		limit = defaultEventTxs
+	}
+	if limit > maxEventTxs {
+		limit = maxEventTxs
+	}
+	return limit
+}
+
 func (a *API) HandleAllEvents(w http.ResponseWriter, r *http.Request) {
 	network := a.networkParam(r)
 	client := a.clientFor(network)
@@ -692,13 +706,7 @@ func (a *API) HandleAllEvents(w http.ResponseWriter, r *http.Request) {
 	}
 	// Recent transactions that have GnoEvents. Bounded by default: unbounded,
 	// this returns every event-emitting transaction the chain ever had.
-	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
-	if limit == 0 {
-		limit = defaultEventTxs
-	}
-	if limit > maxEventTxs {
-		limit = maxEventTxs
-	}
+	limit := eventTxLimit(r)
 	txs, err := client.GetRecentTransactionsWithEvents(r.Context(), limit)
 	if err != nil {
 		jsonError(w, err.Error(), 500)
@@ -745,7 +753,9 @@ func (a *API) HandleEvents(w http.ResponseWriter, r *http.Request) {
 	}
 	path := "gno.land/" + r.PathValue("path")
 	path = strings.TrimRight(path, "/")
-	txs, err := client.GetEventsByPkgPath(r.Context(), path)
+	// Bounded like /api/allevents, and for the same reason: unbounded, this
+	// filter scans the chain's whole history and takes ~34s on a busy one.
+	txs, err := client.GetEventsByPkgPath(r.Context(), path, eventTxLimit(r))
 	if err != nil {
 		jsonError(w, err.Error(), 500)
 		return
@@ -913,7 +923,7 @@ func (a *API) HandleGovDAO(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "no client available", 500)
 		return
 	}
-	txs, err := client.GetGovDAOTransactions(r.Context())
+	txs, err := client.GetGovDAOTransactions(r.Context(), eventTxLimit(r))
 	if err != nil {
 		jsonError(w, err.Error(), 500)
 		return

--- a/indexer.go
+++ b/indexer.go
@@ -831,19 +831,6 @@ func (c *IndexerClient) GetBlock(ctx context.Context, height int) (*Block, error
 }
 
 // GetTransactionsByRealm fetches calls to a specific realm function.
-func (c *IndexerClient) GetTransactionsByRealmFunc(ctx context.Context, pkgPath, funcName string) ([]Transaction, error) {
-	var result struct {
-		GetTransactions []Transaction `json:"getTransactions"`
-	}
-	q := fmt.Sprintf(`{
-		getTransactions(
-			where: { messages: { value: { MsgCall: { pkg_path: { eq: "%s" }, func: { eq: "%s" } } } } }
-			order: { heightAndIndex: DESC }
-		) { %s }
-	}`, gqlEscape(pkgPath), gqlEscape(funcName), txFieldsLight)
-	err := c.query(ctx, q, nil, &result)
-	return result.GetTransactions, err
-}
 
 // GetTransactionsByBlock fetches transactions in a specific block.
 func (c *IndexerClient) GetTransactionsByBlock(ctx context.Context, height int) ([]Transaction, error) {
@@ -936,31 +923,39 @@ func (c *IndexerClient) GetRecentTransactionsWithEvents(ctx context.Context, nee
 }
 
 // GetEventsByPkgPath fetches transactions that emitted GnoEvents for a package.
-func (c *IndexerClient) GetEventsByPkgPath(ctx context.Context, pkgPath string) ([]Transaction, error) {
-	var result struct {
-		GetTransactions []Transaction `json:"getTransactions"`
-	}
-	q := fmt.Sprintf(`{
+func (c *IndexerClient) GetEventsByPkgPath(ctx context.Context, pkgPath string, need int) ([]Transaction, error) {
+	where := fmt.Sprintf(`response: { events: { GnoEvent: { pkg_path: { eq: "%s" } } } }`, gqlEscape(pkgPath))
+	return c.recentTransactionsWindowed(ctx, need, where, func() ([]Transaction, error) {
+		var result struct {
+			GetTransactions []Transaction `json:"getTransactions"`
+		}
+		q := fmt.Sprintf(`{
 		getTransactions(
-			where: { response: { events: { GnoEvent: { pkg_path: { eq: "%s" } } } } }
+			where: { %s }
 			order: { heightAndIndex: DESC }
 		) { %s }
-	}`, gqlEscape(pkgPath), txFieldsLight)
-	err := c.query(ctx, q, nil, &result)
-	return result.GetTransactions, err
+	}`, where, txFieldsLight)
+		err := c.query(ctx, q, nil, &result)
+		return result.GetTransactions, err
+	})
 }
 
 // GetGovDAOTransactions fetches transactions involving govdao realms.
-func (c *IndexerClient) GetGovDAOTransactions(ctx context.Context) ([]Transaction, error) {
-	var result struct {
-		GetTransactions []Transaction `json:"getTransactions"`
-	}
-	q := fmt.Sprintf(`{
+func (c *IndexerClient) GetGovDAOTransactions(ctx context.Context, need int) ([]Transaction, error) {
+	// A leading-wildcard LIKE cannot use an index, so this one is the most
+	// expensive of the realm filters to leave unbounded.
+	const where = `messages: { value: { MsgCall: { pkg_path: { like: "%govdao%"} } } }`
+	return c.recentTransactionsWindowed(ctx, need, where, func() ([]Transaction, error) {
+		var result struct {
+			GetTransactions []Transaction `json:"getTransactions"`
+		}
+		q := fmt.Sprintf(`{
 		getTransactions(
-			where: { messages: { value: { MsgCall: { pkg_path: { like: "%%govdao%%"} } } } }
+			where: { %s }
 			order: { heightAndIndex: DESC }
 		) { %s }
-	}`, txFieldsLight)
-	err := c.query(ctx, q, nil, &result)
-	return result.GetTransactions, err
+	}`, where, txFieldsLight)
+		err := c.query(ctx, q, nil, &result)
+		return result.GetTransactions, err
+	})
 }

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -605,3 +605,99 @@ func TestRefusedRequestNamesTheStatus(t *testing.T) {
 		t.Errorf("error still reads as a decode failure: %v", err)
 	}
 }
+
+// recordingIndexer captures every transaction query it is sent and answers with
+// `rows` transactions at the tip, so a caller asking for fewer stops after one
+// window.
+type recordingIndexer struct {
+	tip  int
+	rows int
+
+	mu      sync.Mutex
+	queries []string
+}
+
+func (f *recordingIndexer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	// Decode rather than matching the raw body: the query travels JSON-encoded,
+	// so every quote in a filter arrives escaped.
+	var req gqlRequest
+	json.Unmarshal(body, &req)
+	query := req.Query
+	w.Header().Set("Content-Type", "application/json")
+
+	if strings.Contains(query, "latestBlockHeight") {
+		fmt.Fprintf(w, `{"data":{"latestBlockHeight":%d}}`, f.tip)
+		return
+	}
+
+	f.mu.Lock()
+	f.queries = append(f.queries, query)
+	f.mu.Unlock()
+
+	rows := make([]string, 0, f.rows)
+	for i := 0; i < f.rows; i++ {
+		rows = append(rows, fmt.Sprintf(`{"hash":"tx-%d","block_height":%d}`, i, f.tip-i))
+	}
+	fmt.Fprintf(w, `{"data":{"getTransactions":[%s]}}`, strings.Join(rows, ","))
+}
+
+// The realm-scoped filters used to run against all of history. On a busy chain
+// that costs ~34s regardless of how much comes back, because the price is the
+// scan rather than the payload — enough to blow the serve timeout and take the
+// realm events and govdao views down. Both must now bound height, and must keep
+// their filter while doing it.
+func TestRealmFiltersAreBounded(t *testing.T) {
+	tests := []struct {
+		name       string
+		call       func(*IndexerClient) error
+		wantFilter string
+	}{
+		{
+			name: "events by pkg_path",
+			call: func(c *IndexerClient) error {
+				_, err := c.GetEventsByPkgPath(context.Background(), "gno.land/r/demo/boards", 20)
+				return err
+			},
+			wantFilter: `pkg_path: { eq: "gno.land/r/demo/boards" }`,
+		},
+		{
+			name: "govdao",
+			call: func(c *IndexerClient) error {
+				_, err := c.GetGovDAOTransactions(context.Background(), 20)
+				return err
+			},
+			wantFilter: `like: "%govdao%"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &recordingIndexer{tip: 500000, rows: 50}
+			srv := httptest.NewServer(fake)
+			defer srv.Close()
+
+			if err := tt.call(NewIndexerClient(srv.URL)); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			fake.mu.Lock()
+			defer fake.mu.Unlock()
+			if len(fake.queries) == 0 {
+				t.Fatal("no transaction query was issued")
+			}
+			for i, q := range fake.queries {
+				if !strings.Contains(q, "block_height") {
+					t.Errorf("query %d has no height bound: %s", i, q)
+				}
+				if !strings.Contains(q, tt.wantFilter) {
+					t.Errorf("query %d lost its filter %q: %s", i, tt.wantFilter, q)
+				}
+			}
+			// 50 rows on offer against a need of 20: one window is enough.
+			if len(fake.queries) != 1 {
+				t.Errorf("issued %d queries, want 1 — the window widened despite having enough rows", len(fake.queries))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Partially addresses #78. Fixes the realm events view and govdao on busy chains; **does not fully close the issue** — see the limitation below, which is measured rather than assumed.

## Background

The audit in #78 found five unbounded full-history queries. On sapphire each costs ~30-35s *regardless of what it returns*, because the price is the scan, not the payload. Four production endpoints were failing at the 10s serve timeout.

The decisive measurement: a height bound does work. Same `pkg_path` filter on sapphire, varying only the window:

| window | time |
| ---: | ---: |
| none | 33.8s |
| 200,000 blocks | 23.2s |
| 20,000 | 2.5s |
| 2,000 | 0.48s |
| 100 | **0.27s** |

The indexer uses the height index; cost scales with the width of the window. So these filters can go through the same widening-window machinery `/api/txs` and `/api/allevents` already use.

## Changes

- `GetEventsByPkgPath` and `GetGovDAOTransactions` now route through `recentTransactionsWindowed`, carrying their filter as `extraWhere`. Both already used `txFieldsLight`, so this is a drop-in.
- `HandleEvents` and `HandleGovDAO` pass a bound. Extracted `eventTxLimit` so all three event views share one default-and-cap (200, max 2000) instead of `HandleAllEvents` having the only one.
- **Removed `GetTransactionsByRealmFunc`** — unbounded, and the audit found it has no callers.

## Measured

Fresh build against the live indexers:

| request | before | after |
| --- | --- | --- |
| sapphire `events/p/demo/tokens/grc20` | **500** @ 10.1s | 200 @ 1.4s |
| gnoland1 `events/r/gov/dao` | 200 | 200 @ 0.30s |
| gnoland1 `govdao` | 200 | 200 @ 1.05s |
| gnoland1 `allevents` | 200 | 200 @ 1.39s |
| gnoland1 `txs?limit=20` | 200 | 200 @ 0.99s |

An active realm on the dense chain goes from broken to under a second and a half. No regression on the sparse chain.

## The limitation, stated plainly

**A realm with no matching rows on a dense chain is still broken.**

`recentTransactionsWindowed` widens until it has `need` rows *or reaches genesis*. When nothing matches, it reaches genesis — which is the full scan again, plus every intermediate window on the way:

```
sapphire events/r/gov/dao   500 @ 17.8s   (was 500 @ 10.1s)
```

gov/dao has zero transactions on sapphire, so that view stays down and now fails a little slower. I considered capping the maximum window, but that trades a visible failure for a silent one: a realm whose only activity is old would render as empty rather than erroring, and the caller has no way to tell the difference. A wrong answer is worse than an error here.

The real fix remains what #78 concluded — serve these from local storage, where `calls` already has `pkg_path` indexed. This PR is the part that can ship now without a schema change, and it converts the common case (looking at a realm that is actually being used) from broken to fast.

Still open from #78, untouched here:

- **`/api/validators`** — needs `args` stored locally for the moniker map, which is the schema decision.
- **`/api/txs` without `limit`** — still falls through to `GetRecentTransactions(ctx, 0)` and `where: {}`.

## Tests

`TestRealmFiltersAreBounded` — table-driven over both methods, with a `recordingIndexer` that captures and decodes every query sent. Asserts each carries a `block_height` bound, keeps its own filter intact through the merge into the where clause, and stops after a single window when the first one already holds enough rows.

`gofmt`/`go vet`/`go test ./...` clean.
