### PR TITLE
feat: add fee, efficiency, outcome and realm charts to the gas view

### DIFF
--- a/db.go
+++ b/db.go
@@ -2228,6 +2228,8 @@ type GasTimePoint struct {
 	AvgGasUsed     int     `json:"avg_gas_used"`
 	GasEfficiency  float64 `json:"gas_efficiency"`
 	AvgFee         int     `json:"avg_fee"`
+	SuccessCount   int     `json:"success_count"`
+	FailCount      int     `json:"fail_count"`
 }
 
 type SanityOverview struct {
@@ -2267,26 +2269,23 @@ func (d *DB) GetGasTimeSeries(network, granularity string, days int) ([]GasTimeP
 	sqlFmt, step, truncFn := timeseriesFormat(granularity)
 	startTime := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
 
-	netFilter := ""
-	if network != "" {
-		netFilter = " AND t.network = ?"
-	}
+	// Always scoped, so a retired network cannot show up in the series and the
+	// (network, ...) indexes stay usable for the all-networks case.
+	netFilter := " AND " + d.networkFilter("t.network", network)
 
 	q := fmt.Sprintf(
 		"SELECT strftime('%s', t.block_time) as bucket,"+
 			" SUM(t.gas_used) as total_gas_used,"+
 			" SUM(t.gas_wanted) as total_gas_wanted,"+
 			" SUM(t.gas_fee) as total_fees,"+
-			" COUNT(*) as tx_count"+
+			" COUNT(*) as tx_count,"+
+			" SUM(CASE WHEN t.success THEN 1 ELSE 0 END) as success_count"+
 			" FROM transactions t"+
 			" WHERE t.block_time >= ?%s"+
 			" GROUP BY bucket ORDER BY bucket ASC",
 		sqlFmt, netFilter)
 
 	args := []any{startTime}
-	if network != "" {
-		args = append(args, network)
-	}
 
 	rows, err := d.db.Query(q, args...)
 	if err != nil {
@@ -2300,11 +2299,12 @@ func (d *DB) GetGasTimeSeries(network, granularity string, days int) ([]GasTimeP
 		totalGasWanted int
 		totalFees      int
 		txCount        int
+		successCount   int
 	}
 	buckets := make(map[string]*row)
 	for rows.Next() {
 		var r row
-		if err := rows.Scan(&r.bucket, &r.totalGasUsed, &r.totalGasWanted, &r.totalFees, &r.txCount); err != nil {
+		if err := rows.Scan(&r.bucket, &r.totalGasUsed, &r.totalGasWanted, &r.totalFees, &r.txCount, &r.successCount); err != nil {
 			return nil, err
 		}
 		buckets[r.bucket] = &r
@@ -2339,6 +2339,8 @@ func (d *DB) GetGasTimeSeries(network, granularity string, days int) ([]GasTimeP
 				AvgGasUsed:     avg,
 				GasEfficiency:  eff,
 				AvgFee:         avgFee,
+				SuccessCount:   r.successCount,
+				FailCount:      r.txCount - r.successCount,
 			})
 		} else {
 			out = append(out, GasTimePoint{Time: k})

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -129,9 +129,11 @@ footer a:hover { color: var(--accent); }
 .network-select:focus { border-color: var(--accent); }
 /* Network badges */
 .net-badge { display: inline-block; padding: 1px 5px; border-radius: 2px; font-size: 10px; font-weight: bold; margin-left: 4px; vertical-align: middle; }
-.net-gnoland1 { background: rgba(78,205,196,0.12); color: var(--accent); border: 1px solid rgba(78,205,196,0.25); }
-.net-test12 { background: rgba(177,148,255,0.12); color: #b194ff; border: 1px solid rgba(177,148,255,0.25); }
-.net-default { background: rgba(136,136,136,0.12); color: var(--fg2); border: 1px solid rgba(136,136,136,0.25); }
+/* Colours come from netColor() at render time, so a network added to the config
+   needs no CSS. The old per-id classes only covered gnoland1 and test12, which
+   left sapphire and staging unstyled. */
+.net-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 6px; vertical-align: middle; flex-shrink: 0; }
+.net-swatch { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 6px; vertical-align: middle; }
 /* Live mode */
 .live-btn { background: var(--bg2); border: 1px solid var(--border); color: var(--fg2); padding: 4px 10px; border-radius: 4px; font-family: var(--mono); font-size: 12px; cursor: pointer; display: flex; align-items: center; gap: 6px; }
 .live-btn:hover { border-color: var(--accent); }
@@ -173,7 +175,7 @@ footer a:hover { color: var(--accent); }
       <input type="text" id="search-input" placeholder="search...">
       <div id="search-results"></div>
     </div>
-    <select class="network-select" id="network-select" onchange="onNetworkChange()"></select>
+    <span class="net-swatch" id="network-swatch" title=""></span><select class="network-select" id="network-select" onchange="onNetworkChange()"></select>
     <button class="live-btn" id="live-toggle" onclick="toggleLive()"><span class="live-dot"></span><span id="live-label"> live</span></button>
   </div>
 </header>
@@ -622,17 +624,74 @@ function onNetworkChange() {
   const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
   history.replaceState(null, '', newUrl);
   renderFooterIndexer();
+  renderNetworkSwatch();
   route();
+}
+// One colour per network, derived rather than hardcoded so a network added to
+// the config is styled without touching CSS. Assigned by position in the
+// configured list, which makes the colours distinct by construction; ids no
+// longer in the config fall back to a hash so they stay stable rather than
+// shifting every render.
+const NET_PALETTE = ['#4ecdc4', '#b194ff', '#ffd43b', '#ff8787', '#63b3ed', '#9ae6b4', '#f6ad55', '#f687b3'];
+function netColor(id) {
+  if (!id) return 'var(--fg2)';
+  const i = _networks.findIndex(n => n.id === id);
+  if (i >= 0) return NET_PALETTE[i % NET_PALETTE.length];
+  let h = 0;
+  for (let k = 0; k < id.length; k++) h = (h * 31 + id.charCodeAt(k)) >>> 0;
+  return NET_PALETTE[h % NET_PALETTE.length];
 }
 function netBadgeEl(networkId) {
   if (!networkId) return document.createTextNode('');
   // Redundant when one network is selected: everything on screen belongs to it.
   if (getNetwork() !== 'all') return document.createTextNode('');
   const span = document.createElement('span');
-  span.className = 'net-badge net-' + networkId;
+  span.className = 'net-badge';
+  const c = netColor(networkId);
+  span.style.color = c;
+  span.style.border = '1px solid ' + c + '40';
+  span.style.background = c + '1f';
   span.textContent = networkId;
   span.setAttribute('data-hl', 'net:' + networkId);
   return span;
+}
+// A dot carries the network without spending a column, so tables keep their
+// shape when a single network is selected and the dot disappears.
+function netDotEl(networkId) {
+  if (!networkId || getNetwork() !== 'all') return document.createTextNode('');
+  const dot = document.createElement('span');
+  dot.className = 'net-dot';
+  dot.style.background = netColor(networkId);
+  dot.title = networkId;
+  dot.setAttribute('data-hl', 'net:' + networkId);
+  return dot;
+}
+// netRow is el('tr', ...) with its network marked by a leading dot in the first
+// cell. Use it anywhere rows from several chains can be interleaved.
+function netRow(networkId, ...cells) {
+  const tr = el('tr', {}, ...cells);
+  const first = tr.firstChild;
+  if (first && networkId && getNetwork() === 'all') {
+    first.insertBefore(netDotEl(networkId), first.firstChild);
+  }
+  return tr;
+}
+// The swatch shows the selected network's colour next to the picker. Option
+// colours are honoured inconsistently across browsers; this is not.
+function renderNetworkSwatch() {
+  const sw = document.getElementById('network-swatch');
+  if (!sw) return;
+  const net = getNetwork();
+  if (!net || net === 'all') {
+    // No single colour applies, so show the palette rather than picking one.
+    const stops = _networks.map((n, i) => netColor(n.id) + ' ' + (i * 100 / Math.max(_networks.length, 1)) + '%, '
+      + netColor(n.id) + ' ' + ((i + 1) * 100 / Math.max(_networks.length, 1)) + '%').join(', ');
+    sw.style.background = _networks.length ? 'linear-gradient(90deg, ' + stops + ')' : 'var(--fg2)';
+    sw.title = 'all networks';
+    return;
+  }
+  sw.style.background = netColor(net);
+  sw.title = net;
 }
 function netSuffix(n) {
   const net = (n !== undefined ? n : null) || getNetwork();
@@ -650,10 +709,14 @@ async function initNetworkSelector() {
     sel.appendChild(all);
     for (const n of nets) {
       const opt = document.createElement('option');
-      opt.value = n.id; opt.textContent = n.id;
+      opt.value = n.id;
+      // The bullet survives browsers that ignore option colours.
+      opt.textContent = '\u25CF ' + n.id;
+      opt.style.color = netColor(n.id);
       sel.appendChild(opt);
     }
     sel.value = getNetwork();
+    renderNetworkSwatch();
     renderFooterIndexer();
   } catch(e) { console.error('network selector:', e); }
 }
@@ -1053,7 +1116,7 @@ async function loadHome() {
     for (const b of (Array.isArray(blocksData) ? blocksData : [])) blockTime[b.height] = b.time;
     const tbody = clear('latest-realms');
     for (const r of (realmsData?.items || [])) {
-      tbody.appendChild(el('tr', {},
+      tbody.appendChild(netRow(r.network,
         el('td', {}, realmPathEl(r.path, r.network)),
         el('td', {}, addrLink(r.creator)),
         el('td', {}, String(r.num_files)),
@@ -1064,7 +1127,7 @@ async function loadHome() {
     for (const tx of (txsData?.items || [])) {
       const msg = tx.messages?.[0];
       const when = tx.block_time ? timeEl(tx.block_time) : blockTime[tx.block_height] ? timeEl(blockTime[tx.block_height]) : (tx.block_height === 0 ? 'genesis' : '');
-      txBody.appendChild(el('tr', {},
+      txBody.appendChild(netRow(tx.network,
         el('td', {}, blockLink(tx.block_height, tx.network)),
         el('td', {}, typeBadge(msg?.value?.__typename)),
         el('td', {}, txDetailEl(msg)),
@@ -1101,7 +1164,7 @@ async function loadRealms(page) {
     }
     const list = clear('realms-list');
     for (const r of (data.items || [])) {
-      list.appendChild(el('tr', {},
+      list.appendChild(netRow(r.network,
         el('td', {}, realmPathEl(r.path, r.network)),
         el('td', {}, addrLink(r.creator)),
         el('td', {}, countCell(r.calls)),
@@ -1129,7 +1192,7 @@ async function loadPackages(page) {
     }
     const list = clear('packages-list');
     for (const p of (data.items || [])) {
-      list.appendChild(el('tr', {},
+      list.appendChild(netRow(p.network,
         el('td', {}, realmPathEl(p.path, p.network)),
         el('td', {}, addrLink(p.creator)),
         el('td', {}, blockLink(p.block_height, p.network)), el('td', {}, String(p.num_files))
@@ -1241,7 +1304,7 @@ function renderTxRows() {
   }
   for (const tx of page) {
     const msg = tx.messages?.[0];
-    list.appendChild(el('tr', {},
+    list.appendChild(netRow(tx.network,
       el('td', {}, txLink(tx.hash, tx.block_height, tx.network)),
       el('td', {}, blockLink(tx.block_height, tx.network)),
       el('td', {}, typeBadge(msg?.value?.__typename)),
@@ -1293,7 +1356,7 @@ function renderBlockRows() {
   for (const b of (_blocksCache || [])) {
     if (_blocksWithTxsOnly && b.num_txs === 0) continue;
     count++;
-    tbody.appendChild(el('tr', {},
+    tbody.appendChild(netRow(b.network,
       el('td', {}, blockLink(b.height, b.network)),
       el('td', {}, timeEl(b.time)),
       el('td', { style: b.num_txs === 0 ? { color: 'var(--fg2)' } : {} }, String(b.num_txs)),

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1017,10 +1017,18 @@ async function renderStorageChart(container, realm) {
 }
 
 let _gasChartInstances = [];
+// The realm breakdown is rebuilt from the /api/gas payload rather than the time
+// series, so it has its own lifecycle and must not be torn down when the period
+// buttons re-render the series.
+let _gasRealmChart = [];
+
+function destroyChartList(list) {
+  list.forEach(c => c.destroy());
+  list.length = 0;
+}
 
 function destroyGasCharts() {
-  _gasChartInstances.forEach(c => c.destroy());
-  _gasChartInstances = [];
+  destroyChartList(_gasChartInstances);
 }
 
 async function renderGasCharts(container) {
@@ -1091,6 +1099,106 @@ async function renderGasCharts(container) {
         x: scaleOpts.x,
         y:  { ...scaleOpts.y, position: 'left',  title: { display: true, text: 'avg gas', color: '#888' } },
         y2: { ...scaleOpts.y, position: 'right', title: { display: true, text: 'tx count', color: '#888' }, grid: { drawOnChartArea: false } }
+      }
+    }
+  }));
+
+  // Fees paid per period, with the average per transaction on a second axis.
+  // Volume and unit price move independently: a fee total can climb purely
+  // because the chain got busier, and this separates the two.
+  const feesCanvas = makeCanvas();
+  _gasChartInstances.push(new Chart(feesCanvas, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        { label: 'total fees (ugnot)', data: data.map(p => p.total_fees), backgroundColor: 'rgba(255,212,59,0.5)', borderColor: '#ffd43b', borderWidth: 1, yAxisID: 'y', order: 2 },
+        { label: 'avg fee/tx', type: 'line', data: data.map(p => p.avg_fee), borderColor: '#ff8787', backgroundColor: 'transparent', tension: 0.3, yAxisID: 'y2', order: 1 },
+      ]
+    },
+    options: {
+      ...commonOpts,
+      plugins: { ...commonOpts.plugins, title: { display: true, text: 'fees paid', color: '#888' } },
+      scales: {
+        x: scaleOpts.x,
+        y:  { ...scaleOpts.y, position: 'left',  title: { display: true, text: 'total ugnot', color: '#888' } },
+        y2: { ...scaleOpts.y, position: 'right', title: { display: true, text: 'avg/tx', color: '#888' }, grid: { drawOnChartArea: false } }
+      }
+    }
+  }));
+
+  // How much of the gas each transaction reserved it actually burned. Low
+  // efficiency means callers are over-estimating and overpaying.
+  const effCanvas = makeCanvas();
+  _gasChartInstances.push(new Chart(effCanvas, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{
+        label: 'gas efficiency',
+        data: data.map(p => p.gas_efficiency > 0 ? +(p.gas_efficiency * 100).toFixed(1) : null),
+        borderColor: '#b194ff', backgroundColor: 'rgba(177,148,255,0.10)', tension: 0.3, fill: true, spanGaps: true
+      }]
+    },
+    options: {
+      ...commonOpts,
+      plugins: {
+        ...commonOpts.plugins,
+        title: { display: true, text: 'gas efficiency (used / wanted)', color: '#888' },
+        tooltip: { callbacks: { label: c => ' ' + c.parsed.y + '%' } }
+      },
+      scales: { x: scaleOpts.x, y: { ...scaleOpts.y, max: 100, ticks: { ...scaleOpts.y.ticks, callback: v => v + '%' } } }
+    }
+  }));
+
+  // Successes and failures stacked, so the bar height is throughput and the red
+  // band is the failure rate — both readable at once.
+  const okCanvas = makeCanvas();
+  _gasChartInstances.push(new Chart(okCanvas, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        { label: 'success', data: data.map(p => p.success_count), backgroundColor: 'rgba(78,205,196,0.6)', borderColor: '#4ecdc4', borderWidth: 1, stack: 's' },
+        { label: 'failed',  data: data.map(p => p.fail_count),    backgroundColor: 'rgba(255,135,135,0.7)', borderColor: '#ff8787', borderWidth: 1, stack: 's' },
+      ]
+    },
+    options: {
+      ...commonOpts,
+      plugins: { ...commonOpts.plugins, title: { display: true, text: 'transactions by outcome', color: '#888' } },
+      scales: { x: { ...scaleOpts.x, stacked: true }, y: { ...scaleOpts.y, stacked: true } }
+    }
+  }));
+}
+
+// Horizontal bars for the realms burning the most gas. The table below carries
+// the exact figures; this is for seeing the shape of the distribution — whether
+// one realm dominates or the load is spread.
+function renderTopRealmsChart(container, realms) {
+  destroyChartList(_gasRealmChart);
+  container.textContent = '';
+  const top = (realms || []).slice(0, 12);
+  if (!top.length) return;
+
+  const wrap = el('div', { style: { position: 'relative', height: Math.max(180, top.length * 26) + 'px' } });
+  const canvas = document.createElement('canvas');
+  wrap.appendChild(canvas);
+  container.appendChild(wrap);
+
+  const shortLabel = p => (p || '').replace('gno.land/', '').replace(/^MsgRun by /, 'run:');
+  _gasRealmChart.push(new Chart(canvas, {
+    type: 'bar',
+    data: {
+      labels: top.map(r => shortLabel(r.path)),
+      datasets: [{ label: 'gas used', data: top.map(r => r.gas), backgroundColor: 'rgba(78,205,196,0.55)', borderColor: '#4ecdc4', borderWidth: 1 }]
+    },
+    options: {
+      indexAxis: 'y',
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false }, title: { display: true, text: 'gas by realm', color: '#888' } },
+      scales: {
+        x: { ticks: { color: '#888' }, grid: { color: '#2a2a2a' }, beginAtZero: true },
+        y: { ticks: { color: '#888', font: { size: 10 } }, grid: { display: false } }
       }
     }
   }));
@@ -2105,8 +2213,11 @@ async function loadGas() {
     container.appendChild(gasSection);
     renderGasCharts(gasChartsDiv);
 
-    // Top realms by gas
+    // Top realms by gas — chart first for the shape, table under it for figures.
     container.appendChild(el('div', { className: 'section-title', style: { marginTop: '24px' } }, 'top realms by gas usage'));
+    const realmChartDiv = el('div', { style: { marginBottom: '16px' } });
+    container.appendChild(realmChartDiv);
+    renderTopRealmsChart(realmChartDiv, data.top_realms);
     const rtbl = el('table');
     rtbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'realm'), el('th', {}, 'gas used'), el('th', {}, 'fees (ugnot)'), el('th', {}, 'txs'), el('th', {}, 'avg gas/tx'))));
     const rbody = el('tbody');


### PR DESCRIPTION
The gas view had two charts. It now has six, mostly from data the API was already computing and throwing away.

`/api/timeseries/gas` returned seven metrics; four were drawn. `total_fees`, `gas_efficiency` and `avg_fee` were calculated per bucket, serialised, and never rendered.

## The new charts

**Fees paid** — `total_fees` as bars with `avg_fee` as a line on a second axis. Volume and unit price move independently: a fee total can climb purely because the chain got busier, and one axis cannot show both.

**Gas efficiency** — `gas_efficiency` as a percentage, capped at 100%. This is used ÷ wanted: how much of the gas each transaction reserved it actually burned. A low line means callers are over-estimating and overpaying, which is not visible anywhere else in the app.

**Transactions by outcome** — successes and failures stacked, so the bar height reads as throughput and the red band reads as the failure rate. This one needed a new field.

**Gas by realm** — horizontal bars over the top 12. The table underneath already carried the exact figures; the chart is for the shape, whether one realm dominates or the load is spread. Paths are shortened (`gno.land/` stripped, `MsgRun by …` → `run:…`) so the labels fit.

## Backend

`GetGasTimeSeries` now also selects `SUM(CASE WHEN t.success THEN 1 ELSE 0 END)`, and `GasTimePoint` carries `success_count` / `fail_count`. One extra aggregate over rows already being scanned.

While in there, its network filter moved to `networkFilter` — it was another of the `if network != ""` sites flagged in #80, so the all-networks series was unscoped and could not use the `(network, …)` indexes. Now it is scoped and a retired network cannot appear in the series.

Verified against the production data copy:

```
buckets: 14 | non-empty: 7
2026-W23 txs=1  ok=1  fail=0  fees=2058     eff=0.91
2026-W25 txs=2  ok=1  fail=1  fees=2000000  eff=0.30
2026-W29 txs=8  ok=0  fail=8  fees=8000000  eff=0.02
```

That last row is the sort of thing the outcome chart exists to surface: a week where every transaction failed.

## Chart lifecycle

The realm chart is built from the `/api/gas` payload, not the time series, so it gets its own instance list. The period and granularity buttons re-render only the series; without the split they would have destroyed the realm chart and left a dead canvas.

Checked by driving the buttons: switching to 90d then weekly leaves **6 canvases with 6 live Chart instances** — no leak, nothing orphaned. No console errors.

```
total gas per period        [bar]  gas used: 9 non-zero, gas wanted: 9
avg gas / tx count          [line] avg gas/tx: 9, tx count: 9
fees paid                   [bar]  total fees: 9, avg fee/tx: 9
gas efficiency              [line] gas efficiency: 9
transactions by outcome     [bar]  success: 8, failed: 2
gas by realm                [bar]  gas used: 12
```

## Not here

These are single-series charts; in all-networks mode they still blend chains, which is the aggregate question in #86. Stacking them by network using `netColor` from #89 is the natural next step and is where the "aggregate that does not lie" lands — the colours and the split already exist, the time series just needs to return per-network buckets.
