### PR TITLE
feat: split the gas series per network in all-networks mode

### DIFF
--- a/db.go
+++ b/db.go
@@ -2230,6 +2230,23 @@ type GasTimePoint struct {
 	AvgFee         int     `json:"avg_fee"`
 	SuccessCount   int     `json:"success_count"`
 	FailCount      int     `json:"fail_count"`
+
+	// ByNetwork splits the same bucket per chain, and is only populated in
+	// all-networks mode. Fees are denominated per chain and are not the same
+	// asset across them, so a single summed figure describes nothing — the
+	// split is what makes an aggregate honest. Counts remain summed above,
+	// where adding them is meaningful.
+	ByNetwork map[string]GasTimeSlice `json:"by_network,omitempty"`
+}
+
+// GasTimeSlice is one network's share of a bucket.
+type GasTimeSlice struct {
+	TotalGasUsed   int `json:"total_gas_used"`
+	TotalGasWanted int `json:"total_gas_wanted"`
+	TotalFees      int `json:"total_fees"`
+	TxCount        int `json:"tx_count"`
+	SuccessCount   int `json:"success_count"`
+	FailCount      int `json:"fail_count"`
 }
 
 type SanityOverview struct {
@@ -2273,8 +2290,11 @@ func (d *DB) GetGasTimeSeries(network, granularity string, days int) ([]GasTimeP
 	// (network, ...) indexes stay usable for the all-networks case.
 	netFilter := " AND " + d.networkFilter("t.network", network)
 
+	// Group by network as well, then fold. One pass gives both the totals and
+	// the per-chain split, and the extra grouping key is already the leading
+	// column of the indexes this reads.
 	q := fmt.Sprintf(
-		"SELECT strftime('%s', t.block_time) as bucket,"+
+		"SELECT strftime('%s', t.block_time) as bucket, t.network,"+
 			" SUM(t.gas_used) as total_gas_used,"+
 			" SUM(t.gas_wanted) as total_gas_wanted,"+
 			" SUM(t.gas_fee) as total_fees,"+
@@ -2282,7 +2302,7 @@ func (d *DB) GetGasTimeSeries(network, granularity string, days int) ([]GasTimeP
 			" SUM(CASE WHEN t.success THEN 1 ELSE 0 END) as success_count"+
 			" FROM transactions t"+
 			" WHERE t.block_time >= ?%s"+
-			" GROUP BY bucket ORDER BY bucket ASC",
+			" GROUP BY bucket, t.network ORDER BY bucket ASC",
 		sqlFmt, netFilter)
 
 	args := []any{startTime}
@@ -2300,14 +2320,29 @@ func (d *DB) GetGasTimeSeries(network, granularity string, days int) ([]GasTimeP
 		totalFees      int
 		txCount        int
 		successCount   int
+		byNetwork      map[string]GasTimeSlice
 	}
 	buckets := make(map[string]*row)
 	for rows.Next() {
-		var r row
-		if err := rows.Scan(&r.bucket, &r.totalGasUsed, &r.totalGasWanted, &r.totalFees, &r.txCount, &r.successCount); err != nil {
+		var bucket, net string
+		var slice GasTimeSlice
+		if err := rows.Scan(&bucket, &net, &slice.TotalGasUsed, &slice.TotalGasWanted,
+			&slice.TotalFees, &slice.TxCount, &slice.SuccessCount); err != nil {
 			return nil, err
 		}
-		buckets[r.bucket] = &r
+		slice.FailCount = slice.TxCount - slice.SuccessCount
+
+		r := buckets[bucket]
+		if r == nil {
+			r = &row{bucket: bucket, byNetwork: map[string]GasTimeSlice{}}
+			buckets[bucket] = r
+		}
+		r.totalGasUsed += slice.TotalGasUsed
+		r.totalGasWanted += slice.TotalGasWanted
+		r.totalFees += slice.TotalFees
+		r.txCount += slice.TxCount
+		r.successCount += slice.SuccessCount
+		r.byNetwork[net] = slice
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -2320,6 +2355,12 @@ func (d *DB) GetGasTimeSeries(network, granularity string, days int) ([]GasTimeP
 	for cur := start; !cur.After(end); cur = truncFn(cur.Add(step)) {
 		k := bucketKey(cur, granularity)
 		if r, ok := buckets[k]; ok {
+			// Only worth sending when several chains are in play; with one
+			// selected the split is the total.
+			var split map[string]GasTimeSlice
+			if network == "" {
+				split = r.byNetwork
+			}
 			avg := 0
 			avgFee := 0
 			var eff float64
@@ -2341,6 +2382,7 @@ func (d *DB) GetGasTimeSeries(network, granularity string, days int) ([]GasTimeP
 				AvgFee:         avgFee,
 				SuccessCount:   r.successCount,
 				FailCount:      r.txCount - r.successCount,
+				ByNetwork:      split,
 			})
 		} else {
 			out = append(out, GasTimePoint{Time: k})

--- a/db_test.go
+++ b/db_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // newTestDB opens a real SQLite file in a temp dir. The driver is pure Go, so
@@ -782,6 +783,72 @@ func TestTopGasQueryUsesAnIndex(t *testing.T) {
 	} {
 		if !strings.Contains(joined, idx) {
 			t.Errorf("type probe does not use %s.\nplan: %s", idx, joined)
+		}
+	}
+}
+
+// In all-networks mode the gas series carries a per-network breakdown. Fees are
+// denominated per chain and summing them across chains produces a figure that
+// describes nothing, so the split is what lets the view aggregate honestly.
+func TestGasTimeSeriesSplitsByNetwork(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "alpha"}, {ID: "beta"}})
+
+	day := time.Now().UTC().Format("2006-01-02") + "T12:00:00Z"
+	seed := func(network, hash string, gasUsed, fee int, ok bool) {
+		t.Helper()
+		if err := db.UpsertTransaction(network, hash, 100, day, gasUsed, gasUsed*2, fee, ok); err != nil {
+			t.Fatalf("UpsertTransaction: %v", err)
+		}
+	}
+	seed("alpha", "a1", 100, 10, true)
+	seed("alpha", "a2", 200, 20, false)
+	seed("beta", "b1", 300, 30, true)
+
+	points, err := db.GetGasTimeSeries("", "daily", 2)
+	if err != nil {
+		t.Fatalf("GetGasTimeSeries: %v", err)
+	}
+
+	var bucket *GasTimePoint
+	for i := range points {
+		if points[i].TxCount > 0 {
+			bucket = &points[i]
+		}
+	}
+	if bucket == nil {
+		t.Fatal("no non-empty bucket")
+	}
+
+	if len(bucket.ByNetwork) != 2 {
+		t.Fatalf("split covers %d networks, want 2: %+v", len(bucket.ByNetwork), bucket.ByNetwork)
+	}
+	// The split must reconcile with the total, or the stacked bars would not add
+	// up to the number printed above them.
+	var txs, fees, used int
+	for _, s := range bucket.ByNetwork {
+		txs += s.TxCount
+		fees += s.TotalFees
+		used += s.TotalGasUsed
+	}
+	if txs != bucket.TxCount || fees != bucket.TotalFees || used != bucket.TotalGasUsed {
+		t.Errorf("split does not sum to the total: txs %d/%d fees %d/%d gas %d/%d",
+			txs, bucket.TxCount, fees, bucket.TotalFees, used, bucket.TotalGasUsed)
+	}
+	if a := bucket.ByNetwork["alpha"]; a.TxCount != 2 || a.SuccessCount != 1 || a.FailCount != 1 {
+		t.Errorf("alpha = %+v, want 2 txs / 1 ok / 1 failed", a)
+	}
+
+	// With one network selected the split is the total, so sending it would be
+	// noise — and the frontend keys "is this multi-network?" off its absence.
+	single, err := db.GetGasTimeSeries("alpha", "daily", 2)
+	if err != nil {
+		t.Fatalf("GetGasTimeSeries(alpha): %v", err)
+	}
+	for _, p := range single {
+		if p.ByNetwork != nil {
+			t.Errorf("single-network series carries a split: %+v", p.ByNetwork)
+			break
 		}
 	}
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1031,6 +1031,31 @@ function destroyGasCharts() {
   destroyChartList(_gasChartInstances);
 }
 
+// Builds bar datasets split per network when the series carries a breakdown.
+//
+// Summing a denominated amount across chains produces a number that describes
+// nothing — gnoland1 ugnot and sapphire ugnot are not the same asset. Stacking
+// keeps the total's shape while making the composition readable, and reuses the
+// row-dot colours so a bar segment and a table row agree.
+//
+// Falls back to a single series when only one network is in play, so a selected
+// network renders exactly as before.
+function networkStacks(data, valueOf, fallback) {
+  const nets = [];
+  for (const p of data) {
+    for (const n of Object.keys(p.by_network || {})) if (!nets.includes(n)) nets.push(n);
+  }
+  if (nets.length < 2) return [fallback];
+  return nets.map(n => ({
+    label: n,
+    data: data.map(p => (p.by_network && p.by_network[n]) ? valueOf(p.by_network[n]) : 0),
+    backgroundColor: netColor(n) + '99',
+    borderColor: netColor(n),
+    borderWidth: 1,
+    stack: 'net',
+  }));
+}
+
 async function renderGasCharts(container) {
   destroyGasCharts();
   container.textContent = '';
@@ -1112,7 +1137,10 @@ async function renderGasCharts(container) {
     data: {
       labels,
       datasets: [
-        { label: 'total fees (ugnot)', data: data.map(p => p.total_fees), backgroundColor: 'rgba(255,212,59,0.5)', borderColor: '#ffd43b', borderWidth: 1, yAxisID: 'y', order: 2 },
+        ...networkStacks(data, v => v.total_fees, {
+          label: 'total fees (ugnot)', data: data.map(p => p.total_fees),
+          backgroundColor: 'rgba(255,212,59,0.5)', borderColor: '#ffd43b', borderWidth: 1, stack: 'net'
+        }).map(d => ({ ...d, yAxisID: 'y', order: 2 })),
         { label: 'avg fee/tx', type: 'line', data: data.map(p => p.avg_fee), borderColor: '#ff8787', backgroundColor: 'transparent', tension: 0.3, yAxisID: 'y2', order: 1 },
       ]
     },
@@ -1120,8 +1148,8 @@ async function renderGasCharts(container) {
       ...commonOpts,
       plugins: { ...commonOpts.plugins, title: { display: true, text: 'fees paid', color: '#888' } },
       scales: {
-        x: scaleOpts.x,
-        y:  { ...scaleOpts.y, position: 'left',  title: { display: true, text: 'total ugnot', color: '#888' } },
+        x: { ...scaleOpts.x, stacked: true },
+        y:  { ...scaleOpts.y, stacked: true, position: 'left',  title: { display: true, text: 'total ugnot', color: '#888' } },
         y2: { ...scaleOpts.y, position: 'right', title: { display: true, text: 'avg/tx', color: '#888' }, grid: { drawOnChartArea: false } }
       }
     }
@@ -1150,6 +1178,22 @@ async function renderGasCharts(container) {
       scales: { x: scaleOpts.x, y: { ...scaleOpts.y, max: 100, ticks: { ...scaleOpts.y.ticks, callback: v => v + '%' } } }
     }
   }));
+
+  // Where the activity actually comes from. Only rendered in all-networks mode:
+  // with one chain selected it would be a single band repeating the tx count.
+  const netStacks = networkStacks(data, v => v.tx_count, null);
+  if (netStacks.length > 1) {
+    const netCanvas = makeCanvas();
+    _gasChartInstances.push(new Chart(netCanvas, {
+      type: 'bar',
+      data: { labels, datasets: netStacks },
+      options: {
+        ...commonOpts,
+        plugins: { ...commonOpts.plugins, title: { display: true, text: 'transactions by network', color: '#888' } },
+        scales: { x: { ...scaleOpts.x, stacked: true }, y: { ...scaleOpts.y, stacked: true } }
+      }
+    }));
+  }
 
   // Successes and failures stacked, so the bar height is throughput and the red
   // band is the failure rate — both readable at once.


### PR DESCRIPTION
The "aggregate rather than per-network panels" decision from #86, applied to the gas view. Builds on the colours from #89 and the charts from #90.

All-networks stays **one combined view**. What changes is that a metric which cannot honestly be summed is now stacked instead of added.

## The distinction being drawn

- **Counts** — transactions, successes, failures. Summing is meaningful; left summed.
- **Denominated amounts** — fees. gnoland1 ugnot and sapphire ugnot are not the same asset and are not fungible, so `79 564 473 923 ugnot` across three chains was a number describing nothing. Now stacked per network: the bar's total height still gives the shape, and the composition is readable.

## Backend

`GetGasTimeSeries` groups by `(bucket, network)` and folds in Go, producing both the totals and a `by_network` map in one pass. The extra grouping key is already the leading column of the indexes this query reads, so it costs nothing.

`by_network` is `omitempty` and only populated when no network is selected — with one chain selected the split *is* the total, so sending it would be noise. The frontend keys "is this multi-network?" off its absence rather than off a separate flag.

Verified against the production data copy:

```
buckets=10 non-empty=6
mismatches between total and split: 0

2026-W29  txs=8       {gnoland1: 8}
2026-W31  txs=4       {gnoland1: 4}
2026-W32  txs=850     {gnoland1: 133, sapphire: 717}
2026-W33  txs=102924  {gnoland1: 4, sapphire: 102920}
```

## Frontend

`networkStacks()` builds the datasets, falling back to a single series when fewer than two networks appear — so a selected network renders exactly as before, no special-casing at the call sites.

- **fees paid** — bars stacked per network, `avg fee/tx` still a line on the second axis.
- **transactions by network** — new, and only in all-networks mode. With one chain selected it would be a single band repeating the tx count, so it is not drawn at all.

Colours come from `netColor`, so a stacked segment and a table row dot for the same chain are the same colour.

Left unstacked deliberately: `total gas per period` (gas is a compute unit, comparable across chains), the two ratio charts (averages and efficiency cannot be stacked — stacking a ratio is meaningless), and `transactions by outcome` (already stacked on success/failure; adding a second dimension would make it unreadable).

## Verified in the browser

```
ALL NETWORKS (7 charts)
  fees paid              -> [gnoland1/net, sapphire/net, avg fee/tx]
  transactions by network-> [gnoland1/net, sapphire/net]
  …
SINGLE NETWORK (6 charts)
  fees paid              -> [total fees (ugnot)/net, avg fee/tx]
  (no composition chart)
```

Colours match the row dots exactly:

```
fees paid:   gnoland1 border=#4ecdc4 expected=#4ecdc4
             sapphire border=#b194ff expected=#b194ff
```

No console errors.

## Tests

`TestGasTimeSeriesSplitsByNetwork` seeds two networks into a real temp database and checks the split covers both, that **it reconciles with the total** for txs, fees and gas — otherwise the stacked bars would not add up to the figure printed above them — that per-network success/fail counts are right, and that a single-network series carries no split.

## Next

The same treatment applies to `tokens` (volume) and `analytics`, which have the same summing problem and no split yet. `sanity` still needs its own answer — liveness cannot be aggregated at all, and `clientFor("")` picking an arbitrary chain remains the root of that and of the govdao null (#86).
