### PR TITLE
fix: scope accounts and tokens to their network

### DIFF
--- a/db.go
+++ b/db.go
@@ -1503,6 +1503,7 @@ func (d *DB) Search(network, q string) ([]PackageInfo, error) {
 
 type TokenInfo struct {
 	Path      string `json:"path"`
+	Network   string `json:"network,omitempty"`
 	Name      string `json:"name"`
 	Creator   string `json:"creator"`
 	CallCount int    `json:"call_count"`
@@ -1511,27 +1512,28 @@ type TokenInfo struct {
 func (d *DB) GetTokenPackages(network string) ([]TokenInfo, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
+	// p.network comes along so the row can say which chain it is from. No two
+	// chains currently share a package path, but nothing prevents it, and a
+	// silent merge would be indistinguishable from a single deployment.
 	q := `
-		SELECT DISTINCT p.path, p.name, p.creator, COALESCE(c.cnt, 0)
+		SELECT DISTINCT p.path, p.network, p.name, p.creator, COALESCE(c.cnt, 0)
 		FROM packages p
 		JOIN dependencies dep ON dep.package_path = p.path AND dep.network = p.network
 		LEFT JOIN (SELECT pkg_path, network, COUNT(*) as cnt FROM calls GROUP BY pkg_path, network) c ON c.pkg_path = p.path AND c.network = p.network
 		WHERE dep.import_path LIKE '%grc20%'`
+	// Scoped like every other reader, so a retired network cannot reappear here.
+	q += ` AND ` + d.networkFilter("p.network", network)
 	args := []any{}
-	if network != "" {
-		q += ` AND p.network = ?`
-		args = append(args, network)
-	}
 	q += ` ORDER BY p.block_height DESC`
 	rows, err := d.db.Query(q, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var tokens []TokenInfo
+	tokens := []TokenInfo{}
 	for rows.Next() {
 		var t TokenInfo
-		if err := rows.Scan(&t.Path, &t.Name, &t.Creator, &t.CallCount); err != nil {
+		if err := rows.Scan(&t.Path, &t.Network, &t.Name, &t.Creator, &t.CallCount); err != nil {
 			return nil, err
 		}
 		tokens = append(tokens, t)
@@ -1541,6 +1543,7 @@ func (d *DB) GetTokenPackages(network string) ([]TokenInfo, error) {
 
 type AccountInfo struct {
 	Address     string `json:"address"`
+	Network     string `json:"network,omitempty"`
 	CallCount   int    `json:"call_count"`
 	DeployCount int    `json:"deploy_count"`
 	MsgRunCount int    `json:"msgrun_count"`
@@ -1553,20 +1556,30 @@ func (d *DB) GetActiveAccounts(network string) ([]AccountInfo, error) {
 
 	nFilter := " WHERE " + d.networkFilter("network", network)
 
+	// Grouped by (address, network), not by address alone.
+	//
+	// The same key can exist on several chains, and its activity there is
+	// unrelated: an address busy on sapphire and quiet on gnoland1 is two
+	// different actors as far as this table is concerned. Summing across chains
+	// produced one row whose numbers belonged to neither — 47 addresses on the
+	// production database were conflated this way.
+	//
+	// The consequence is that an address can appear once per chain it is active
+	// on. That is the honest shape; the network column says which is which.
 	q := `
-		SELECT address, SUM(call_count), SUM(deploy_count), SUM(run_count), SUM(send_count)
+		SELECT address, network, SUM(call_count), SUM(deploy_count), SUM(run_count), SUM(send_count)
 		FROM (
-			SELECT caller as address, COUNT(*) as call_count, 0 as deploy_count, 0 as run_count, 0 as send_count FROM calls` + nFilter + ` GROUP BY caller
+			SELECT caller as address, network, COUNT(*) as call_count, 0 as deploy_count, 0 as run_count, 0 as send_count FROM calls` + nFilter + ` GROUP BY caller, network
 			UNION ALL
-			SELECT creator as address, 0, COUNT(*), 0, 0 FROM packages` + nFilter + ` GROUP BY creator
+			SELECT creator as address, network, 0, COUNT(*), 0, 0 FROM packages` + nFilter + ` GROUP BY creator, network
 			UNION ALL
-			SELECT caller as address, 0, 0, COUNT(*), 0 FROM msg_runs` + nFilter + ` GROUP BY caller
+			SELECT caller as address, network, 0, 0, COUNT(*), 0 FROM msg_runs` + nFilter + ` GROUP BY caller, network
 			UNION ALL
-			SELECT from_address as address, 0, 0, 0, COUNT(*) FROM bank_sends` + nFilter + ` GROUP BY from_address
+			SELECT from_address as address, network, 0, 0, 0, COUNT(*) FROM bank_sends` + nFilter + ` GROUP BY from_address, network
 			UNION ALL
-			SELECT to_address as address, 0, 0, 0, COUNT(*) FROM bank_sends` + nFilter + ` GROUP BY to_address
+			SELECT to_address as address, network, 0, 0, 0, COUNT(*) FROM bank_sends` + nFilter + ` GROUP BY to_address, network
 		)
-		GROUP BY address
+		GROUP BY address, network
 		ORDER BY (SUM(call_count) + SUM(deploy_count) + SUM(run_count) + SUM(send_count)) DESC
 		LIMIT 100
 	`
@@ -1575,10 +1588,10 @@ func (d *DB) GetActiveAccounts(network string) ([]AccountInfo, error) {
 		return nil, err
 	}
 	defer rows.Close()
-	var accounts []AccountInfo
+	accounts := []AccountInfo{}
 	for rows.Next() {
 		var a AccountInfo
-		if err := rows.Scan(&a.Address, &a.CallCount, &a.DeployCount, &a.MsgRunCount, &a.SendCount); err != nil {
+		if err := rows.Scan(&a.Address, &a.Network, &a.CallCount, &a.DeployCount, &a.MsgRunCount, &a.SendCount); err != nil {
 			return nil, err
 		}
 		accounts = append(accounts, a)

--- a/db_test.go
+++ b/db_test.go
@@ -852,3 +852,61 @@ func TestGasTimeSeriesSplitsByNetwork(t *testing.T) {
 		}
 	}
 }
+
+// An address can exist on several chains, and its activity on each is
+// unrelated. Grouping by address alone summed those into one row whose numbers
+// belonged to neither chain — 47 addresses were conflated this way on the
+// production database.
+func TestActiveAccountsAreScopedPerNetwork(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "alpha"}, {ID: "beta"}})
+
+	const shared = "g1shared"
+	call := func(network, hash string) {
+		t.Helper()
+		if err := db.InsertCall(network, hash, 1, "2026-01-01T00:00:00Z",
+			shared, "gno.land/r/demo/x", "Fn", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+	// 3 calls on alpha, 1 on beta.
+	call("alpha", "a1")
+	call("alpha", "a2")
+	call("alpha", "a3")
+	call("beta", "b1")
+
+	accounts, err := db.GetActiveAccounts("")
+	if err != nil {
+		t.Fatalf("GetActiveAccounts: %v", err)
+	}
+
+	byNet := map[string]AccountInfo{}
+	for _, a := range accounts {
+		if a.Address == shared {
+			byNet[a.Network] = a
+		}
+	}
+	if len(byNet) != 2 {
+		t.Fatalf("shared address produced %d rows, want one per chain: %+v", len(byNet), accounts)
+	}
+	if got := byNet["alpha"].CallCount; got != 3 {
+		t.Errorf("alpha call_count = %d, want 3", got)
+	}
+	if got := byNet["beta"].CallCount; got != 1 {
+		t.Errorf("beta call_count = %d, want 1 — the chains were summed", got)
+	}
+
+	// Selecting one chain must show only that chain's activity.
+	only, err := db.GetActiveAccounts("beta")
+	if err != nil {
+		t.Fatalf("GetActiveAccounts(beta): %v", err)
+	}
+	for _, a := range only {
+		if a.Network != "beta" {
+			t.Errorf("row from %q leaked into the beta view", a.Network)
+		}
+		if a.Address == shared && a.CallCount != 1 {
+			t.Errorf("beta call_count = %d, want 1", a.CallCount)
+		}
+	}
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -337,14 +337,18 @@ function shortAddr(addr) {
   if (!addr) return '';
   return KNOWN_ADDRS[addr] || truncAddr(addr);
 }
-function addrLink(addr) {
+// network is optional: pass it when the row belongs to a specific chain, so the
+// link lands on that chain rather than on whatever is selected. Without it an
+// address row from a merged view navigated to the current selection, which in
+// all-networks mode meant no network at all.
+function addrLink(addr, network) {
   const label = KNOWN_ADDRS[addr];
   const span = el('span');
   span.setAttribute('data-hl', addr);
   // Show the abbreviated form; a full 40-character address in every table cell
   // crowds out the content beside it. The full value stays in the tooltip, and
   // the link target is unchanged.
-  const a = link(label || truncAddr(addr), () => navigate('/address/' + addr + netSuffix(getNetwork())));
+  const a = link(label || truncAddr(addr), () => navigate('/address/' + addr + netSuffix(network)));
   a.setAttribute('data-hl', addr);
   a.title = addr;
   span.appendChild(a);
@@ -1577,8 +1581,8 @@ async function loadAccounts() {
     const tbody = clear('accounts-list');
     for (const a of (data || [])) {
       const total = a.call_count + a.deploy_count + a.msgrun_count + (a.send_count || 0);
-      tbody.appendChild(el('tr', {},
-        el('td', {}, addrLink(a.address)),
+      tbody.appendChild(netRow(a.network,
+        el('td', {}, addrLink(a.address, a.network)),
         el('td', {}, String(a.call_count)),
         el('td', {}, String(a.deploy_count)),
         el('td', {}, String(a.msgrun_count)),
@@ -1668,9 +1672,9 @@ async function loadTokens() {
     // GRC20 tokens list
     const tbody = clear('tokens-list');
     for (const t of (data || [])) {
-      tbody.appendChild(el('tr', {},
-        el('td', {}, realmPathEl(t.path)),
-        el('td', {}, addrLink(t.creator)),
+      tbody.appendChild(netRow(t.network,
+        el('td', {}, realmPathEl(t.path, t.network)),
+        el('td', {}, addrLink(t.creator, t.network)),
         el('td', {}, String(t.call_count))
       ));
     }


### PR DESCRIPTION
Closes the last piece of #86, and the page that started it: `/accounts` in all-networks mode, where a ranked list of addresses gave no indication which chain any of them was on.

## Accounts

`GetActiveAccounts` grouped by `address` alone and summed the per-chain counters. An address active on sapphire and on gnoland1 became one row whose numbers belonged to neither. Measured on the production database: **47 addresses were conflated this way.**

Now grouped by `(address, network)`, and the row carries its network.

The consequence is that an address can appear once per chain it is active on, rather than once in total. That is the honest shape — the same key on two chains is two different actors as far as this table is concerned — and the dot says which is which.

## Tokens

Same missing field. No two chains currently share a package path (checked: zero collisions), so nothing was visibly wrong, but a future collision would have merged silently and been indistinguishable from a single deployment.

Also scoped through `networkFilter` like every other reader — it was still on the old `if network != ""` branch, so the unfiltered case included retired networks. Visible effect: the token count drops from 64 to 46, the difference being topaz, whose testnet no longer exists.

## Frontend

Both tables use `netRow`, so rows get the colour dot from #89. That was the point of the dot and these were the two pages it could not reach.

`addrLink` takes an optional network. Without it, clicking an address in a merged view navigated with whatever network was selected — which in all-networks mode is none, so the destination resolved arbitrarily. The parameter is optional and `netSuffix(undefined)` still falls back to the current selection, so the twenty-odd existing call sites are unchanged.

## Verified against production data

```
accounts  rows=100  networks={sapphire: 99, gnoland1: 1}
tokens    rows=46   networks={sapphire: 39, gnoland1: 7}
```

## Tests

`TestActiveAccountsAreScopedPerNetwork` seeds one address with three calls on `alpha` and one on `beta`, then checks it produces two rows with 3 and 1 rather than a single row with 4 — the exact conflation this fixes — and that selecting a single chain shows only that chain's activity.

## What is left in #86

Only the aggregate-shaped items, and gas already has its answer (#91): `tokens` still reports a single blended `VOLUME … GNOT` across chains, and `analytics` blends every total the same way. Both want the per-network split that the gas series now has. `sanity` remains the one page with no sensible all-networks rendering at all.
