### PR TITLE
perf: index the aggregate readers and keep planner statistics fresh

### DIFF
--- a/db.go
+++ b/db.go
@@ -3,11 +3,11 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"log"
+	_ "modernc.org/sqlite"
 	"strings"
 	"sync"
 	"time"
-
-	_ "modernc.org/sqlite"
 )
 
 type DB struct {
@@ -96,7 +96,26 @@ func NewDB(path string) (*DB, error) {
 		return nil, err
 	}
 
-	return &DB{db: db}, nil
+	d := &DB{db: db}
+
+	// Refresh the planner's statistics in the background.
+	//
+	// Without sqlite_stat1 the planner guesses, and adding indexes can make it
+	// guess worse: the gas-by-realm join picked (network, pkg_path) over the
+	// (network, tx_hash) index it actually wanted and went from 2.51s to 3.73s.
+	// With statistics it chooses correctly and lands at 2.09s — better than
+	// before the new indexes existed.
+	//
+	// 0.87s on a 569MB database, and it grows with the chain, so it runs on every
+	// start rather than once: stale statistics are how the planner drifts back to
+	// the wrong choice. Off the startup path because it takes the write lock.
+	go func() {
+		if _, err := db.Exec(`ANALYZE`); err != nil {
+			log.Printf("analyze: %v", err)
+		}
+	}()
+
+	return d, nil
 }
 
 // blockTimeTables are the tables carrying a block_time column.
@@ -396,6 +415,23 @@ func initSchema(db *sql.DB) error {
 		CREATE INDEX IF NOT EXISTS idx_packages_network_hash   ON packages(network, tx_hash);
 		CREATE INDEX IF NOT EXISTS idx_msg_runs_network_hash   ON msg_runs(network, tx_hash);
 		CREATE INDEX IF NOT EXISTS idx_bank_sends_network_hash ON bank_sends(network, tx_hash);
+
+		-- The analytics and accounts views aggregate by actor and by package
+		-- inside a network. The single-column indexes that existed (caller,
+		-- creator, from_address, to_address) cannot serve a query that also
+		-- filters on network, so those aggregates fell back to table scans.
+		-- Measured on production data: the five-way distinct-address union went
+		-- 1.99s -> 0.42s and the realm join 1.23s -> 0.16s.
+		CREATE INDEX IF NOT EXISTS idx_calls_net_caller  ON calls(network, caller);
+		CREATE INDEX IF NOT EXISTS idx_calls_net_pkg     ON calls(network, pkg_path);
+		CREATE INDEX IF NOT EXISTS idx_pkgs_net_creator  ON packages(network, creator);
+		CREATE INDEX IF NOT EXISTS idx_runs_net_caller   ON msg_runs(network, caller);
+		CREATE INDEX IF NOT EXISTS idx_sends_net_from    ON bank_sends(network, from_address);
+		CREATE INDEX IF NOT EXISTS idx_sends_net_to      ON bank_sends(network, to_address);
+
+		-- The realm/analytics joins group calls by package and count distinct
+		-- callers within it, which this covers without touching the table.
+		CREATE INDEX IF NOT EXISTS idx_calls_pkg_caller  ON calls(pkg_path, caller);
 	`)
 	return err
 }


### PR DESCRIPTION
Part of #87. Measured on a consistent snapshot of the production database (570 MB), same snapshot for both runs:

| endpoint | before | after | |
| --- | ---: | ---: | ---: |
| `/api/analytics` | 8.55s | **2.75s** | 3.1x |
| `/api/accounts` | 2.86s | **0.69s** | 4.1x |
| `/api/stats` | 2.22s | **0.49s** | 4.5x |
| `/api/tokens` | 2.54s | **0.17s** | 14.9x |
| `/api/gas` | 6.33s | **4.24s** | 1.5x |

None of these touch the indexer — `HandleAnalytics` is `a.db.GetAnalytics(network)` and nothing else. It was all local SQL.

## The indexes

The single-column indexes that existed (`caller`, `creator`, `from_address`, `to_address`) cannot serve a query that also filters on network, so every aggregate fell back to a table scan. Seven composite indexes fix that:

```
calls(network, caller)         packages(network, creator)
calls(network, pkg_path)       msg_runs(network, caller)
calls(pkg_path, caller)        bank_sends(network, from_address)
                               bank_sends(network, to_address)
```

Per-query, on the same data:

```
five-way distinct-address union   1.99s -> 0.42s
realm/dependency join             1.23s -> 0.16s
top callers                       1.22s -> 1.11s
```

`top callers` barely moves: it groups every row by caller, so there is nothing for an index to skip. That one wants a maintained rollup, not an index.

## ANALYZE, and why the indexes alone made things worse

Adding the indexes **regressed `/api/gas` from 5.90s to 7.06s.** Without `sqlite_stat1` the planner guesses at selectivity, and a new candidate index made it guess worse — the gas-by-realm join switched from `(network, tx_hash)` to `(network, pkg_path)`:

```
before indexes    2.51s   SEARCH c USING idx_calls_network_hash (network=?)
after indexes     3.73s   SEARCH c USING idx_calls_net_pkg (network=?)
after ANALYZE     2.09s   SEARCH c USING idx_calls_network_hash (network=? AND tx_hash=?)
```

With statistics it picks correctly and beats the original. So `ANALYZE` is not a nicety here — without it this PR would be a net regression for gas.

It runs in a goroutine at startup: 0.87s on a 570 MB database, off the serving path because it takes the write lock. Every start rather than once, because the statistics go stale as the chain grows and stale statistics are exactly how the planner drifts back to the wrong index.

## Two things I checked and was wrong about

**Lock contention was not a factor.** `DB` wraps every access in a `sync.RWMutex` on top of SQLite's WAL, which looked like it should make readers queue behind the sync loop's writes. Measured, same data, same box:

```
analytics  sync OFF  8.36s
analytics  sync ON   8.45s
```

No meaningful difference. The mutex is arguably redundant with WAL, but it is not costing latency, so it is left alone.

**My benchmark method was unsound at first.** I was copying the live database with `cp` while production wrote to it, without the `-wal` file. That eventually produced `database disk image is malformed`, and it means the earlier numbers were taken on copies that happened to be consistent. Every figure above is from a snapshot taken with SQLite's online backup API and verified with `PRAGMA integrity_check`.

## Still slow

`/api/gas` at 4.24s is the worst remaining, and its cost is the three-way UNION in gas-by-realm plus the type-resolution subqueries. `top callers` needs a rollup. Both are in #87.
