### PR TITLE
feat: store validator monikers locally instead of scanning all history

### DIFF
--- a/api.go
+++ b/api.go
@@ -876,13 +876,12 @@ func (a *API) HandleValidators(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "no client available", 500)
 		return
 	}
-	// Get validator registrations from gno.land/r/gnops/valopers
-	txs, err := client.GetTransactionsByPkgPath(r.Context(), "gno.land/r/gnops/valopers")
+	regs, err := a.db.ValoperRegistrations(network)
 	if err != nil {
 		jsonError(w, err.Error(), 500)
 		return
 	}
-	jsonResponse(w, txs)
+	jsonResponse(w, regs)
 }
 
 func (a *API) HandleTokens(w http.ResponseWriter, r *http.Request) {

--- a/db.go
+++ b/db.go
@@ -318,6 +318,31 @@ func initSchema(db *sql.DB) error {
 			UNIQUE(network, tx_hash, from_address, to_address)
 		);
 
+		-- Validator registrations, the one thing the calls table cannot answer:
+		-- the moniker is the call's first argument, and args are not stored.
+		-- Keeping just this instead of every call's args is the difference between
+		-- a few hundred rows and a column on half a million.
+		CREATE TABLE IF NOT EXISTS valoper_registrations (
+			network TEXT NOT NULL DEFAULT 'gnoland1',
+			tx_hash TEXT NOT NULL,
+			block_height INTEGER NOT NULL,
+			block_time TEXT,
+			caller TEXT NOT NULL,
+			func_name TEXT NOT NULL,
+			-- The validator the call is about, which is not always the caller: an
+			-- admin can update someone else's entry, and Register carries the
+			-- validator address in its arguments.
+			address TEXT NOT NULL,
+			-- Empty unless the call actually sets a name. Most valopers functions
+			-- do not.
+			moniker TEXT NOT NULL,
+			success BOOLEAN NOT NULL,
+			UNIQUE(network, tx_hash, caller)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_valoper_network_height
+			ON valoper_registrations(network, block_height DESC);
+
 		CREATE TABLE IF NOT EXISTS transactions (
 			network      TEXT NOT NULL DEFAULT 'gnoland1',
 			tx_hash      TEXT NOT NULL,
@@ -422,6 +447,103 @@ func (d *DB) InsertCall(network, txHash string, blockHeight int, blockTime, call
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	`, network, txHash, blockHeight, blockTime, caller, pkgPath, funcName, success)
 	return err
+}
+
+// ValoperRegistration is one validator's registration call, flattened. The
+// moniker is the call's first argument.
+type ValoperRegistration struct {
+	TxHash      string `json:"tx_hash"`
+	BlockHeight int    `json:"block_height"`
+	BlockTime   string `json:"block_time,omitempty"`
+	Caller      string `json:"caller"`
+	Func        string `json:"func"`
+	Address     string `json:"address"`
+	Moniker     string `json:"moniker"`
+	Success     bool   `json:"success"`
+	Network     string `json:"network,omitempty"`
+}
+
+// InsertValoperRegistration records a call to a valopers realm.
+func (d *DB) InsertValoperRegistration(network, txHash string, blockHeight int, blockTime, caller, funcName, address, moniker string, success bool) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_, err := d.db.Exec(`
+		INSERT OR REPLACE INTO valoper_registrations
+			(network, tx_hash, block_height, block_time, caller, func_name, address, moniker, success)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, network, txHash, blockHeight, blockTime, caller, funcName, address, moniker, success)
+	return err
+}
+
+// ValoperRegistrations returns registrations newest first.
+//
+// Served from storage rather than the indexer: filtering all of history by
+// pkg_path costs ~30s on a busy chain regardless of how little it returns,
+// because the price is the scan.
+func (d *DB) ValoperRegistrations(network string) ([]ValoperRegistration, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT network, tx_hash, block_height, COALESCE(block_time, ''), caller, func_name, address, moniker, success
+		FROM valoper_registrations
+		WHERE ` + d.networkFilter("network", network) + `
+		ORDER BY block_height DESC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []ValoperRegistration{}
+	for rows.Next() {
+		var v ValoperRegistration
+		if err := rows.Scan(&v.Network, &v.TxHash, &v.BlockHeight, &v.BlockTime,
+			&v.Caller, &v.Func, &v.Address, &v.Moniker, &v.Success); err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
+// ValoperCallsMissingRegistration lists valopers calls already stored that have
+// no registration row, so the moniker can be backfilled from the indexer.
+//
+// The calls table has everything except the moniker, which only exists in the
+// call's arguments — and those were never stored. Fetching by hash is a keyed
+// lookup, so repairing history costs one cheap request per row rather than a
+// full-history scan.
+func (d *DB) ValoperCallsMissingRegistration(network string, limit int) ([]string, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT DISTINCT c.tx_hash
+		FROM calls c
+		WHERE c.pkg_path LIKE '%valopers%'
+		  AND `+d.networkFilter("c.network", network)+`
+		  AND NOT EXISTS (
+			SELECT 1 FROM valoper_registrations v
+			WHERE v.network = c.network AND v.tx_hash = c.tx_hash
+		  )
+		ORDER BY c.block_height DESC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var h string
+		if err := rows.Scan(&h); err != nil {
+			return nil, err
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
 }
 
 // InsertMsgRun records a MsgRun transaction with its source.

--- a/db_test.go
+++ b/db_test.go
@@ -621,3 +621,92 @@ func TestNetworkFilterQuoting(t *testing.T) {
 		t.Errorf("no config: got %q, want %q", got, want)
 	}
 }
+
+// The validators view needs the moniker, which is the registration call's first
+// argument — and args are not stored on the call row. Before this table the view
+// filtered all of history by pkg_path on every request, which costs ~30s on a
+// busy chain whatever it returns.
+func TestValoperRegistrations(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "live"}})
+
+	if err := db.InsertValoperRegistration("live", "tx-1", 100, "2026-01-01T00:00:00Z",
+		"g1aaa", "Register", "g1aaa", "alice", true); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := db.InsertValoperRegistration("live", "tx-2", 200, "2026-01-02T00:00:00Z",
+		"g1bbb", "Register", "g1bbb", "bob", false); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	// A different network must not leak into the configured view.
+	if err := db.InsertValoperRegistration("other", "tx-3", 300, "",
+		"g1ccc", "Register", "g1ccc", "carol", true); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	regs, err := db.ValoperRegistrations("")
+	if err != nil {
+		t.Fatalf("ValoperRegistrations: %v", err)
+	}
+	if len(regs) != 2 {
+		t.Fatalf("got %d registrations, want 2 (an unconfigured network leaked in)", len(regs))
+	}
+	// Newest first, so the view shows recent registrations without sorting.
+	if regs[0].BlockHeight != 200 || regs[1].BlockHeight != 100 {
+		t.Errorf("order = %d,%d, want 200,100", regs[0].BlockHeight, regs[1].BlockHeight)
+	}
+	if regs[0].Moniker != "bob" || regs[0].Success {
+		t.Errorf("row = %+v, want moniker bob and success false", regs[0])
+	}
+
+	// Re-registering replaces rather than duplicating.
+	if err := db.InsertValoperRegistration("live", "tx-1", 100, "2026-01-01T00:00:00Z",
+		"g1aaa", "Register", "g1aaa", "alice-renamed", true); err != nil {
+		t.Fatalf("re-insert: %v", err)
+	}
+	regs, _ = db.ValoperRegistrations("live")
+	if len(regs) != 2 {
+		t.Fatalf("got %d registrations after re-insert, want 2", len(regs))
+	}
+	for _, r := range regs {
+		if r.Caller == "g1aaa" && r.Moniker != "alice-renamed" {
+			t.Errorf("moniker = %q, want alice-renamed", r.Moniker)
+		}
+	}
+}
+
+// The backfill finds valopers calls already stored that have no moniker yet, so
+// history can be repaired one keyed lookup at a time.
+func TestValoperCallsMissingRegistration(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "live"}})
+
+	mustCall := func(hash, pkgPath string, height int) {
+		t.Helper()
+		if err := db.InsertCall("live", hash, height, "2026-01-01T00:00:00Z",
+			"g1aaa", pkgPath, "Register", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+	mustCall("tx-valoper-1", "gno.land/r/gnops/valopers", 100)
+	mustCall("tx-valoper-2", "gno.land/r/gov/valopers/v2", 200)
+	mustCall("tx-unrelated", "gno.land/r/demo/boards", 300)
+
+	missing, err := db.ValoperCallsMissingRegistration("live", 10)
+	if err != nil {
+		t.Fatalf("ValoperCallsMissingRegistration: %v", err)
+	}
+	if len(missing) != 2 {
+		t.Fatalf("got %v, want the two valopers calls only", missing)
+	}
+
+	// Once recorded, a call drops out of the work list.
+	if err := db.InsertValoperRegistration("live", "tx-valoper-1", 100, "",
+		"g1aaa", "Register", "g1aaa", "alice", true); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	missing, _ = db.ValoperCallsMissingRegistration("live", 10)
+	if len(missing) != 1 || missing[0] != "tx-valoper-2" {
+		t.Errorf("got %v, want only tx-valoper-2", missing)
+	}
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -300,15 +300,11 @@ const KNOWN_ADDRS = {
 const _valMonikers = {};
 async function loadValMonikers() {
   try {
-    const txs = await fetch('/api/validators?network=' + getNetwork()).then(r => r.json());
-    for (const tx of (txs || [])) {
-      if (!tx.success) continue;
-      for (const msg of (tx.messages || [])) {
-        const v = msg.value;
-        if (v.__typename === 'MsgCall' && (v.args || []).length > 0) {
-          _valMonikers[v.caller] = v.args[0];
-        }
-      }
+    const regs = await fetch('/api/validators?network=' + getNetwork()).then(r => r.json());
+    // Newest first, so the first moniker seen for an address is the current one.
+    for (const reg of (regs || [])) {
+      if (!reg.success || !reg.moniker || !reg.address) continue;
+      if (_valMonikers[reg.address] === undefined) _valMonikers[reg.address] = reg.moniker;
     }
   } catch(e) {}
 }
@@ -1534,19 +1530,15 @@ function renderValoperRows(container) {
   const tbl = el('table');
   tbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'block'), el('th', {}, 'caller'), el('th', {}, 'function'), el('th', {}, 'moniker'), el('th', {}, 'status'))));
   const tbody = el('tbody');
-  for (const tx of (_valopersCache || [])) {
-    if (!_valopersShowFailed && !tx.success) continue;
-    for (const msg of tx.messages) {
-      if (msg.value.__typename === 'MsgCall') {
-        tbody.appendChild(el('tr', {},
-          el('td', {}, blockLink(tx.block_height)),
-          el('td', { className: 'truncate' }, addrLink(msg.value.caller)),
-          el('td', {}, msg.value.func),
-          el('td', {}, (msg.value.args || [])[0] || '-'),
-          el('td', {}, statusBadge(tx.success))
-        ));
-      }
-    }
+  for (const reg of (_valopersCache || [])) {
+    if (!_valopersShowFailed && !reg.success) continue;
+    tbody.appendChild(el('tr', {},
+      el('td', {}, blockLink(reg.block_height)),
+      el('td', { className: 'truncate' }, addrLink(reg.address || reg.caller)),
+      el('td', {}, reg.func),
+      el('td', {}, reg.moniker || '-'),
+      el('td', {}, statusBadge(reg.success))
+    ));
   }
   tbl.appendChild(tbody); wrap.appendChild(tbl);
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1528,7 +1528,7 @@ function renderValoperRows(container) {
   if (!wrap) return;
   wrap.textContent = '';
   const tbl = el('table');
-  tbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'block'), el('th', {}, 'caller'), el('th', {}, 'function'), el('th', {}, 'moniker'), el('th', {}, 'status'))));
+  tbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'block'), el('th', {}, 'validator'), el('th', {}, 'function'), el('th', {}, 'moniker'), el('th', {}, 'status'))));
   const tbody = el('tbody');
   for (const reg of (_valopersCache || [])) {
     if (!_valopersShowFailed && !reg.success) continue;

--- a/indexer.go
+++ b/indexer.go
@@ -611,21 +611,6 @@ func (c *IndexerClient) GetTransactionsFromHeight(ctx context.Context, lastHeigh
 	return c.transactionsFromHeight(ctx, lastHeight, "", txFieldsLight)
 }
 
-// GetTransactionsByPkgPath fetches MsgCall transactions for a specific package.
-func (c *IndexerClient) GetTransactionsByPkgPath(ctx context.Context, pkgPath string) ([]Transaction, error) {
-	var result struct {
-		GetTransactions []Transaction `json:"getTransactions"`
-	}
-	q := fmt.Sprintf(`{
-		getTransactions(
-			where: { messages: { value: { MsgCall: { pkg_path: { eq: "%s" } } } } }
-			order: { heightAndIndex: DESC }
-		) { %s }
-	}`, gqlEscape(pkgPath), txFieldsLight)
-	err := c.query(ctx, q, nil, &result)
-	return result.GetTransactions, err
-}
-
 // GetTransactionByHash fetches a single transaction by hash.
 func (c *IndexerClient) GetTransactionByHash(ctx context.Context, hash string) (*Transaction, error) {
 	var result struct {

--- a/syncer.go
+++ b/syncer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 )
 
@@ -31,6 +32,7 @@ func (s *Syncer) SyncAll(ctx context.Context) error {
 	s.warnOnHeightRegression(ctx)
 	s.backfillBlockTimes(ctx)
 	s.backfillTransactions(ctx)
+	s.backfillValopers(ctx)
 	if err := s.syncPackages(ctx); err != nil {
 		return fmt.Errorf("sync packages: %w", err)
 	}
@@ -390,6 +392,135 @@ func (s *Syncer) getLastRecentTransactionBlockHeight(ctx context.Context) (*int,
 	return &lastHeight, nil
 }
 
+// valopersMarker identifies the validator registration realm.
+//
+// Matched as a substring rather than a fixed path so a move between realms
+// (gnops → gov, or a versioned path) does not silently stop recording. The word
+// is specific enough that a false match is unlikely.
+const valopersMarker = "valopers"
+
+// looksLikeAddress reports whether s is a gno bech32 account address.
+func looksLikeAddress(s string) bool {
+	return strings.HasPrefix(s, "g1") && len(s) == 40
+}
+
+// valoperSubject reads the validator address and moniker out of a valopers call.
+//
+// The argument layout differs per function, and taking args[0] as the moniker —
+// which is what the frontend used to do — is right for exactly one of them:
+//
+//	Register(moniker, description, serverType, address, pubkey)
+//	UpdateMoniker(address, newMoniker)
+//	UpdateDescription(address, description)
+//	UpdateKeepRunning / UpdateServerType / UpdateSigningKey(address, value)
+//	DeleteFromAuthList(address, address)
+//
+// So for everything except Register and UpdateMoniker, args[0] is an address,
+// and the old code recorded addresses as names. It also keyed on the caller,
+// which is wrong twice over: Register carries the validator address in its
+// arguments, and an admin can update an entry that is not their own.
+//
+// moniker is empty when the call does not set a name — most of them do not.
+func valoperSubject(msg TxMessage) (address, moniker string) {
+	args := msg.Value.Args
+	switch msg.Value.Func {
+	case "Register":
+		if len(args) > 0 {
+			moniker = args[0]
+		}
+		// The address is an argument, but fall back to the caller for a shorter
+		// call than the current ABI.
+		if len(args) > 3 && looksLikeAddress(args[3]) {
+			address = args[3]
+		} else {
+			address = msg.Value.Caller
+		}
+	case "UpdateMoniker":
+		if len(args) > 1 {
+			moniker = args[1]
+		}
+		fallthrough
+	default:
+		if address == "" {
+			if len(args) > 0 && looksLikeAddress(args[0]) {
+				address = args[0]
+			} else {
+				address = msg.Value.Caller
+			}
+		}
+	}
+	return address, moniker
+}
+
+// recordValoper stores a validator registration when a call is one.
+//
+// Best effort: this feeds a display nicety, and losing one must not interrupt a
+// sync pass.
+func (s *Syncer) recordValoper(tx Transaction, msg TxMessage, blockTime string) {
+	if !strings.Contains(msg.Value.PkgPath, valopersMarker) {
+		return
+	}
+	address, moniker := valoperSubject(msg)
+	if address == "" {
+		return
+	}
+	if err := s.db.InsertValoperRegistration(
+		s.networkID, tx.Hash, tx.BlockHeight, blockTime,
+		msg.Value.Caller, msg.Value.Func, address, moniker, tx.Success,
+	); err != nil {
+		log.Printf("[%s] record valoper: %v", s.networkID, err)
+	}
+}
+
+// backfillValoperBatch bounds how many historical registrations are repaired per
+// pass. Each is one keyed request, and there are only ever a few hundred in
+// total, so this closes quickly.
+const backfillValoperBatch = 50
+
+// backfillValopers recovers monikers for valopers calls stored before
+// registrations were recorded.
+//
+// The call rows have everything except the moniker, which lives only in the
+// call's arguments. Those are recoverable one transaction at a time by hash,
+// which is a keyed lookup — unlike filtering all of history by pkg_path, which
+// costs ~30s on a busy chain however little it returns.
+func (s *Syncer) backfillValopers(ctx context.Context) {
+	hashes, err := s.db.ValoperCallsMissingRegistration(s.networkID, backfillValoperBatch)
+	if err != nil {
+		log.Printf("[%s] valoper backfill: %v", s.networkID, err)
+		return
+	}
+	if len(hashes) == 0 {
+		return
+	}
+
+	recorded := 0
+	for _, h := range hashes {
+		tx, err := s.client.GetTransactionByHash(ctx, h)
+		if err != nil {
+			// Keep what we have and retry the rest next pass.
+			log.Printf("[%s] valoper backfill: %v", s.networkID, err)
+			break
+		}
+		if tx == nil {
+			continue
+		}
+		for _, msg := range tx.Messages {
+			if msg.Value.Typename != "MsgCall" {
+				continue
+			}
+			if !strings.Contains(msg.Value.PkgPath, valopersMarker) {
+				continue
+			}
+			s.recordValoper(*tx, msg, tx.BlockTime)
+			recorded++
+		}
+	}
+	if recorded > 0 {
+		log.Printf("[%s] backfilled %d valoper registrations", s.networkID, recorded)
+	}
+}
+
 func (s *Syncer) syncCalls(ctx context.Context) error {
 	lastHeight, err := s.getLastRecentTransactionBlockHeight(ctx)
 	if err != nil {
@@ -418,6 +549,9 @@ func (s *Syncer) syncCalls(ctx context.Context) error {
 						continue
 					}
 					callCount++
+					// Args are available here and nowhere else — they are not
+					// stored on the call row. Capture the moniker while we have it.
+					s.recordValoper(tx, msg, bt)
 				case "BankMsgSend":
 					if err := s.db.InsertBankSend(
 						s.networkID,

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -336,3 +336,102 @@ func TestWalkTransactionsStopsWhenCaughtUp(t *testing.T) {
 		t.Errorf("processed %d pages while caught up, want 0", calls)
 	}
 }
+
+// valoperSubject decides which address a valopers call is about and whether it
+// sets a name. The argument layout differs per function, so every case here uses
+// arguments taken from real sapphire transactions.
+func TestValoperSubject(t *testing.T) {
+	const (
+		caller  = "g1qynsu9dwj9lq0m5fkje7jh6qy3md80ztqnshhm"
+		subject = "g1rw8av9eghy9h8vajktzk9d0wn2sd5d9ftwkhuf"
+	)
+
+	tests := []struct {
+		name        string
+		fn          string
+		args        []string
+		wantAddress string
+		wantMoniker string
+	}{
+		{
+			// Register(moniker, description, serverType, address, pubkey) — the one
+			// function where args[0] really is the name, and the address is args[3]
+			// rather than the caller.
+			name:        "Register takes the moniker first and the address fourth",
+			fn:          "Register",
+			args:        []string{"onbloc-val-01", "a long description", "cloud", subject, "gpub1..."},
+			wantAddress: subject,
+			wantMoniker: "onbloc-val-01",
+		},
+		{
+			name:        "UpdateMoniker takes the address first and the name second",
+			fn:          "UpdateMoniker",
+			args:        []string{subject, "delete"},
+			wantAddress: subject,
+			wantMoniker: "delete",
+		},
+		{
+			// The old code recorded this description's address as a moniker.
+			name:        "UpdateDescription sets no name",
+			fn:          "UpdateDescription",
+			args:        []string{subject, "Infra & Insights"},
+			wantAddress: subject,
+			wantMoniker: "",
+		},
+		{
+			name:        "UpdateKeepRunning sets no name",
+			fn:          "UpdateKeepRunning",
+			args:        []string{subject, "true"},
+			wantAddress: subject,
+			wantMoniker: "",
+		},
+		{
+			name:        "UpdateSigningKey sets no name",
+			fn:          "UpdateSigningKey",
+			args:        []string{subject, "gpub1..."},
+			wantAddress: subject,
+			wantMoniker: "",
+		},
+		{
+			name:        "a non-address first argument falls back to the caller",
+			fn:          "UpdateServerType",
+			args:        []string{"cloud"},
+			wantAddress: caller,
+			wantMoniker: "",
+		},
+		{
+			name:        "no arguments falls back to the caller",
+			fn:          "SomethingElse",
+			args:        nil,
+			wantAddress: caller,
+			wantMoniker: "",
+		},
+		{
+			// A Register shorter than the current ABI must still attribute the row.
+			name:        "Register without an address argument falls back to the caller",
+			fn:          "Register",
+			args:        []string{"solo"},
+			wantAddress: caller,
+			wantMoniker: "solo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := TxMessage{Value: MessageValue{
+				Typename: "MsgCall",
+				Caller:   caller,
+				PkgPath:  "gno.land/r/gnops/valopers",
+				Func:     tt.fn,
+				Args:     tt.args,
+			}}
+			address, moniker := valoperSubject(msg)
+			if address != tt.wantAddress {
+				t.Errorf("address = %q, want %q", address, tt.wantAddress)
+			}
+			if moniker != tt.wantMoniker {
+				t.Errorf("moniker = %q, want %q", moniker, tt.wantMoniker)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #78. `/api/validators` was returning 500 after 10s on sapphire; it now answers in **2 milliseconds**, and the monikers it serves are correct for the first time.

## Why it was broken

`GetTransactionsByPkgPath` filtered all of history by `pkg_path` on every request. That costs ~30s on a busy chain **regardless of what it returns** — the price is the scan over 642k transactions, not the payload. No window to shrink, no fields to trim.

`calls` already has everything the view needs except one thing: the moniker, which lives only in the call's arguments, and args are not stored.

## Storing args was the wrong trade

The obvious fix — add an `args` column to `calls` — means carrying every argument of every call to serve one display nicety. On sapphire that is 522k rows, and args are the bulk of what made `txFieldsLight` 45MB per 10k rows (see #74). One `UpdateDescription` argument in the wild is a 1,600-character markdown validator bio.

So: a `valoper_registrations` table instead. A few hundred rows, one index, populated as the syncer already walks every `MsgCall` — where args *are* in hand.

## The moniker was wrong before, and it is worth being precise about why

The frontend did `_valMonikers[msg.value.caller] = msg.value.args[0]`. I went and read the actual arguments of every valopers function on sapphire:

```
Register(moniker, description, serverType, address, pubkey)
UpdateMoniker(address, newMoniker)
UpdateDescription(address, description)
UpdateKeepRunning / UpdateServerType / UpdateSigningKey(address, value)
DeleteFromAuthList(address, address)
```

`args[0]` is the moniker for **one** of seven functions. For the rest it is an address — so the old code was recording addresses as validator names. On sapphire, where the traffic is overwhelmingly `UpdateDescription`, essentially every "moniker" was the address.

And the key was wrong too: `Register` carries the validator's address at `args[3]`, not in `caller`, and an admin can update an entry that is not their own.

`valoperSubject` now reads both per function, and stores an empty moniker when the call does not set a name — which most do not.

## Measured against a copy of the production database

```
total rows:                        160
with a real moniker:                95
moniker == address (the old bug):    0

gnoland1  Register  g168x59yty3asqw853e6xwnc6u4wequ9lx5w0v2k  ->  BonyNode
gnoland1  Register  g15804zy06zp2mcg5r7wguxke9askqssy3hr0htw  ->  gnocore-val-01
sapphire  Register  g16l8m9wrtjsa8m3563trduja5m5n7accfmgn8zx  ->  ProMEX Hub Gnoland
gnoland1  Register  g1pslde6zthl8crd3970rd6xz5rgxjgasenu3svu  ->  PRO Delegators
gnoland1  Register  g1vl79vskhqwpmex8g2d5tpu9vrcm0fy9fv7exck  ->  KalpaTech
sapphire  Register  g1uhw04e2ehj66wfp5pkngejjcwmxf3ef0hzt23v  ->  BlockPro
```

| | before | after |
| --- | --- | --- |
| `/api/validators?network=sapphire` | **500** @ 10.0s | 200 @ **0.002s** |
| `/api/validators?network=gnoland1` | 200 @ 0.31s | 200 @ 0.0008s |

Block proposers in the blocks view get real names instead of `g1…`, which is what `loadValMonikers` was for all along.

## Backfilling history

Rows written before this table existed have no moniker, and it cannot be recomputed locally — args were never stored. But the `calls` table knows *which* transactions to ask about, and fetching by hash is a keyed lookup rather than a scan.

`backfillValopers` repairs 50 per sync pass. On the production snapshot it closed all 160 in four passes (~2 minutes), then went quiet. Bounded, resumable, and it stops on the first indexer error so a bad pass retries rather than hammering.

## Also

- `GetTransactionsByPkgPath` is **removed** — it had no callers left, and it was the last of the unbounded full-history filters that #78's audit turned up.
- The realm matcher is `strings.Contains(pkgPath, "valopers")` rather than the previously hardcoded `gno.land/r/gnops/valopers`, so a move between realms or a versioned path does not silently stop recording. The production data has calls to `gno.land/r/gnops/valopers` on three networks; a versioned path would have been missed.

## Tests

- `TestValoperSubject` — eight cases, every argument list taken from a real sapphire transaction: `Register` reading moniker-first and address-fourth, `UpdateMoniker` reading address-first, the four functions that set no name, and the fallbacks when the first argument is not an address or there are no arguments at all.
- `TestValoperRegistrations` — ordering (newest first), network scoping via the configured set, and that re-registering replaces rather than duplicates.
- `TestValoperCallsMissingRegistration` — the backfill work list picks up valopers calls across differently-named realms, ignores unrelated ones, and drops a call once it has been recorded.

`gofmt`/`go vet`/`go test ./...` clean.
