### PR TITLE
feat: re-extract dependency edges at startup when the extractor changes

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"go/parser"
 	"go/token"
+	"log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -111,6 +113,65 @@ func (a *Analyzer) ProcessPackage(network string, pkg *MemPackage, creator, txHa
 	}
 
 	return nil
+}
+
+// dependencyExtractorVersion names the extraction logic that produced the rows
+// currently in the dependencies table. Bump it whenever ExtractImports changes
+// in a way that would give a different answer, and every package is re-extracted
+// once on the next start.
+//
+// v2 replaced a regex scan for quoted gno.land paths with a real parse of the
+// import block. The regex counted commented-out imports and paths that only
+// appeared in string literals, so rows written before it carry edges that do not
+// exist.
+const dependencyExtractorVersion = "2"
+
+const dependencyExtractorKey = "dependency_extractor_version"
+
+// ReextractDependencies recomputes every package's dependencies from the source
+// already in the database, once per extractor version.
+//
+// Sync only ever moves forward from its cursor, so a package deployed before an
+// extraction change is never revisited and keeps whatever the old logic wrote.
+// package_files holds the bodies, so this needs no indexer and no network.
+func (a *Analyzer) ReextractDependencies() error {
+	done, err := a.db.GetSyncState(dependencyExtractorKey)
+	if err == nil && done == dependencyExtractorVersion {
+		return nil
+	}
+
+	refs, err := a.db.StoredPackageRefs()
+	if err != nil {
+		return err
+	}
+
+	packages, edges, failed := 0, 0, 0
+	for _, ref := range refs {
+		files, err := a.db.StoredPackageFiles(ref.Network, ref.Path)
+		if err != nil {
+			// One bad package must not abandon the pass; the version marker is
+			// only written if everything else got through, so a later start
+			// retries.
+			log.Printf("re-extract %s/%s: %v", ref.Network, ref.Path, err)
+			failed++
+			continue
+		}
+		imports := a.ExtractImports(files)
+		if err := a.db.SetDependencies(ref.Network, ref.Path, imports); err != nil {
+			log.Printf("re-extract %s/%s: %v", ref.Network, ref.Path, err)
+			failed++
+			continue
+		}
+		packages++
+		edges += len(imports)
+	}
+	if failed > 0 {
+		return fmt.Errorf("re-extracted %d packages, %d failed", packages, failed)
+	}
+
+	log.Printf("re-extracted dependencies for %d packages (%d edges) with extractor v%s",
+		packages, edges, dependencyExtractorVersion)
+	return a.db.SetSyncState(dependencyExtractorKey, dependencyExtractorVersion)
 }
 
 // ProcessCall stores a function call record.

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -184,3 +184,114 @@ func TestExtractMsgRunImports(t *testing.T) {
 		})
 	}
 }
+
+// seedPackage writes a package's source the way ProcessPackage would, then
+// installs dependency rows as if an older extractor had produced them.
+func seedPackage(t *testing.T, db *DB, network, path string, files []MemFile, staleEdges []string) {
+	t.Helper()
+	if err := db.UpsertPackage(network, path, "pkg", "g1creator", "tx-"+path, 1, "2026-01-01T00:00:00Z", true, len(files)); err != nil {
+		t.Fatalf("UpsertPackage: %v", err)
+	}
+	for _, f := range files {
+		if err := db.UpsertPackageFile(network, path, f.Name, f.Body); err != nil {
+			t.Fatalf("UpsertPackageFile: %v", err)
+		}
+	}
+	if err := db.SetDependencies(network, path, staleEdges); err != nil {
+		t.Fatalf("SetDependencies: %v", err)
+	}
+}
+
+// Sync only moves forward from its cursor, so packages deployed before an
+// extractor change keep whatever the old logic wrote. The regex used to count
+// commented-out imports and paths in string literals, so those phantom edges
+// would have outlived the fix without this.
+func TestReextractDependenciesReplacesStaleEdges(t *testing.T) {
+	db := newTestDB(t)
+	analyzer := NewAnalyzer(db)
+
+	src := []MemFile{{Name: "a.gno", Body: `package main
+
+// import "gno.land/r/demo/commented"
+import "gno.land/p/demo/avl"
+
+const link = "gno.land/r/demo/mentioned"
+`}}
+	// What the old regex would have written for that file.
+	seedPackage(t, db, "testnet", "gno.land/r/demo/target", src, []string{
+		"gno.land/r/demo/commented",
+		"gno.land/p/demo/avl",
+		"gno.land/r/demo/mentioned",
+	})
+
+	if got := depsOf(t, db, "testnet", "gno.land/r/demo/target"); len(got) != 3 {
+		t.Fatalf("seed failed: %v", got)
+	}
+
+	if err := analyzer.ReextractDependencies(); err != nil {
+		t.Fatalf("ReextractDependencies: %v", err)
+	}
+
+	got := depsOf(t, db, "testnet", "gno.land/r/demo/target")
+	want := []string{"gno.land/p/demo/avl"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("dependencies = %v, want %v", got, want)
+	}
+}
+
+// The pass is marked done by extractor version, so a restart does not redo it —
+// but bumping the version must.
+func TestReextractDependenciesRunsOncePerVersion(t *testing.T) {
+	db := newTestDB(t)
+	analyzer := NewAnalyzer(db)
+
+	src := []MemFile{{Name: "a.gno", Body: "package main\nimport \"gno.land/p/demo/avl\"\n"}}
+	seedPackage(t, db, "testnet", "gno.land/r/demo/target", src, []string{"gno.land/r/demo/phantom"})
+
+	if err := analyzer.ReextractDependencies(); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	if got, _ := db.GetSyncState(dependencyExtractorKey); got != dependencyExtractorVersion {
+		t.Fatalf("version marker = %q, want %q", got, dependencyExtractorVersion)
+	}
+
+	// Corrupt the table, then re-run: the marker means it must not be touched.
+	if err := db.SetDependencies("testnet", "gno.land/r/demo/target", []string{"gno.land/r/demo/manual"}); err != nil {
+		t.Fatalf("SetDependencies: %v", err)
+	}
+	if err := analyzer.ReextractDependencies(); err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if got := depsOf(t, db, "testnet", "gno.land/r/demo/target"); !reflect.DeepEqual(got, []string{"gno.land/r/demo/manual"}) {
+		t.Errorf("second pass re-ran despite the version marker: %v", got)
+	}
+
+	// A new extractor version must run again.
+	if err := db.SetSyncState(dependencyExtractorKey, "0"); err != nil {
+		t.Fatalf("SetSyncState: %v", err)
+	}
+	if err := analyzer.ReextractDependencies(); err != nil {
+		t.Fatalf("third pass: %v", err)
+	}
+	if got := depsOf(t, db, "testnet", "gno.land/r/demo/target"); !reflect.DeepEqual(got, []string{"gno.land/p/demo/avl"}) {
+		t.Errorf("a bumped version did not re-extract: %v", got)
+	}
+}
+
+func depsOf(t *testing.T, db *DB, network, pkgPath string) []string {
+	t.Helper()
+	rows, err := db.db.Query(`SELECT import_path FROM dependencies WHERE network = ? AND package_path = ? ORDER BY import_path`, network, pkgPath)
+	if err != nil {
+		t.Fatalf("query dependencies: %v", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, s)
+	}
+	return out
+}

--- a/db.go
+++ b/db.go
@@ -383,6 +383,70 @@ func (d *DB) UpsertPackageFile(network, pkgPath, fileName, body string) error {
 	return err
 }
 
+// StoredPackageRef identifies a package whose source is held locally.
+type StoredPackageRef struct {
+	Network string
+	Path    string
+}
+
+// StoredPackageRefs lists every package that has source in the database.
+//
+// Deliberately returns references rather than bodies, and takes no callback: a
+// caller iterating packages will want to write as it goes, and d.mu is not
+// reentrant — handing out source under the read lock would deadlock the first
+// caller that tried. package_files is also the largest table on a busy chain, so
+// not buffering every body is worth having anyway.
+func (d *DB) StoredPackageRefs() ([]StoredPackageRef, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT DISTINCT network, package_path
+		FROM package_files
+		ORDER BY network, package_path
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []StoredPackageRef
+	for rows.Next() {
+		var ref StoredPackageRef
+		if err := rows.Scan(&ref.Network, &ref.Path); err != nil {
+			return nil, err
+		}
+		out = append(out, ref)
+	}
+	return out, rows.Err()
+}
+
+// StoredPackageFiles returns one package's stored source.
+func (d *DB) StoredPackageFiles(network, pkgPath string) ([]MemFile, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT file_name, body FROM package_files
+		WHERE network = ? AND package_path = ?
+		ORDER BY file_name
+	`, network, pkgPath)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []MemFile
+	for rows.Next() {
+		var f MemFile
+		if err := rows.Scan(&f.Name, &f.Body); err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
 // SetDependencies replaces all dependencies for a package.
 func (d *DB) SetDependencies(network, pkgPath string, imports []string) error {
 	d.mu.Lock()

--- a/main.go
+++ b/main.go
@@ -69,6 +69,16 @@ func run() error {
 	// Initialize analyzer
 	analyzer := NewAnalyzer(db)
 
+	// Recompute dependency edges when the extractor has changed. Reads only
+	// stored source, so it costs nothing on the network and is a no-op once the
+	// current version is recorded. Errors are logged, not fatal: a stale
+	// dependency graph is not a reason to refuse to start.
+	go func() {
+		if err := analyzer.ReextractDependencies(); err != nil {
+			log.Printf("re-extract dependencies: %v", err)
+		}
+	}()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
Follow-up to #81, which fixed import extraction but left every existing row untouched. Sync only moves forward from its cursor, so a package deployed before the change is never revisited and keeps whatever the regex wrote.

Runs at startup, as requested.

## What it does

`ReextractDependencies` recomputes every package's edges from the source already in `package_files`. **No indexer, no network** — the bodies are already local.

Guarded by an extractor version in the existing `sync_state` table, so it runs once and is a no-op on every later start. Bump `dependencyExtractorVersion` when `ExtractImports` changes in a way that would give a different answer, and the next start re-extracts.

Called from a goroutine in `run()`: it must not delay serving, and a stale dependency graph is not a reason to refuse to start, so failures are logged rather than fatal. The version marker is only written when nothing failed, so a partial pass retries next time.

## Measured against a copy of the production database

```
dependency edges: before=2269  after=2037  removed=232
phantom edges removed: 232
edges ADDED (should be 0 unless the old regex missed something): 0
```

**Over 10% of the dependency graph was fictional.** Nothing real was lost.

A sample of what came out, which is a better argument than the diffstat:

```
gno.land/p/moul/addrset       -> gno.land/p/moul/addrset
gno.land/p/moul/mdtable       -> gno.land/p/moul/mdtable
gno.land/p/nt/uassert/v0      -> gno.land/p/nt/uassert/v0
gno.land/p/nt/fqname/v0       -> gno.land/p/nt/avl/v0.Tree
gno.land/p/demo/tokens/grc20  -> gno.land/r/demo/foo20
gno.land/r/…/gingernft2       -> gno.land/r/…/gingernft2.GetTokenURI(\\\
```

The first three are **self-edges** — packages recorded as depending on themselves, because their own path appears in a string somewhere in their own source. The graph had nodes pointing at themselves. The fourth is a type reference (`.Tree`), the fifth a token denom, the last a fragment of a function reference complete with escape characters.

653 packages processed in well under a second, since it never leaves the database.

## A deadlock the tests caught

The first version had `EachStoredPackage(fn)` streaming rows under `d.mu.RLock()` and calling `fn` per package. Every realistic callback writes — `SetDependencies` takes `d.mu.Lock()` — and `sync.RWMutex` is not reentrant, so it hung on the first package.

Replaced with two plain readers, `StoredPackageRefs` and `StoredPackageFiles`, each holding the lock only for its own query. The caller loops. Incidentally better anyway: `package_files` is the largest table on a busy chain and this never buffers more than one package's source.

Worth knowing for anything else that iterates and writes — the callback-under-lock shape is a trap here.

## Tests

- `TestReextractDependenciesReplacesStaleEdges` — seeds a package whose stored source contains a commented import and a path in a string literal, installs the three edges the old regex would have written, then checks only the real import survives.
- `TestReextractDependenciesRunsOncePerVersion` — first pass writes the marker; a second pass leaves hand-edited rows alone; resetting the marker makes it re-extract. This is what stops it running on every restart, so it is worth pinning.

`gofmt`/`go vet`/`go test ./...` clean.
