### PR TITLE
fix: fan out the events view across every network

### DIFF
--- a/api.go
+++ b/api.go
@@ -697,31 +697,20 @@ func eventTxLimit(r *http.Request) int {
 	return limit
 }
 
-func (a *API) HandleAllEvents(w http.ResponseWriter, r *http.Request) {
-	network := a.networkParam(r)
-	client := a.clientFor(network)
-	if client == nil {
-		jsonError(w, "no client available", 500)
-		return
-	}
-	// Recent transactions that have GnoEvents. Bounded by default: unbounded,
-	// this returns every event-emitting transaction the chain ever had.
-	limit := eventTxLimit(r)
-	txs, err := client.GetRecentTransactionsWithEvents(r.Context(), limit)
-	if err != nil {
-		jsonError(w, err.Error(), 500)
-		return
-	}
-	if limit > 0 && len(txs) > limit {
-		txs = txs[:limit]
-	}
-	type EventResult struct {
-		TxHash      string    `json:"tx_hash"`
-		BlockHeight int       `json:"block_height"`
-		Success     bool      `json:"success"`
-		Events      []TxEvent `json:"events"`
-	}
-	var results []EventResult
+// EventResult is one transaction's GnoEvents, tagged with the chain it came from.
+type EventResult struct {
+	TxHash      string    `json:"tx_hash"`
+	BlockHeight int       `json:"block_height"`
+	BlockTime   string    `json:"block_time,omitempty"`
+	Success     bool      `json:"success"`
+	Network     string    `json:"network,omitempty"`
+	Events      []TxEvent `json:"events"`
+}
+
+// gnoEvents keeps the GnoEvents of each transaction, dropping transactions that
+// emitted none.
+func gnoEvents(txs []Transaction, network string) []EventResult {
+	out := make([]EventResult, 0, len(txs))
 	for _, tx := range txs {
 		if tx.Response == nil {
 			continue
@@ -732,16 +721,85 @@ func (a *API) HandleAllEvents(w http.ResponseWriter, r *http.Request) {
 				matched = append(matched, ev)
 			}
 		}
-		if len(matched) > 0 {
-			results = append(results, EventResult{
-				TxHash:      tx.Hash,
-				BlockHeight: tx.BlockHeight,
-				Success:     tx.Success,
-				Events:      matched,
-			})
+		if len(matched) == 0 {
+			continue
 		}
+		out = append(out, EventResult{
+			TxHash:      tx.Hash,
+			BlockHeight: tx.BlockHeight,
+			BlockTime:   tx.BlockTime,
+			Success:     tx.Success,
+			Network:     network,
+			Events:      matched,
+		})
 	}
-	jsonResponse(w, results)
+	return out
+}
+
+func (a *API) HandleAllEvents(w http.ResponseWriter, r *http.Request) {
+	network := a.networkParam(r)
+	// Bounded by default: unbounded, this returns every event-emitting
+	// transaction the chain ever had.
+	limit := eventTxLimit(r)
+
+	if network != "" {
+		client := a.clientFor(network)
+		if client == nil {
+			jsonError(w, "network not found", 404)
+			return
+		}
+		txs, err := client.GetRecentTransactionsWithEvents(r.Context(), limit)
+		if err != nil {
+			jsonError(w, err.Error(), 500)
+			return
+		}
+		// Same stamping as the merged path, so a row carries a timestamp
+		// whichever way it was fetched.
+		a.stampBlockTimes(r.Context(), network, client, txs)
+		results := gnoEvents(txs, network)
+		if len(results) > limit {
+			results = results[:limit]
+		}
+		jsonResponse(w, results)
+		return
+	}
+
+	// All networks means every network, not whichever one clientFor happened to
+	// return. It used to call clientFor("") — which hands back an arbitrary entry
+	// of a Go map — so this endpoint silently served a single chain's events
+	// under an "all networks" heading, and the busiest chain was often the one
+	// left out.
+	var merged []EventResult
+	for _, batch := range fanOut(r.Context(), a.networks, a.clients, a.health,
+		func(ctx context.Context, n NetworkConfig, c *IndexerClient) ([]EventResult, error) {
+			txs, err := c.GetRecentTransactionsWithEvents(ctx, limit)
+			if err != nil {
+				return nil, err
+			}
+			// Timestamps are load-bearing here, not decoration. txFieldsLight
+			// carries no block_time, so without this every row sorts on raw
+			// height — and heights are not comparable across chains. gnoland1
+			// sits near 3.1M while sapphire is near 400k, so gnoland1 would win
+			// every comparison and the truncation below would drop sapphire
+			// entirely. Measured: 100 rows returned, 100 of them gnoland1.
+			a.stampBlockTimes(ctx, n.ID, c, txs)
+			return gnoEvents(txs, n.ID), nil
+		}) {
+		merged = append(merged, batch...)
+	}
+
+	// Interleave by time. Heights are not comparable across chains, so they are
+	// only a fallback for rows the block-time backfill has not reached.
+	sort.Slice(merged, func(i, j int) bool {
+		if merged[i].BlockTime != "" && merged[j].BlockTime != "" {
+			return merged[i].BlockTime > merged[j].BlockTime
+		}
+		return merged[i].BlockHeight > merged[j].BlockHeight
+	})
+	if len(merged) > limit {
+		merged = merged[:limit]
+	}
+	jsonResponse(w, merged)
 }
 
 func (a *API) HandleEvents(w http.ResponseWriter, r *http.Request) {

--- a/api_test.go
+++ b/api_test.go
@@ -93,3 +93,77 @@ func TestRejectUnknownNetwork(t *testing.T) {
 		})
 	}
 }
+
+// gnoEvents is the pure half of the events endpoints: pick out GnoEvents, drop
+// transactions that emitted none, and tag each row with the chain it came from.
+// The tag is what lets the merged view interleave chains and show a dot.
+func TestGnoEvents(t *testing.T) {
+	tx := func(hash string, ok bool, evs ...TxEvent) Transaction {
+		return Transaction{Hash: hash, BlockHeight: 10, BlockTime: "2026-01-01T00:00:00Z", Success: ok,
+			Response: &TxResponse{Events: evs}}
+	}
+	gno := func(typ string) TxEvent { return TxEvent{Typename: "GnoEvent", Type: typ} }
+	storage := TxEvent{Typename: "StorageDepositEvent", Type: "StorageDeposit"}
+
+	tests := []struct {
+		name     string
+		txs      []Transaction
+		wantRows int
+		wantEvs  int
+	}{
+		{
+			name:     "keeps gno events",
+			txs:      []Transaction{tx("a", true, gno("Transfer"), gno("Approval"))},
+			wantRows: 1,
+			wantEvs:  2,
+		},
+		{
+			name: "drops transactions with no gno events",
+			// A storage event is still an event, but not one this view lists.
+			txs:      []Transaction{tx("a", true, storage), tx("b", true, gno("Mint"))},
+			wantRows: 1,
+			wantEvs:  1,
+		},
+		{
+			name:     "filters non-gno events out of a mixed transaction",
+			txs:      []Transaction{tx("a", true, storage, gno("Mint"), storage)},
+			wantRows: 1,
+			wantEvs:  1,
+		},
+		{
+			name:     "a nil response is not a crash",
+			txs:      []Transaction{{Hash: "a", BlockHeight: 1}},
+			wantRows: 0,
+		},
+		{
+			name:     "no transactions",
+			txs:      nil,
+			wantRows: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gnoEvents(tt.txs, "sapphire")
+			if len(got) != tt.wantRows {
+				t.Fatalf("got %d rows, want %d", len(got), tt.wantRows)
+			}
+			for _, r := range got {
+				if r.Network != "sapphire" {
+					t.Errorf("row %s has network %q, want sapphire", r.TxHash, r.Network)
+				}
+				if r.BlockTime == "" {
+					t.Errorf("row %s lost its timestamp — the merged view sorts on it", r.TxHash)
+				}
+				for _, ev := range r.Events {
+					if ev.Typename != "GnoEvent" {
+						t.Errorf("row %s kept a %s", r.TxHash, ev.Typename)
+					}
+				}
+			}
+			if tt.wantRows == 1 && len(got[0].Events) != tt.wantEvs {
+				t.Errorf("got %d events, want %d", len(got[0].Events), tt.wantEvs)
+			}
+		})
+	}
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2346,6 +2346,7 @@ async function loadEvents() {
           block: item.block_height,
           tx: item.tx_hash,
           success: item.success,
+          network: item.network,
           type: ev.type || 'unknown',
           pkg_path: ev.pkg_path,
           attrs: ev.attrs,
@@ -2447,12 +2448,12 @@ function renderEventRows() {
       ? link(ev.pkg_path, () => navigate('/realm/' + ev.pkg_path.replace('gno.land/', '')))
       : el('span', {}, '-');
     if (ev.pkg_path) realmLink.setAttribute('data-hl', 'realm:' + ev.pkg_path);
-    list.appendChild(el('tr', {},
-      el('td', {}, blockLink(ev.block)),
+    list.appendChild(netRow(ev.network,
+      el('td', {}, blockLink(ev.block, ev.network)),
       el('td', {}, realmLink),
       el('td', {}, badge('realm', ev.type)),
       el('td', {}, attrStr ? linkify(attrStr) : el('span', {}, '-')),
-      el('td', {}, txLink(ev.tx, ev.block))
+      el('td', {}, txLink(ev.tx, ev.block, ev.network))
     ));
   }
 


### PR DESCRIPTION
Part of #86. The events view in all-networks mode was showing exactly one chain.

## What it was doing

```
all-networks   rows=100  height range 3159061..3199437
gnoland1       rows=100  height range 3159061..3199437   ← identical
sapphire       rows=100  height range  395877..396070
```

The all-networks response *was* the gnoland1 response, row for row. sapphire — by far the busiest chain and the source of essentially all current events — did not appear.

Cause: `clientFor("")` returns an arbitrary entry of a Go map, so "all networks" meant "whichever chain the runtime iterated to first". This endpoint never aggregated.

## The fix, and the trap inside it

Switched to `fanOut`, the same helper the merged blocks and transactions views already use: query every configured network concurrently, skip the ones that fail, tag each row with its network.

That alone did not work, and the way it failed is worth recording.

With the fan-out in place, all-networks returned **100 rows, still all gnoland1**. The rows from sapphire were being fetched and then discarded by the sort. `txFieldsLight` carries no `block_time`, so every `BlockTime` was empty and the comparator fell through to its height fallback — and heights are not comparable across chains. gnoland1 sits near 3,100,000; sapphire near 400,000. gnoland1 won every comparison and the `limit` truncation dropped sapphire entirely.

This is the latent half of #35, and here it silently deleted a whole chain rather than merely mis-ordering.

The fix is to stamp block times inside the fan-out before sorting. Afterwards:

```
gnoland1  newest event: 2026-08-09T02:36:06Z
sapphire  newest event: 2026-08-24T20:51:29Z
merged:   rows=100, all sapphire
merged range: 2026-08-24T20:36:46Z .. 2026-08-24T20:51:29Z
sorted newest-first: True
```

Still all sapphire — but now for the right reason. gnoland1's most recent event is fifteen days old, so the hundred most recent events across all chains genuinely are all sapphire. The difference is that this is now a fact about the data rather than an artefact of comparing incomparable numbers.

## Also

- `EventResult` gained `network` and `block_time`. The single-network path stamps times too, so a row carries a timestamp whichever way it was fetched — previously neither path did, and the view could not show when an event happened.
- The frontend threads the network through: rows get the dot from #89, and the block and transaction links now resolve on the right chain. Before this, clicking a block from the events list navigated without a network and resolved arbitrarily.
- A named network that is not configured now returns 404 rather than falling into the arbitrary-client path.

## Tests

`TestGnoEvents` covers the pure half — keeping GnoEvents, dropping transactions that emitted none, filtering non-Gno events out of a mixed transaction, surviving a nil response — and asserts every row carries its network tag and its timestamp, since the merge sorts on the latter.

The merge itself was verified end to end against the live indexers from val1, as above.

## Still open in #86

`clientFor("")` remains, and still breaks `govdao` (returns `null`) and `sanity` (reports one chain's liveness as global). Those need their own answers — govdao a fan-out, sanity probably no all-networks mode at all. The root fix is making `clientFor` refuse to guess.
