### PR TITLE
fix: parse imports instead of scanning for quoted paths

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"go/parser"
+	"go/token"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
-// importRegex matches Go import statements for gno.land packages.
+// importRegex matches any quoted gno.land path. It is the fallback for source
+// that will not parse at all — see fileImports.
 var importRegex = regexp.MustCompile(`"(gno\.land/[^"]+)"`)
 
 type Analyzer struct {
@@ -30,16 +34,53 @@ func (a *Analyzer) ExtractImports(files []MemFile) []string {
 			continue
 		}
 
-		matches := importRegex.FindAllStringSubmatch(f.Body, -1)
-		for _, m := range matches {
-			imp := m[1]
-			if !seen[imp] {
-				seen[imp] = true
-				imports = append(imports, imp)
+		for _, imp := range fileImports(f) {
+			// The graph tracks on-chain dependencies, so stdlib imports are not
+			// edges in it.
+			if !strings.HasPrefix(imp, "gno.land/") || seen[imp] {
+				continue
 			}
+			seen[imp] = true
+			imports = append(imports, imp)
 		}
 	}
 	return imports
+}
+
+// fileImports returns the paths one file imports.
+//
+// gno's import syntax is Go's, so go/parser reads it directly. ImportsOnly stops
+// at the end of the import block, which means a file whose *body* does not parse
+// still yields correct imports — worth knowing, because that is the common shape
+// of source that fails to compile.
+//
+// Scanning for quoted paths instead, as this used to, cannot tell an import from
+// any other string. It counted commented-out imports and paths that merely
+// appear in string literals, and cross-realm paths in string literals are common
+// enough in gno that the dependency graph carried edges that do not exist.
+//
+// The regex survives as a fallback for source where even the package clause and
+// import block will not parse — likely not Go at all. It over-reports, but a
+// real import is never lost, which is the better failure for a graph.
+func fileImports(f MemFile) []string {
+	parsed, err := parser.ParseFile(token.NewFileSet(), f.Name, f.Body, parser.ImportsOnly)
+	if err != nil {
+		var out []string
+		for _, m := range importRegex.FindAllStringSubmatch(f.Body, -1) {
+			out = append(out, m[1])
+		}
+		return out
+	}
+
+	out := make([]string, 0, len(parsed.Imports))
+	for _, imp := range parsed.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			continue
+		}
+		out = append(out, path)
+	}
+	return out
 }
 
 // ExtractMsgRunImports parses MsgRun source for gno.land imports.

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -93,32 +93,61 @@ func TestExtractImports(t *testing.T) {
 	}
 }
 
-// TestExtractImportsMatchesAnyQuotedPath pins a known limitation rather than
-// endorsing it: extraction is a regex over the file body, not a parse of the
-// import block, so any quoted gno.land path anywhere in the source is reported
-// as a dependency — including ones in comments, in string literals, and in
-// imports that were commented out.
-//
-// The effect is a dependency graph that over-reports. It never misses a real
-// import, which is why this is tolerable, but a realm that merely mentions a
-// path in a string gets an edge it does not have. Changing it means parsing the
-// source properly; this test exists so that change is visible when it happens.
-func TestExtractImportsMatchesAnyQuotedPath(t *testing.T) {
+// Only real imports count. This test previously asserted the opposite — the old
+// regex reported every quoted gno.land path, so a commented-out import and a
+// path in a string literal both became dependency edges.
+func TestExtractImportsIgnoresPathsThatAreNotImports(t *testing.T) {
 	files := []MemFile{{Name: "a.gno", Body: `
 		package main
 
 		// import "gno.land/r/demo/commented"
 		import "gno.land/p/demo/avl"
 
+		// Cross-realm paths live in string literals all over gno, which is what
+		// made the old behaviour actively wrong rather than merely untidy.
 		const link = "gno.land/r/demo/mentioned"
+
+		func Render(path string) string {
+			return "see gno.land/r/demo/alsonot"
+		}
 	`}}
 
 	got := NewAnalyzer(nil).ExtractImports(files)
-	want := []string{
-		"gno.land/r/demo/commented",
-		"gno.land/p/demo/avl",
-		"gno.land/r/demo/mentioned",
+	want := []string{"gno.land/p/demo/avl"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractImports() = %v, want %v", got, want)
 	}
+}
+
+// ImportsOnly stops at the end of the import block, so source that fails to
+// compile further down still reports its imports correctly. This is the common
+// shape of broken on-chain source, and it must not lose edges.
+func TestExtractImportsSurvivesAnUnparseableBody(t *testing.T) {
+	files := []MemFile{{Name: "a.gno", Body: `
+		package main
+
+		import "gno.land/p/demo/avl"
+
+		func broken( { this is not go at all }
+	`}}
+
+	got := NewAnalyzer(nil).ExtractImports(files)
+	want := []string{"gno.land/p/demo/avl"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractImports() = %v, want %v", got, want)
+	}
+}
+
+// When even the package clause will not parse, fall back to scanning. It
+// over-reports, but a real import is never lost — the better failure for a graph.
+func TestExtractImportsFallsBackWhenNothingParses(t *testing.T) {
+	files := []MemFile{{Name: "a.gno", Body: `
+		}}} not go {{{
+		import "gno.land/p/demo/avl"
+	`}}
+
+	got := NewAnalyzer(nil).ExtractImports(files)
+	want := []string{"gno.land/p/demo/avl"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ExtractImports() = %v, want %v", got, want)
 	}


### PR DESCRIPTION
Closes #71. The dependency graph was inventing edges.

## The problem

`ExtractImports` scanned the file body for quoted `gno.land` paths, which cannot tell an import from any other string:

```go
var importRegex = regexp.MustCompile(`"(gno\.land/[^"]+)"`)
```

Commented-out imports counted. Paths in string literals counted. Cross-realm paths live in string literals all over gno, so this was not a theoretical concern.

## The fix

`go/parser` in `ImportsOnly` mode. gno's import syntax is Go's, so it reads it directly.

The open question in #71 — what to do about files that will not parse — turned out to be much smaller than expected. **`ImportsOnly` stops at the end of the import block**, so a file whose *body* is broken still yields correct imports:

```go
package main
import "gno.land/p/demo/avl"
func broken( { this is not go at all }
```

→ parses fine, returns `gno.land/p/demo/avl`. That is the common shape of source that fails to compile, and it needs no special handling at all.

The regex survives only as a fallback for source where even the package clause and import block will not parse — where it is likely not Go. It over-reports there, but a real import is never lost, which is the better failure for a graph.

## Validated against real on-chain source

Fetched every `MsgAddPackage` from `indexer.gno.land` and diffed old extraction against new across the actual package bodies:

```
packages=18   gno files=37   parse failures=0
packages whose edges changed=2
```

**Zero real imports missed.** Two phantom edges removed, and they are worth quoting because they show exactly what the regex was doing:

```
gno.land/r/onbloc/utils/grc20helper
    - gno.land/r/demo/foo20.FOO

gno.land/r/g1n500fmqx8m6tgts85kmn43htegkv0eewkdm4lg/gingernft2
    - gno.land/r/g1n500fmqx8m6tgts85kmn43htegkv0eewkdm4lg/gingernft2.GetTokenURI(\\\
```

The first is a **token denom**, not a package path — note the `.FOO`. The second is a fragment of a function reference from inside a string literal, escape characters and all. Both were live edges in the production dependency graph.

## Tests

`TestExtractImportsMatchesAnyQuotedPath` is **inverted**, as #71 asked — it asserted the wrong output on purpose so this change would be visible, and it now asserts the right one as `TestExtractImportsIgnoresPathsThatAreNotImports`. Two new cases alongside it:

- `TestExtractImportsSurvivesAnUnparseableBody` — broken body, imports still extracted
- `TestExtractImportsFallsBackWhenNothingParses` — unparseable package clause falls back to scanning rather than losing the import

The existing eight-case table is unchanged and still passes: grouped import blocks, stdlib ignored, dedup with first-seen order, non-`.gno` skipped, `_test.gno` skipped, and the empty cases.

## Backfill

Existing `dependencies` rows were written by the old logic, so **the phantom edges stay until each package is re-synced**. `ProcessPackage` calls `SetDependencies` on every sync pass for packages it sees, but the syncer only walks forward from its cursor, so historical packages are not revisited.

`package_files` already stores the bodies, so a one-off re-extraction over stored source would fix it without touching the indexer. Not included here — it wants its own change and a decision about whether it runs automatically on startup or as an explicit command. Worth doing before anyone trusts the graph's edge counts.

`gofmt`/`go vet`/`go test ./...` clean.
