### PR TITLE
fix: scope all-networks aggregates to the configured networks

### DIFF
--- a/db.go
+++ b/db.go
@@ -13,6 +13,50 @@ import (
 type DB struct {
 	db *sql.DB
 	mu sync.RWMutex
+
+	// configured is the set of networks the process is running, set once at
+	// startup. Rows survive a network being retired from the config, so without
+	// this the database — not the config — decides which networks exist.
+	configured []string
+}
+
+// SetConfiguredNetworks scopes unfiltered reads to the networks currently in the
+// config. Call once at startup, before serving.
+func (d *DB) SetConfiguredNetworks(networks []NetworkConfig) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.configured = d.configured[:0]
+	for _, n := range networks {
+		d.configured = append(d.configured, n.ID)
+	}
+}
+
+// networkFilter builds a SQL condition restricting rows to one network, or to
+// the configured set when network is empty.
+//
+// Returns a bare condition, so callers supply their own WHERE or AND. When
+// nothing is configured it yields `1=1`, which keeps every call site a plain
+// concatenation rather than a branch.
+//
+// The identifiers are interpolated rather than bound. These fragments are
+// spliced into CTEs at several points, where positional parameters would have to
+// be threaded through in query order, and both sources are trusted: a named
+// network has already been checked against the config by rejectUnknownNetwork,
+// and the fallback list is the config file itself, never a request. The quote
+// doubling is belt and braces.
+func (d *DB) networkFilter(column, network string) string {
+	quote := func(s string) string { return "'" + strings.ReplaceAll(s, "'", "''") + "'" }
+	if network != "" {
+		return column + " = " + quote(network)
+	}
+	if len(d.configured) == 0 {
+		return "1=1"
+	}
+	quoted := make([]string, 0, len(d.configured))
+	for _, n := range d.configured {
+		quoted = append(quoted, quote(n))
+	}
+	return column + " IN (" + strings.Join(quoted, ",") + ")"
 }
 
 func NewDB(path string) (*DB, error) {
@@ -1192,28 +1236,18 @@ func (d *DB) GetStats(network string) (*Stats, error) {
 	defer d.mu.RUnlock()
 
 	var s Stats
-	nf := ""
-	if network != "" {
-		nf = " WHERE network = '" + strings.ReplaceAll(network, "'", "''") + "'"
-	}
+	// One filter for every count, so a retired network cannot inflate some
+	// totals and not others.
+	nf := " WHERE " + d.networkFilter("network", network)
 	d.db.QueryRow(`SELECT COUNT(*) FROM calls` + nf).Scan(&s.TotalCalls)
 	d.db.QueryRow(`SELECT COUNT(*) FROM packages` + nf).Scan(&s.TotalDeploys)
-	if network != "" {
-		d.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE is_realm = 1 AND network = ?`, network).Scan(&s.TotalRealms)
-	} else {
-		d.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE is_realm = 1`).Scan(&s.TotalRealms)
-	}
+	d.db.QueryRow(`SELECT COUNT(*) FROM packages` + nf + ` AND is_realm = 1`).Scan(&s.TotalRealms)
 	s.TotalPackages = s.TotalDeploys - s.TotalRealms
 	d.db.QueryRow(`SELECT COUNT(*) FROM msg_runs` + nf).Scan(&s.TotalMsgRuns)
 	d.db.QueryRow(`SELECT COUNT(*) FROM bank_sends` + nf).Scan(&s.TotalSends)
 	s.TotalTxs = s.TotalCalls + s.TotalDeploys + s.TotalMsgRuns + s.TotalSends
-	if network != "" {
-		d.db.QueryRow(`SELECT COUNT(DISTINCT caller) FROM calls WHERE network = ?`, network).Scan(&s.UniqueCallers)
-		d.db.QueryRow(`SELECT COALESCE(MAX(block_height), 0) FROM packages WHERE network = ?`, network).Scan(&s.LatestBlock)
-	} else {
-		d.db.QueryRow(`SELECT COUNT(DISTINCT caller) FROM calls`).Scan(&s.UniqueCallers)
-		d.db.QueryRow(`SELECT COALESCE(MAX(block_height), 0) FROM packages`).Scan(&s.LatestBlock)
-	}
+	d.db.QueryRow(`SELECT COUNT(DISTINCT caller) FROM calls` + nf).Scan(&s.UniqueCallers)
+	d.db.QueryRow(`SELECT COALESCE(MAX(block_height), 0) FROM packages` + nf).Scan(&s.LatestBlock)
 	return &s, nil
 }
 
@@ -1301,12 +1335,7 @@ func (d *DB) GetActiveAccounts(network string) ([]AccountInfo, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	nFilter := ""
-	if network != "" {
-		// SQLite-safe string interpolation for CTEs
-		safe := strings.ReplaceAll(network, "'", "''")
-		nFilter = " WHERE network = '" + safe + "'"
-	}
+	nFilter := " WHERE " + d.networkFilter("network", network)
 
 	q := `
 		SELECT address, SUM(call_count), SUM(deploy_count), SUM(run_count), SUM(send_count)
@@ -1376,11 +1405,7 @@ func (d *DB) GetBankStats(network string) (*BankStats, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	nFilter := ""
-	if network != "" {
-		safe := strings.ReplaceAll(network, "'", "''")
-		nFilter = " WHERE network = '" + safe + "'"
-	}
+	nFilter := " WHERE " + d.networkFilter("network", network)
 
 	var s BankStats
 	d.db.QueryRow(`SELECT COUNT(*) FROM bank_sends` + nFilter).Scan(&s.TotalSends)
@@ -1388,11 +1413,7 @@ func (d *DB) GetBankStats(network string) (*BankStats, error) {
 	d.db.QueryRow(`SELECT COUNT(DISTINCT to_address) FROM bank_sends` + nFilter).Scan(&s.UniqueReceivers)
 	d.db.QueryRow(`SELECT ` + amountExpr + ` FROM bank_sends` + nFilter).Scan(&s.TotalVolume)
 
-	andFilter := ""
-	if network != "" {
-		safe := strings.ReplaceAll(network, "'", "''")
-		andFilter = " AND network = '" + safe + "'"
-	}
+	andFilter := " AND " + d.networkFilter("network", network)
 	d.db.QueryRow(`SELECT COUNT(DISTINCT addr) FROM (SELECT from_address as addr FROM bank_sends` + nFilter + ` UNION SELECT to_address FROM bank_sends` + nFilter + `)`).Scan(&s.UniqueAddresses)
 
 	s.TopSenders = d.queryAddrStats(`SELECT from_address, COUNT(*), ` + amountExpr + ` FROM bank_sends` + nFilter + ` GROUP BY from_address ORDER BY COUNT(*) DESC LIMIT 10`)
@@ -1446,13 +1467,8 @@ func (d *DB) GetAnalytics(network string) (*Analytics, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	nFilter := ""
-	pFilter := ""
-	if network != "" {
-		safe := strings.ReplaceAll(network, "'", "''")
-		nFilter = " WHERE network = '" + safe + "'"
-		pFilter = " AND p.network = '" + safe + "'"
-	}
+	nFilter := " WHERE " + d.networkFilter("network", network)
+	pFilter := " AND " + d.networkFilter("p.network", network)
 
 	var a Analytics
 	if network != "" {
@@ -1467,11 +1483,7 @@ func (d *DB) GetAnalytics(network string) (*Analytics, error) {
 	d.db.QueryRow(`SELECT COUNT(*) FROM msg_runs` + nFilter).Scan(&a.TotalMsgRuns)
 	d.db.QueryRow(`SELECT COUNT(*) FROM bank_sends` + nFilter).Scan(&a.TotalSends)
 
-	addrUnionFilter := ""
-	if network != "" {
-		safe := strings.ReplaceAll(network, "'", "''")
-		addrUnionFilter = " WHERE network = '" + safe + "'"
-	}
+	addrUnionFilter := " WHERE " + d.networkFilter("network", network)
 	d.db.QueryRow(`SELECT COUNT(DISTINCT addr) FROM (
 		SELECT caller as addr FROM calls` + addrUnionFilter + ` UNION SELECT creator FROM packages` + addrUnionFilter + `
 		UNION SELECT caller FROM msg_runs` + addrUnionFilter + ` UNION SELECT from_address FROM bank_sends` + addrUnionFilter + `
@@ -1483,13 +1495,8 @@ func (d *DB) GetAnalytics(network string) (*Analytics, error) {
 		d.db.QueryRow(`SELECT COALESCE(SUM(LENGTH(body)), 0) / 1024 FROM package_files`).Scan(&a.TotalSourceKB)
 	}
 
-	callJoinFilter := ""
-	depJoinFilter := ""
-	if network != "" {
-		safe := strings.ReplaceAll(network, "'", "''")
-		callJoinFilter = " AND c_inner.network = '" + safe + "'"
-		depJoinFilter = " AND dep_inner.network = '" + safe + "'"
-	}
+	callJoinFilter := " AND " + d.networkFilter("c_inner.network", network)
+	depJoinFilter := " AND " + d.networkFilter("dep_inner.network", network)
 
 	// Top realms by calls
 	rows, _ := d.db.Query(`
@@ -1541,9 +1548,7 @@ func (d *DB) GetAnalytics(network string) (*Analytics, error) {
 
 	// Top imports
 	importsQ := `SELECT import_path, COUNT(*) as c FROM dependencies WHERE import_path LIKE 'gno.land/%'`
-	if network != "" {
-		importsQ += ` AND network = '` + strings.ReplaceAll(network, "'", "''") + `'`
-	}
+	importsQ += " AND " + d.networkFilter("network", network)
 	importsQ += ` GROUP BY import_path ORDER BY c DESC LIMIT 15`
 	rows4, _ := d.db.Query(importsQ)
 	if rows4 != nil {

--- a/db_test.go
+++ b/db_test.go
@@ -2,9 +2,23 @@ package main
 
 import (
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"testing"
 )
+
+// newTestDB opens a real SQLite file in a temp dir. The driver is pure Go, so
+// this works everywhere including CI, and it exercises the actual schema rather
+// than a mock.
+func newTestDB(t *testing.T) *DB {
+	t.Helper()
+	db, err := NewDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
 
 // oldSchemaNoBlockTime is the schema as it existed after the network column was
 // added but before the time-series work introduced block_time. Databases in this
@@ -502,5 +516,108 @@ func TestBackfillSkipsGenesisRows(t *testing.T) {
 		if h == 0 {
 			t.Error("block time backfill returned genesis height 0")
 		}
+	}
+}
+
+// A network removed from the config keeps its rows. Without scoping, every
+// all-networks total silently counts a chain that no longer exists — on
+// production this inflated the transaction count by 4,101 and the realm count by
+// 187 the day topaz was retired.
+func TestStatsAreScopedToConfiguredNetworks(t *testing.T) {
+	db := newTestDB(t)
+
+	seed := func(network string, calls, realms int) {
+		t.Helper()
+		for i := 0; i < calls; i++ {
+			if err := db.InsertCall(network, fmt.Sprintf("%s-tx-%d", network, i), 100+i,
+				"2026-01-01T00:00:00Z", fmt.Sprintf("g1caller%d", i), "gno.land/r/demo/x", "Fn", true); err != nil {
+				t.Fatalf("seed call: %v", err)
+			}
+		}
+		for i := 0; i < realms; i++ {
+			if err := db.UpsertPackage(network, fmt.Sprintf("gno.land/r/%s/pkg%d", network, i), "pkg",
+				"g1creator", fmt.Sprintf("%s-dep-%d", network, i), 200+i, "2026-01-01T00:00:00Z", true, 1); err != nil {
+				t.Fatalf("seed package: %v", err)
+			}
+		}
+	}
+
+	seed("live", 5, 2)
+	seed("retired", 3, 1)
+
+	tests := []struct {
+		name       string
+		configured []string
+		network    string
+		wantCalls  int
+		wantRealms int
+	}{
+		{
+			name:       "all networks counts only the configured one",
+			configured: []string{"live"},
+			network:    "",
+			wantCalls:  5,
+			wantRealms: 2,
+		},
+		{
+			name:       "a named network is unaffected by the config list",
+			configured: []string{"live"},
+			network:    "live",
+			wantCalls:  5,
+			wantRealms: 2,
+		},
+		{
+			name:       "re-adding the network brings its rows back",
+			configured: []string{"live", "retired"},
+			network:    "",
+			wantCalls:  8,
+			wantRealms: 3,
+		},
+		{
+			name:       "no configuration counts everything, as before",
+			configured: nil,
+			network:    "",
+			wantCalls:  8,
+			wantRealms: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := make([]NetworkConfig, 0, len(tt.configured))
+			for _, id := range tt.configured {
+				cfg = append(cfg, NetworkConfig{ID: id})
+			}
+			db.SetConfiguredNetworks(cfg)
+
+			s, err := db.GetStats(tt.network)
+			if err != nil {
+				t.Fatalf("GetStats: %v", err)
+			}
+			if s.TotalCalls != tt.wantCalls {
+				t.Errorf("TotalCalls = %d, want %d", s.TotalCalls, tt.wantCalls)
+			}
+			if s.TotalRealms != tt.wantRealms {
+				t.Errorf("TotalRealms = %d, want %d", s.TotalRealms, tt.wantRealms)
+			}
+		})
+	}
+}
+
+// The filter interpolates identifiers, so a quote in a network id must not be
+// able to close the literal.
+func TestNetworkFilterQuoting(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "o'brien"}, {ID: "plain"}})
+
+	if got, want := db.networkFilter("network", ""), `network IN ('o''brien','plain')`; got != want {
+		t.Errorf("configured set: got %q, want %q", got, want)
+	}
+	if got, want := db.networkFilter("network", "o'brien"), `network = 'o''brien'`; got != want {
+		t.Errorf("named network: got %q, want %q", got, want)
+	}
+	db.SetConfiguredNetworks(nil)
+	if got, want := db.networkFilter("network", ""), "1=1"; got != want {
+		t.Errorf("no config: got %q, want %q", got, want)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -53,6 +53,10 @@ func run() error {
 	}
 	log.Printf("networks %v (from %s)", cfg.IDs(), cfgSource)
 
+	// Rows outlive a network being retired from the config, so tell the database
+	// which ones still count before anything reads an all-networks total.
+	db.SetConfiguredNetworks(cfg.Networks)
+
 	// Create per-network clients. The sync loop gets its own, on a budget sized
 	// for catching up on history rather than for answering a page.
 	clients := make(map[string]*IndexerClient)


### PR DESCRIPTION
Closes #76. Retiring topaz from the config did not retire it from the numbers — every all-networks total on the site was inflated by a chain that no longer exists.

## The problem

The database was acting as the source of truth for which networks exist. Rows survive a network being dropped from the config, and the unfiltered branch simply omitted the `WHERE`:

```go
nf := ""
if network != "" {
    nf = " WHERE network = '" + strings.ReplaceAll(network, "'", "''") + "'"
}
d.db.QueryRow(`SELECT COUNT(*) FROM calls` + nf).Scan(&s.TotalCalls)
```

Empty network meant "count everything", not "count the networks we run".

## The fix

`DB` learns the configured set once at startup (`SetConfiguredNetworks`, called from `run()` right after the config is resolved), and a single helper builds the condition for both cases:

```go
func (d *DB) networkFilter(column, network string) string
// "sapphire"  → network = 'sapphire'
// ""          → network IN ('gnoland1','sapphire','staging')
// "" + no cfg → 1=1
```

Returning a bare condition means every call site is a plain concatenation instead of a branch, and the `1=1` fallback keeps behaviour identical for anything constructing a `DB` without a config — which is what the existing tests do.

## Verified against a copy of the production database

Ran the new binary against a snapshot of `/root/mygnoscan-gnoland1.db`, which still holds topaz's rows:

```
unfiltered   txs=655624  realms=249

gnoland1     txs=2875      realms=39
sapphire     txs=652742    realms=210
staging      txs=7         realms=0
SUM          txs=655624    realms=249
```

The unfiltered total is now **exactly** the sum of the configured networks. Before this change the same database reported 659,092 txs and 436 realms — the differences, 4,101 and 187, were topaz to the row.

(The absolute numbers moved between measurements because sapphire keeps syncing; the identity is the point, and it holds exactly.)

## Also: no more hand-rolled SQL quoting

The eight sites that built filters by concatenating `strings.ReplaceAll(network, "'", "''")` are gone. `grep -c 'ReplaceAll(network' db.go` is now 0.

These fragments are spliced into CTEs at several points, where positional parameters would have to be threaded through in query order — so the helper still interpolates rather than binds. What changed is where the value comes from: a named network has already been checked against the config by #75, and the unfiltered list is the config file itself, never a request. The quote doubling is kept as belt and braces and is now in one place instead of eight, with a test.

## Tests

- `TestStatsAreScopedToConfiguredNetworks` — seeds a `live` and a `retired` network into a real temp SQLite file, then checks four cases: all-networks counts only the configured one, a named network is unaffected by the list, re-adding a network brings its rows back, and an unconfigured `DB` counts everything as before.
- `TestNetworkFilterQuoting` — a network id containing an apostrophe cannot close the literal, in both the single and the set form.

Also adds a `newTestDB` helper; every existing test was opening its own temp database by hand.

## Scope

This converts `GetStats` and every site that was building a filter string manually — which is all of the all-networks aggregate readers, and the ones that were producing the wrong numbers. There remain call sites in `db.go` that branch on `network != ""` while using bound parameters; those are correct for a named network and only over-count in the unfiltered case. They should move to the helper too, but they are a mechanical follow-up rather than part of this fix, and each needs its own read to confirm the join it sits in.

Not addressed here: topaz's rows are still on disk. That is deliberate — deleting them should be an explicit maintenance step with a dry run, never a side effect of a config edit, per the argument in #76.

`gofmt`/`go vet`/`go test ./...` clean.
