### PR TITLE
perf: cache API responses for the sync interval

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Response caching for the read-only API.
+//
+// Nothing was cached before this: every request recomputed its aggregates from
+// scratch, and the expensive ones are expensive every time. /api/analytics was
+// 8.5s of SQL on the production database, repeated per visitor per page load.
+//
+// The data only moves when the sync loop writes, once every 30 seconds, so a
+// short TTL costs no freshness that the pipeline could have delivered anyway.
+const (
+	// cacheTTL matches the sync interval: a shorter one would expire entries
+	// that cannot have changed, a longer one would serve rows the syncer has
+	// already replaced.
+	cacheTTL = 30 * time.Second
+
+	// cacheMaxEntries bounds memory. Keys are (path, query), and the query
+	// carries network, limit, offset, sort and days — a crawler walking
+	// pagination could otherwise grow this without limit.
+	cacheMaxEntries = 512
+
+	// cacheMaxBodyBytes keeps one oversized response from dominating the cache.
+	// /api/txs without a limit can return the whole chain.
+	cacheMaxBodyBytes = 8 << 20 // 8 MiB
+)
+
+type cacheEntry struct {
+	body        []byte
+	contentType string
+	storedAt    time.Time
+}
+
+type responseCache struct {
+	mu      sync.Mutex
+	entries map[string]cacheEntry
+	ttl     time.Duration
+
+	hits, misses int
+}
+
+func newResponseCache(ttl time.Duration) *responseCache {
+	return &responseCache{entries: map[string]cacheEntry{}, ttl: ttl}
+}
+
+func (c *responseCache) get(key string) (cacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok || time.Since(e.storedAt) > c.ttl {
+		c.misses++
+		return cacheEntry{}, false
+	}
+	c.hits++
+	return e, true
+}
+
+func (c *responseCache) put(key string, e cacheEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Drop anything already expired before deciding the map is full, so a burst
+	// of distinct keys does not evict entries that are still good.
+	if len(c.entries) >= cacheMaxEntries {
+		for k, v := range c.entries {
+			if time.Since(v.storedAt) > c.ttl {
+				delete(c.entries, k)
+			}
+		}
+	}
+	// Still full: this is a pathological key space rather than normal traffic,
+	// so start over rather than grow without bound.
+	if len(c.entries) >= cacheMaxEntries {
+		c.entries = map[string]cacheEntry{}
+	}
+	c.entries[key] = e
+}
+
+func (c *responseCache) stats() (hits, misses, size int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.hits, c.misses, len(c.entries)
+}
+
+// cachingWriter buffers a handler's response so it can be stored. It records the
+// status so only successes are kept: caching a 500 would pin a transient indexer
+// failure for the whole TTL.
+type cachingWriter struct {
+	http.ResponseWriter
+	status int
+	buf    bytes.Buffer
+	tooBig bool
+}
+
+func (w *cachingWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *cachingWriter) Write(b []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	if !w.tooBig {
+		if w.buf.Len()+len(b) > cacheMaxBodyBytes {
+			w.tooBig = true
+			w.buf.Reset()
+		} else {
+			w.buf.Write(b)
+		}
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// cacheable reports whether a request may be served from, and stored in, the
+// cache.
+//
+// /api/live is a Server-Sent Events stream that never completes, so buffering it
+// would hold the response open forever and leak the buffer. /api/version is
+// constant and free to compute — caching it would only add bookkeeping.
+func cacheable(r *http.Request) bool {
+	if r.Method != http.MethodGet {
+		return false
+	}
+	switch r.URL.Path {
+	case "/api/live", "/api/version":
+		return false
+	}
+	return len(r.URL.Path) >= 5 && r.URL.Path[:5] == "/api/"
+}
+
+// withResponseCache serves repeated identical GETs from memory for the TTL.
+//
+// Deliberately keyed on path plus raw query, so ?network=sapphire and
+// ?network=gnoland1 are different entries and a network cannot be served another
+// one's data.
+func withResponseCache(c *responseCache, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !cacheable(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		key := r.URL.Path + "?" + r.URL.RawQuery
+		if e, ok := c.get(key); ok {
+			if e.contentType != "" {
+				w.Header().Set("Content-Type", e.contentType)
+			}
+			w.Header().Set("X-Cache", "HIT")
+			w.Write(e.body)
+			return
+		}
+
+		w.Header().Set("X-Cache", "MISS")
+		cw := &cachingWriter{ResponseWriter: w}
+		next.ServeHTTP(cw, r)
+
+		if cw.status == http.StatusOK && !cw.tooBig && cw.buf.Len() > 0 {
+			c.put(key, cacheEntry{
+				body:        append([]byte(nil), cw.buf.Bytes()...),
+				contentType: cw.Header().Get("Content-Type"),
+				storedAt:    time.Now(),
+			})
+		}
+	})
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingHandler records how often the expensive work behind the cache ran.
+func countingHandler(calls *atomic.Int32, status int, body string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		fmt.Fprint(w, body)
+	})
+}
+
+func TestResponseCache(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		status    int
+		requests  int
+		wantCalls int32
+		wantCache string
+	}{
+		{
+			name:      "repeated reads hit the cache",
+			path:      "/api/analytics?network=sapphire",
+			status:    200,
+			requests:  3,
+			wantCalls: 1,
+			wantCache: "HIT",
+		},
+		{
+			// A cached 500 would pin a transient indexer failure for the whole
+			// TTL, turning a blip into half a minute of outage.
+			name:      "errors are never cached",
+			path:      "/api/gas",
+			status:    500,
+			requests:  3,
+			wantCalls: 3,
+			wantCache: "MISS",
+		},
+		{
+			// Buffering a stream that never ends would hold the response open
+			// and grow the buffer forever.
+			name:      "the live stream is not cached",
+			path:      "/api/live",
+			status:    200,
+			requests:  2,
+			wantCalls: 2,
+			wantCache: "",
+		},
+		{
+			name:      "version is not worth caching",
+			path:      "/api/version",
+			status:    200,
+			requests:  2,
+			wantCalls: 2,
+			wantCache: "",
+		},
+		{
+			name:      "non-api routes pass through",
+			path:      "/realms",
+			status:    200,
+			requests:  2,
+			wantCalls: 2,
+			wantCache: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			h := withResponseCache(newResponseCache(cacheTTL), countingHandler(&calls, tt.status, `{"ok":true}`))
+
+			var last *httptest.ResponseRecorder
+			for i := 0; i < tt.requests; i++ {
+				last = httptest.NewRecorder()
+				h.ServeHTTP(last, httptest.NewRequest("GET", tt.path, nil))
+			}
+
+			if got := calls.Load(); got != tt.wantCalls {
+				t.Errorf("handler ran %d times, want %d", got, tt.wantCalls)
+			}
+			if got := last.Header().Get("X-Cache"); got != tt.wantCache {
+				t.Errorf("X-Cache = %q, want %q", got, tt.wantCache)
+			}
+			if last.Body.String() != `{"ok":true}` {
+				t.Errorf("body = %q", last.Body.String())
+			}
+		})
+	}
+}
+
+// Two networks must never share an entry — serving one chain's data under
+// another's name is the failure this whole area has been full of.
+func TestResponseCacheKeysOnQuery(t *testing.T) {
+	var calls atomic.Int32
+	h := withResponseCache(newResponseCache(cacheTTL), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"network":%q}`, r.URL.Query().Get("network"))
+	}))
+
+	get := func(path string) string {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest("GET", path, nil))
+		return rec.Body.String()
+	}
+
+	if got := get("/api/stats?network=sapphire"); got != `{"network":"sapphire"}` {
+		t.Fatalf("got %s", got)
+	}
+	if got := get("/api/stats?network=gnoland1"); got != `{"network":"gnoland1"}` {
+		t.Errorf("got %s — a different network was served from the cache", got)
+	}
+	if got := get("/api/stats"); got != `{"network":""}` {
+		t.Errorf("got %s — all-networks was served a single network's entry", got)
+	}
+	if calls.Load() != 3 {
+		t.Errorf("handler ran %d times, want 3 distinct keys", calls.Load())
+	}
+}
+
+func TestResponseCacheExpires(t *testing.T) {
+	var calls atomic.Int32
+	h := withResponseCache(newResponseCache(20*time.Millisecond), countingHandler(&calls, 200, `{"ok":true}`))
+
+	req := func() {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest("GET", "/api/stats", nil))
+	}
+	req()
+	req()
+	if calls.Load() != 1 {
+		t.Fatalf("handler ran %d times before expiry, want 1", calls.Load())
+	}
+	time.Sleep(40 * time.Millisecond)
+	req()
+	if calls.Load() != 2 {
+		t.Errorf("handler ran %d times after expiry, want 2 — the entry never expired", calls.Load())
+	}
+}
+
+// The entry count is bounded: paginated URLs are unbounded in principle and a
+// crawler should not be able to grow this without limit.
+func TestResponseCacheIsBounded(t *testing.T) {
+	c := newResponseCache(time.Hour)
+	h := withResponseCache(c, countingHandler(new(atomic.Int32), 200, `{"ok":true}`))
+
+	for i := 0; i < cacheMaxEntries*2; i++ {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest("GET", fmt.Sprintf("/api/txs?offset=%d", i), nil))
+	}
+	if _, _, size := c.stats(); size > cacheMaxEntries {
+		t.Errorf("cache holds %d entries, want at most %d", size, cacheMaxEntries)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -190,9 +190,13 @@ func run() error {
 		w.Write(indexHTML)
 	})
 
+	// Cache first, so a hit costs nothing beyond the network-name check.
+	cache := newResponseCache(cacheTTL)
+	handler := withResponseCache(cache, rejectUnknownNetwork(cfg.Networks, mux))
+
 	srv := &http.Server{
 		Addr:         *listenAddr,
-		Handler:      rejectUnknownNetwork(cfg.Networks, mux),
+		Handler:      handler,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}


### PR DESCRIPTION
Part of #87. Nothing was cached before this — every request recomputed its aggregates from scratch, for every visitor, on every page load.

Measured on a consistent snapshot of the production database:

| endpoint | first request | repeat |
| --- | ---: | ---: |
| `/api/govdao` | 8.00s | **0.001s** |
| `/api/gas` | 4.86s | **0.001s** |
| `/api/analytics` | 2.80s | **0.001s** |
| `/api/accounts` | 0.74s | **0.001s** |
| `/api/stats` | 0.54s | **0.001s** |
| `/api/tokens` | 0.22s | **0.001s** |

## Why a short TTL is free here

The data only moves when the sync loop writes, once every 30 seconds. A 30-second TTL therefore costs no freshness the pipeline could have delivered anyway — an entry can only be stale for data that had not been synced when it was stored.

Shorter would expire entries that cannot have changed; longer would serve rows the syncer has already replaced.

## What is deliberately not cached

- **`/api/live`** is a Server-Sent Events stream that never completes. Buffering it would hold the response open forever and grow the buffer without bound. Excluded by path.
- **`/api/version`** is constant and free; caching it would be pure bookkeeping.
- **Errors.** Only a 200 is stored. Caching a 500 would pin a transient indexer failure for the whole TTL, turning a blip into thirty seconds of outage — which matters here, where several endpoints depend on an indexer that has been intermittently unreachable all week.
- **Non-API routes**, so the SPA is untouched.

## Keying

Path plus raw query, so `?network=sapphire` and `?network=gnoland1` are separate entries. Serving one chain's data under another's name is precisely the class of bug this area has been full of (#86), and a cache is an easy way to reintroduce it — hence a test that pins it.

## Bounds

Entry count is capped at 512 and a single body at 8 MiB. Paginated URLs are unbounded in principle: `?offset=` alone gives a crawler an infinite key space, and `/api/txs` without a limit can return the whole chain. On overflow, expired entries are dropped first so a burst of distinct keys does not evict entries that are still good; if it is still full the map is reset, since that is a pathological key space rather than normal traffic.

`X-Cache: HIT`/`MISS` is set so this is observable from outside without adding an endpoint.

## Honest limitation

This improves the common case, not the worst one. The first visitor in each 30-second window still pays full price — `govdao` still takes 8 seconds for them. The cache makes repeat and concurrent traffic free; it does not make the underlying queries faster.

The queries themselves are still worth fixing, and #87 tracks them: `gas`'s three-way UNION, `top callers` needing a rollup, and `govdao` waiting out `perNetworkDeadline` because sapphire widens its window to genesis looking for a realm that has no calls there.

## Tests

`cache_test.go`, table-driven over the behaviours that would be dangerous to get wrong: repeated reads collapse to one handler call, errors are re-executed every time, the live stream and version bypass entirely, non-API routes pass through. Plus three focused cases — distinct networks never share an entry, entries actually expire, and the entry count stays bounded when driven with twice its capacity in distinct keys.
