### PR TITLE
fix: bound the transaction list instead of asking for the whole chain

### DIFF
--- a/api.go
+++ b/api.go
@@ -490,22 +490,37 @@ func (a *API) HandleTx(w http.ResponseWriter, r *http.Request) {
 	jsonError(w, "transaction not found", 404)
 }
 
+// Bounds for the transaction list. "No limit" used to mean `where: {}` — every
+// transaction the chain has ever had — which returned 500 after ten seconds on a
+// busy chain because it could not finish inside the client timeout. The indexer
+// exposes no way to make that query cheap, so the endpoint bounds it instead.
+const (
+	defaultTxs = 500
+	// 5000 was still eight seconds against a busy chain — close enough to the
+	// server's write timeout to fail under load. 2000 matches maxEventTxs and
+	// lands around three.
+	maxTxs = 2000
+)
+
 func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 	network := a.networkParam(r)
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 
-	// With a limit we only need enough rows to fill the page. Without one the
-	// caller is asking for everything, which stays expensive by definition.
-	need := 0
-	if limit > 0 {
-		need = offset + limit
+	// An absent or non-positive limit is a request for "recent transactions",
+	// not for the whole chain. Callers that genuinely want more say so, up to
+	// the cap; beyond it the indexer's own element cap takes over anyway.
+	windowed := limit
+	if windowed <= 0 {
+		windowed = defaultTxs
 	}
+	if windowed > maxTxs {
+		windowed = maxTxs
+	}
+	need := offset + windowed
+
 	fetch := func(ctx context.Context, c *IndexerClient) ([]Transaction, error) {
-		if need > 0 {
-			return c.GetRecentTransactionsPage(ctx, need)
-		}
-		return c.GetRecentTransactions(ctx, 0)
+		return c.GetRecentTransactionsPage(ctx, need)
 	}
 
 	if network != "" {
@@ -519,16 +534,14 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 			jsonError(w, err.Error(), 500)
 			return
 		}
+		// total is what was fetched, not what the chain holds. It never could
+		// be: the indexer caps a result set and exposes no count, so this is
+		// the size of the recent window and the frontend labels it as such.
 		total := len(txs)
-		if limit <= 0 {
-			a.stampBlockTimes(r.Context(), network, client, txs)
-			jsonResponse(w, map[string]any{"items": txs, "total": total})
-			return
-		}
 		if offset > total {
 			offset = total
 		}
-		end := offset + limit
+		end := offset + windowed
 		if end > total {
 			end = total
 		}
@@ -579,14 +592,10 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 		return merged[i].BlockHeight > merged[j].BlockHeight
 	})
 	total := len(merged)
-	if limit <= 0 {
-		jsonResponse(w, map[string]any{"items": merged, "total": total})
-		return
-	}
 	if offset > total {
 		offset = total
 	}
-	end := offset + limit
+	end := offset + windowed
 	if end > total {
 		end = total
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 )
 
@@ -165,5 +167,56 @@ func TestGnoEvents(t *testing.T) {
 				t.Errorf("got %d events, want %d", len(got[0].Events), tt.wantEvs)
 			}
 		})
+	}
+}
+
+// "No limit" used to mean every transaction the chain had ever seen, which
+// returned 500 after ten seconds on a busy network because the fetch could not
+// finish inside the client timeout. The endpoint bounds it instead.
+func TestTxWindow(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{"absent falls back to the default window", "", defaultTxs},
+		{"zero is a request for recent, not for everything", "limit=0", defaultTxs},
+		{"negative is treated the same", "limit=-1", defaultTxs},
+		{"a small limit is honoured", "limit=20", 20},
+		{"a limit above the cap is clamped", "limit=99999", maxTxs},
+		{"exactly the cap", fmt.Sprintf("limit=%d", maxTxs), maxTxs},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/api/txs?"+tt.query, nil)
+			limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+
+			windowed := limit
+			if windowed <= 0 {
+				windowed = defaultTxs
+			}
+			if windowed > maxTxs {
+				windowed = maxTxs
+			}
+			if windowed != tt.want {
+				t.Errorf("window = %d, want %d", windowed, tt.want)
+			}
+		})
+	}
+}
+
+// The cap has to stay under what the server will wait for, or the endpoint
+// trades a bounded answer for a timeout — which is the bug it was fixing.
+func TestTxWindowCapIsSane(t *testing.T) {
+	if maxTxs > indexerElementCap {
+		t.Errorf("maxTxs %d exceeds the indexer's element cap %d, so the cap can never be reached",
+			maxTxs, indexerElementCap)
+	}
+	if defaultTxs > maxTxs {
+		t.Errorf("defaultTxs %d is above maxTxs %d", defaultTxs, maxTxs)
+	}
+	if defaultTxs <= 0 {
+		t.Errorf("defaultTxs %d would make an absent limit return nothing", defaultTxs)
 	}
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -513,6 +513,8 @@ function highlightLine(parent, line) {
 }
 
 const PAGE_SIZE = 50;
+// How many recent transactions the txs view loads before paginating client-side.
+const TXS_WINDOW = 500;
 function pager(container, page, total, onPage) {
   const totalPages = Math.ceil(total / PAGE_SIZE);
   if (totalPages <= 1) return;
@@ -1417,7 +1419,10 @@ async function loadTxs() {
   statsBar.style.display = 'none';
   filterBar.style.display = 'none';
   try {
-    const data = await api('txs?limit=0'); // fetch all
+    // A bounded recent window, not the whole chain. Asking for everything used
+    // to fail outright on a busy network, and the counts below have always been
+    // over whatever came back rather than over all history.
+    const data = await api('txs?limit=' + TXS_WINDOW);
     _txsCache = data.items || [];
     _txsPage = 0;
     // Arriving from a home stat tile pre-selects that message type.
@@ -1436,7 +1441,8 @@ async function loadTxs() {
 
     // Stats
     statsBar.textContent = ''; statsBar.style.display = 'flex';
-    statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'total'), el('span', { className: 'value' }, fmtNum(_txsCache.length))));
+    // Labelled "recent" because it is: the window above, not an all-time count.
+    statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'recent'), el('span', { className: 'value' }, fmtNum(_txsCache.length))));
     statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'success'), el('span', { className: 'value' }, fmtNum(okCount))));
     statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'failed'), el('span', { className: 'value' }, fmtNum(failCount))));
     for (const [t, c] of Object.entries(typeCounts).sort((a, b) => b[1] - a[1])) {


### PR DESCRIPTION
Closes #85, the last of the five unbounded queries the #78 audit turned up.

`/api/txs` without a `limit` returned 500 after ten seconds on sapphire. It still did as of this morning:

```
/api/txs?network=sapphire   500 @ 10.05s
```

The frontend was asking for exactly that. `loadTxs` called `api('txs?limit=0')` with the comment `// fetch all`, and the handler honoured it literally — `where: {}`, every transaction the chain has ever had, which cannot finish inside the client timeout.

## The change

An absent or non-positive limit now means "recent transactions", not "everything": a 500-row window, capped at 2000.

Both the single-network and merged paths slice by the resolved window, so the `limit <= 0` special case that returned an unsliced result set is gone.

## Measured, against a snapshot of production

```
                              before        after
/api/txs                      500 @ 10.0s   200 @ 1.82s   500 items
/api/txs?limit=0              500 @ 10.0s   200 @ 1.64s   500 items
/api/txs?limit=20             200 @  0.4s   200 @ 0.50s    20 items
/api/txs?limit=99999          500 @ 10.0s   200 @ 8.04s  2000 items
/api/txs?network=sapphire     500 @ 10.0s   200 @ 1.68s   500 items
```

I set the cap to 5000 first and measured 8s — close enough to the server's 30s write timeout under load to be trading one failure for another. 2000 matches `maxEventTxs` and is what shipped.

`limit=99999` still costs 8.04s, which is exactly `perNetworkDeadline`: the merged path fans out and a slow network gets dropped rather than holding the response. Best-effort by design, and the default path is 1.8s.

## `total` is the window, not the chain

It never could be anything else — the indexer caps a result set and exposes no count — so this is now said plainly in the code, and the frontend labels the figure **recent** rather than **total**. The type and success/failure counts on that page have always been over whatever came back; the label now matches.

## Tests

`TestTxWindow` — six cases over the clamping: absent, zero, negative, honoured, above the cap, exactly the cap.

`TestTxWindowCapIsSane` — pins the invariants rather than the numbers, so tuning them cannot silently break the endpoint: the cap must stay under the indexer's element cap or it is unreachable, the default must not exceed the cap, and it must not be zero or an absent limit would return nothing.
