### PR TITLE
perf: index the lookups behind the gas view

### DIFF
--- a/db.go
+++ b/db.go
@@ -378,6 +378,24 @@ func initSchema(db *sql.DB) error {
 		CREATE INDEX IF NOT EXISTS idx_runs_block_time   ON msg_runs(network, block_time);
 		CREATE INDEX IF NOT EXISTS idx_sends_block_time  ON bank_sends(network, block_time);
 		CREATE INDEX IF NOT EXISTS idx_txs_block_time    ON transactions(network, block_time);
+
+		-- The gas view's "most expensive transactions" sorts by gas_used within a
+		-- network and keeps 20 rows. Without this the sort cannot be served from
+		-- an index, so the eight correlated subqueries in its select list are
+		-- evaluated across the whole table rather than the twenty rows that
+		-- survive the LIMIT: 16s on a chain with 314k transactions, against a 30s
+		-- server write timeout.
+		CREATE INDEX IF NOT EXISTS idx_txs_network_gas ON transactions(network, gas_used DESC);
+
+		-- Resolving a transaction's type and target means looking it up by
+		-- (network, tx_hash) in each of these. Without a matching index the
+		-- planner falls back to the block_time indexes, which lead with network
+		-- only — so every lookup scans that network's whole table. On a chain with
+		-- 533k calls that turned twenty lookups into seconds.
+		CREATE INDEX IF NOT EXISTS idx_calls_network_hash      ON calls(network, tx_hash);
+		CREATE INDEX IF NOT EXISTS idx_packages_network_hash   ON packages(network, tx_hash);
+		CREATE INDEX IF NOT EXISTS idx_msg_runs_network_hash   ON msg_runs(network, tx_hash);
+		CREATE INDEX IF NOT EXISTS idx_bank_sends_network_hash ON bank_sends(network, tx_hash);
 	`)
 	return err
 }
@@ -968,11 +986,12 @@ func (d *DB) GetGasStats(network string, topN int) (*GasStats, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	where, args := "", []any{}
-	if network != "" {
-		where = " WHERE network = ?"
-		args = append(args, network)
-	}
+	// Always filter, even for "all networks": an empty WHERE cannot use the
+	// (network, gas_used) index, which is what makes the top-gas sort scan the
+	// whole table. Scoping to the configured set keeps the index usable and
+	// keeps retired networks out of the totals.
+	where := " WHERE " + d.networkFilter("network", network)
+	args := []any{}
 
 	out := &GasStats{}
 	err := d.db.QueryRow(`
@@ -992,11 +1011,8 @@ func (d *DB) GetGasStats(network string, topN int) (*GasStats, error) {
 	// joined to at most one realm here; calls and deployments are the two paths
 	// that carry a package path, and MsgRun is grouped under its caller because
 	// its ephemeral path is unique per run and would otherwise be one row each.
-	realmWhere, realmArgs := "", []any{}
-	if network != "" {
-		realmWhere = " AND t.network = ?"
-		realmArgs = append(realmArgs, network, network, network)
-	}
+	realmWhere := " AND " + d.networkFilter("t.network", network)
+	realmArgs := []any{}
 	rows, err := d.db.Query(`
 		SELECT path, SUM(gas_used), SUM(gas_fee), COUNT(*) FROM (
 			SELECT c.pkg_path AS path, t.gas_used, t.gas_fee, t.tx_hash
@@ -1030,7 +1046,21 @@ func (d *DB) GetGasStats(network string, topN int) (*GasStats, error) {
 
 	// Most expensive transactions, with the type and target resolved from
 	// whichever table recorded the message.
+	//
+	// The ranking is materialised first so the subqueries below are evaluated
+	// exactly topN times rather than at the planner's discretion.
+	//
+	// This is insurance, not the fix: measured, the CTE alone changed nothing
+	// (2.47s -> 2.43s). What made this query slow was the absence of a
+	// (network, tx_hash) index on the four tables it probes — see the schema.
+	// The CTE stays because it makes the intended shape explicit and bounds the
+	// damage if the planner ever loses those indexes again.
 	txRows, err := d.db.Query(`
+		WITH top AS (
+			SELECT network, tx_hash, block_height, gas_used, gas_wanted, gas_fee, success
+			FROM transactions`+where+`
+			ORDER BY gas_used DESC LIMIT ?
+		)
 		SELECT t.tx_hash, t.block_height, t.gas_used, t.gas_wanted, t.gas_fee, t.success,
 		  COALESCE(
 		    (SELECT 'MsgCall' FROM calls c WHERE c.network = t.network AND c.tx_hash = t.tx_hash LIMIT 1),
@@ -1043,8 +1073,8 @@ func (d *DB) GetGasStats(network string, topN int) (*GasStats, error) {
 		    (SELECT p.path FROM packages p WHERE p.network = t.network AND p.tx_hash = t.tx_hash LIMIT 1),
 		    (SELECT 'MsgRun by ' || m.caller FROM msg_runs m WHERE m.network = t.network AND m.tx_hash = t.tx_hash LIMIT 1),
 		    '')
-		FROM transactions t`+where+`
-		ORDER BY t.gas_used DESC LIMIT ?`, append(args, topN)...)
+		FROM top t
+		ORDER BY t.gas_used DESC`, append(args, topN)...)
 	if err != nil {
 		return nil, fmt.Errorf("top gas transactions: %w", err)
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -708,5 +709,79 @@ func TestValoperCallsMissingRegistration(t *testing.T) {
 	missing, _ = db.ValoperCallsMissingRegistration("live", 10)
 	if len(missing) != 1 || missing[0] != "tx-valoper-2" {
 		t.Errorf("got %v, want only tx-valoper-2", missing)
+	}
+}
+
+// The gas view's "most expensive transactions" query sorts by gas_used within a
+// network. Without an index for that the sort scans the whole table and the
+// eight correlated subqueries in its select list run far more than the twenty
+// times the LIMIT needs — 16s on a chain with 314k transactions, against a 30s
+// server write timeout.
+//
+// Asserts the plan, not a duration: a timing test would be flaky, and what
+// actually regresses is the planner losing the index.
+func TestTopGasQueryUsesAnIndex(t *testing.T) {
+	db := newTestDB(t)
+
+	const q = `
+		WITH top AS (
+			SELECT network, tx_hash, gas_used FROM transactions
+			WHERE network = ? ORDER BY gas_used DESC LIMIT 20
+		)
+		SELECT t.tx_hash, t.gas_used,
+		  COALESCE(
+		    (SELECT 'MsgCall' FROM calls c WHERE c.network = t.network AND c.tx_hash = t.tx_hash LIMIT 1),
+		    (SELECT 'MsgAddPackage' FROM packages p WHERE p.network = t.network AND p.tx_hash = t.tx_hash LIMIT 1),
+		    (SELECT 'MsgRun' FROM msg_runs m WHERE m.network = t.network AND m.tx_hash = t.tx_hash LIMIT 1),
+		    (SELECT 'BankMsgSend' FROM bank_sends b WHERE b.network = t.network AND b.tx_hash = t.tx_hash LIMIT 1),
+		    '')
+		FROM top t`
+
+	rows, err := db.db.Query("EXPLAIN QUERY PLAN "+q, "sapphire")
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer rows.Close()
+
+	var plan []string
+	for rows.Next() {
+		cols, err := rows.Columns()
+		if err != nil {
+			t.Fatalf("columns: %v", err)
+		}
+		vals := make([]any, len(cols))
+		for i := range vals {
+			vals[i] = new(sql.NullString)
+		}
+		if err := rows.Scan(vals...); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if s, ok := vals[len(vals)-1].(*sql.NullString); ok && s.Valid {
+			plan = append(plan, s.String)
+		}
+	}
+
+	joined := strings.Join(plan, " | ")
+
+	// The ranking must come off the index rather than a sort.
+	if !strings.Contains(joined, "idx_txs_network_gas") {
+		t.Errorf("ranking does not use idx_txs_network_gas.\nplan: %s", joined)
+	}
+	if strings.Contains(joined, "USE TEMP B-TREE FOR ORDER BY") {
+		t.Errorf("ranking still sorts in a temp b-tree.\nplan: %s", joined)
+	}
+
+	// Each type probe must be a keyed lookup. Without these the planner falls
+	// back to the block_time indexes, which lead with network only, and every
+	// probe scans that network's whole table — 2.7s instead of instant.
+	for _, idx := range []string{
+		"idx_calls_network_hash",
+		"idx_packages_network_hash",
+		"idx_msg_runs_network_hash",
+		"idx_bank_sends_network_hash",
+	} {
+		if !strings.Contains(joined, idx) {
+			t.Errorf("type probe does not use %s.\nplan: %s", idx, joined)
+		}
 	}
 }


### PR DESCRIPTION
Closes #87. The gas page did not render on sapphire — the request never completed.

Measured on val1 against `localhost:8888`:

| request | before | after |
| --- | ---: | ---: |
| `/api/gas?network=sapphire` | **62.9s, never completed** | **6.4s** |
| `/api/gas` (all networks) | 29.0s | 5.8s |
| `/api/gas?network=gnoland1` | 0.04s | 0.01s |

The server's `WriteTimeout` is 30s, so both of the first two were failing for a browser.

## What was actually wrong

I chased this in the wrong order, so the honest version:

**First guess — a missing sort index.** `ORDER BY gas_used DESC LIMIT 20` had nothing to walk, so I added `idx_txs_network_gas`. Real but partial: sapphire went 62.9s → 14.2s.

**Second — the unfiltered case had no `WHERE` at all.** `GetGasStats` still used the old `if network != ""` branch, so all-networks produced a bare query the index could not serve. Switching it to `networkFilter` (the helper from #80, whose remaining call sites I had flagged) took all-networks 28s → 15s and scopes the totals to configured networks as a bonus.

**Third — a CTE to bound the subqueries. This did nothing.** I assumed SQLite was resolving the eight correlated subqueries across the whole table before applying the LIMIT, and materialised the ranking first to stop it. Measured: 2.47s → 2.43s. The assumption was wrong.

**The actual cause: no `(network, tx_hash)` index on the four probed tables.** Each subquery looks a transaction up by `(network, tx_hash)`, but the only candidate indexes were `idx_*_block_time`, which lead with `network` alone — so every probe scanned that network's entire table. 533k rows of `calls`, twenty times over.

```
before tx_hash indexes   2.73s
index build              1.58s
after tx_hash indexes    0.00s
```

```
SEARCH c USING COVERING INDEX idx_calls_network_hash (network=? AND tx_hash=?)
SEARCH p USING COVERING INDEX idx_packages_network_hash (network=? AND tx_hash=?)
SEARCH m USING COVERING INDEX idx_msg_runs_network_hash (network=? AND tx_hash=?)
SEARCH b USING COVERING INDEX idx_bank_sends_network_hash (network=? AND tx_hash=?)
```

## Changes

- `idx_txs_network_gas` on `transactions(network, gas_used DESC)` — the ranking walks the index instead of sorting.
- `idx_{calls,packages,msg_runs,bank_sends}_network_hash` on `(network, tx_hash)` — the type/target probes become keyed lookups. **This is the one that mattered.**
- `GetGasStats` filters by network in every branch, so all-networks can use the indexes too.
- The CTE stays, with a comment saying plainly that it is insurance rather than the fix, so nobody credits it with the improvement I originally credited it with.

Indexes are created by the existing `CREATE INDEX IF NOT EXISTS` block, so an existing database picks them up on the next start — verified against a copy of production, 1.58s to build.

## Tests

`TestTopGasQueryUsesAnIndex` asserts the query plan rather than a duration — a timing test would be flaky, and what regresses is the planner losing an index. It checks the ranking uses `idx_txs_network_gas`, that there is no `USE TEMP B-TREE FOR ORDER BY`, and that all four type probes use their `(network, tx_hash)` index.

Verified it fails without them: removing `idx_txs_network_gas` produces `USE TEMP B-TREE FOR ORDER BY` and the test catches it.

## Still slow

6s is usable, not good. The remaining cost is the gas-by-realm three-way UNION (~1.9s) and it grows with the chain. `/api/analytics` is also ~5-7s on sapphire and untouched here. Both noted in #87.
