### PR TITLE
feat: add pearl and refresh the network examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ mygnoscan
 Point it at one network:
 
 ```bash
-mygnoscan -indexer https://indexer.topaz.testnets.gno.land/graphql/query -network topaz
+mygnoscan -indexer https://indexer.pearl.testnets.gno.land/graphql/query -network pearl
 ```
 
 …or several, with a config file:

--- a/config.go
+++ b/config.go
@@ -24,10 +24,16 @@ const implicitConfigFile = "networks.json"
 // defaultNetworkID names the network when -indexer is passed without -network.
 const defaultNetworkID = "default"
 
+// The out-of-the-box networks: mainnet-ish plus the current public testnets.
+// Testnets are named after gemstones and are retired as new ones launch — topaz
+// was here and its endpoints no longer resolve — so this list needs revisiting
+// whenever the next stone ships. A network that disappears degrades to a per-
+// network circuit breaker rather than breaking startup.
 var defaultConfig = &AppConfig{
 	Networks: []NetworkConfig{
 		{ID: "gnoland1", IndexerURL: "https://indexer.gno.land/graphql/query", RPCURL: "https://rpc.gno.land"},
-		{ID: "test12", IndexerURL: "https://indexer.test12.moul.p2p.team/graphql"},
+		{ID: "pearl", IndexerURL: "https://indexer.pearl.testnets.gno.land/graphql/query", RPCURL: "https://rpc.pearl.testnets.gno.land"},
+		{ID: "sapphire", IndexerURL: "https://indexer.sapphire.testnets.gno.land/graphql/query", RPCURL: "https://rpc.sapphire.testnets.gno.land"},
 	},
 }
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,7 +28,7 @@ Combining `-config` with the single-network flags is an error, as is passing
 resulting network IDs:
 
 ```
-networks [topaz betanet] (from config file)
+networks [pearl sapphire] (from config file)
 ```
 
 Check that line, or `/api/networks`, after any config change. A wrongly configured
@@ -41,14 +41,14 @@ chain.
 {
   "networks": [
     {
-      "id": "topaz",
-      "indexer": "https://indexer.topaz.testnets.gno.land/graphql/query",
-      "rpc": "https://rpc.topaz.testnets.gno.land"
+      "id": "pearl",
+      "indexer": "https://indexer.pearl.testnets.gno.land/graphql/query",
+      "rpc": "https://rpc.pearl.testnets.gno.land"
     },
     {
-      "id": "betanet",
-      "indexer": "https://indexer.betanet.testnets.gno.land/graphql/query",
-      "rpc": "https://rpc.betanet.testnets.gno.land"
+      "id": "sapphire",
+      "indexer": "https://indexer.sapphire.testnets.gno.land/graphql/query",
+      "rpc": "https://rpc.sapphire.testnets.gno.land"
     }
   ]
 }

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -35,7 +35,7 @@ disabled**, then drives headless Chrome over the pages:
 | `DB` | `mygnoscan.db` | database snapshot to render |
 | `OUT` | `docs/images` | output directory |
 | `PORT` | `8899` | port for the temporary server |
-| `NETWORK` | `topaz` | network to select in the UI |
+| `NETWORK` | `pearl` | network to select in the UI |
 | `CONFIG` | `testdata/screenshots-networks.json` | network list |
 | `WIDTH` / `HEIGHT` | `1400` / `900` | window size |
 | `CHROME` | auto-detected | path to Chrome or Chromium |

--- a/testdata/screenshots-networks.json
+++ b/testdata/screenshots-networks.json
@@ -1,9 +1,9 @@
 {
   "networks": [
     {
-      "id": "topaz",
-      "indexer": "https://indexer.topaz.testnets.gno.land/graphql/query",
-      "rpc": "https://rpc.topaz.testnets.gno.land"
+      "id": "pearl",
+      "indexer": "https://indexer.pearl.testnets.gno.land/graphql/query",
+      "rpc": "https://rpc.pearl.testnets.gno.land"
     },
     {
       "id": "gnoland1",


### PR DESCRIPTION
pearl is live. Verified before touching anything:

```
chain_id:  pearl-1
height:    7490
txs:       231
indexer:   https://indexer.pearl.testnets.gno.land/graphql/query   200
rpc:       https://rpc.pearl.testnets.gno.land                      200
```

sapphire stays.

## No code was needed

`pearl` was already in the gemstone colour table from #95, so it arrives with its stone colour — a cream `#e8e0d0` — in the row dots, the badges, the picker and the stacked charts, with nothing to add.

What did need updating was everything pointing at **topaz**, which has been dead for a while: `indexer.topaz.testnets.gno.land` and `rpc.topaz.testnets.gno.land` are both NXDOMAIN. The README told a new user to run a command against a host that does not resolve.

- `README.md` — the single-network example
- `docs/deployment.md` — the config-file example and the startup log sample
- `docs/screenshots.md` and `testdata/screenshots-networks.json` — the screenshot fixture

## Default config

Was `gnoland1` + `test12`. Now `gnoland1` + `pearl` + `sapphire`, so a bare `mygnoscan` with no config file shows the current public testnets rather than a private indexer.

Left a note on it: testnets are named after gemstones and retire as new ones launch, so this list needs revisiting when the next stone ships. A network that disappears degrades to its per-network circuit breaker rather than breaking startup, which is why topaz going away was invisible until someone read the README.

## Verified end to end

Fresh database, live indexer:

```
[pearl] synced 93 packages
[pearl] synced 57 calls, 63 sends
[pearl] synced 17 msg_runs
[pearl] initial sync complete          (~3s)

stats?network=pearl            200  0.08s
txs?limit=10&network=pearl     200  0.35s
realms?limit=5&network=pearl   200  0.00s
blocks?limit=10&network=pearl  200  0.17s
```

35 realms render with the pearl badge and dot. No console errors.

```
pearl colour: #e8e0d0 (stone: yes)
dropdown: ● pearl = rgb(232, 224, 208)
```

## Aside

One test run failed once during this work and did not reproduce in four subsequent clean runs (`go clean -testcache` each time). I could not pin it down and it is not related to this change, but noting it rather than pretending I did not see it — worth watching for in CI.
