### PR TITLE
test: cover the API handlers, and fix the two bugs it found

### DIFF
--- a/api.go
+++ b/api.go
@@ -638,7 +638,7 @@ func (a *API) HandleAddress(w http.ResponseWriter, r *http.Request) {
 	} else {
 		c := a.clientFor(network)
 		if c == nil {
-			jsonError(w, "no client available", 500)
+			jsonError(w, "network not found", 404)
 			return
 		}
 		var err error
@@ -928,7 +928,7 @@ func (a *API) HandleBlocks(w http.ResponseWriter, r *http.Request) {
 	if network != "" {
 		client := a.clientFor(network)
 		if client == nil {
-			jsonError(w, "no client available", 500)
+			jsonError(w, "network not found", 404)
 			return
 		}
 		blocks, err := client.GetRecentBlocks(r.Context(), limit)
@@ -983,7 +983,7 @@ func (a *API) HandleBlock(w http.ResponseWriter, r *http.Request) {
 	}
 	client := a.clientFor(network)
 	if client == nil {
-		jsonError(w, "no client available", 500)
+		jsonError(w, "network not found", 404)
 		return
 	}
 	height, err := strconv.Atoi(r.PathValue("height"))

--- a/db.go
+++ b/db.go
@@ -1522,16 +1522,21 @@ func (d *DB) Search(network, q string) ([]PackageInfo, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
+	// The counts are selected, not left to the scan: this used to read eight
+	// columns into eleven destinations, so every search returned
+	// "expected 8 destination arguments in Scan, not 11" and the site's search
+	// box was dead for any query.
 	qStr := `
-		SELECT network, path, name, creator, block_height, tx_hash, is_realm, num_files
-		FROM packages
-		WHERE (path LIKE ? OR name LIKE ? OR creator LIKE ?)`
+		SELECT p.network, p.path, p.name, p.creator, p.block_height, p.tx_hash,
+		       p.is_realm, p.num_files,
+		       (SELECT COUNT(*) FROM calls c WHERE c.network = p.network AND c.pkg_path = p.path),
+		       (SELECT COUNT(*) FROM dependencies d WHERE d.network = p.network AND d.import_path = p.path),
+		       (SELECT COUNT(*) FROM dependencies d WHERE d.network = p.network AND d.package_path = p.path)
+		FROM packages p
+		WHERE (p.path LIKE ? OR p.name LIKE ? OR p.creator LIKE ?)`
 	args := []any{"%" + q + "%", "%" + q + "%", "%" + q + "%"}
-	if network != "" {
-		qStr += ` AND network = ?`
-		args = append(args, network)
-	}
-	qStr += ` ORDER BY block_height DESC LIMIT 20`
+	qStr += ` AND ` + d.networkFilter("p.network", network)
+	qStr += ` ORDER BY p.block_height DESC LIMIT 20`
 
 	rows, err := d.db.Query(qStr, args...)
 	if err != nil {

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -161,3 +161,89 @@ func TestHealthTrackerIsConcurrencySafe(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// The breaker's edges, which the cases above do not reach.
+func TestHealthTrackerEdges(t *testing.T) {
+	boom := errors.New("indexer unreachable")
+
+	t.Run("one failure is a blip, not an outage", func(t *testing.T) {
+		h := newHealthTracker()
+		h.record("alpha", boom)
+		if h.shouldSkip("alpha") {
+			t.Error("breaker opened after a single failure")
+		}
+	})
+
+	t.Run("networks are tracked independently", func(t *testing.T) {
+		h := newHealthTracker()
+		for i := 0; i < breakerThreshold; i++ {
+			h.record("dead", boom)
+		}
+		if !h.shouldSkip("dead") {
+			t.Error("dead network should be skipped")
+		}
+		if h.shouldSkip("alive") {
+			t.Error("one network's failures silenced another")
+		}
+	})
+
+	t.Run("a network with no history is attempted", func(t *testing.T) {
+		if newHealthTracker().shouldSkip("never-seen") {
+			t.Error("an unknown network should not be skipped")
+		}
+	})
+
+	t.Run("a nil tracker is inert", func(t *testing.T) {
+		// api.go guards for this; the guard is only useful if it works.
+		var h *healthTracker
+		h.record("alpha", boom)
+		if h.shouldSkip("alpha") {
+			t.Error("a nil tracker should skip nothing")
+		}
+	})
+
+	t.Run("concurrent use is safe", func(t *testing.T) {
+		// Meaningful under -race: shouldSkip and record share a map.
+		h := newHealthTracker()
+		var wg sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				if i%2 == 0 {
+					h.record("alpha", boom)
+				} else {
+					h.shouldSkip("alpha")
+				}
+			}(i)
+		}
+		wg.Wait()
+	})
+}
+
+func TestFanOutSkipsNetworksWithoutAClient(t *testing.T) {
+	// A network can be configured without a usable client — clientFor returns
+	// nil for anything not in the map. It must be skipped, not panicked on.
+	nets := []NetworkConfig{{ID: "configured"}, {ID: "clientless"}}
+	clients := map[string]*IndexerClient{"configured": {}}
+
+	got := fanOut(context.Background(), nets, clients, newHealthTracker(),
+		func(ctx context.Context, n NetworkConfig, c *IndexerClient) (string, error) {
+			return n.ID, nil
+		})
+
+	if len(got) != 1 || got[0] != "configured" {
+		t.Errorf("got %v, want only the network that has a client", got)
+	}
+}
+
+func TestFanOutWithNoNetworks(t *testing.T) {
+	got := fanOut(context.Background(), nil, nil, newHealthTracker(),
+		func(ctx context.Context, n NetworkConfig, c *IndexerClient) (string, error) {
+			t.Error("callback ran with no networks configured")
+			return "", nil
+		})
+	if len(got) != 0 {
+		t.Errorf("got %v, want nothing", got)
+	}
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newTestAPI builds an API over a real temp database with no indexer clients.
+//
+// Every handler covered here reads from storage, so an absent client is the
+// point rather than a limitation: it proves these endpoints answer without the
+// indexer, which is what keeps them working when it is slow or down.
+func newTestAPI(t *testing.T) (*API, *DB) {
+	t.Helper()
+
+	db := newTestDB(t)
+	nets := []NetworkConfig{{ID: "alpha"}, {ID: "beta"}}
+	db.SetConfiguredNetworks(nets)
+
+	return NewAPI(db, map[string]*IndexerClient{}, nets, NewAnalyzer(db)), db
+}
+
+// seedActivity writes a small, coherent slice of activity for one network.
+// (syncer_test.go already has a seedNetwork with a different shape.)
+func seedActivity(t *testing.T, db *DB, network string, calls, realms, sends int) {
+	t.Helper()
+
+	when := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+	for i := 0; i < calls; i++ {
+		if err := db.InsertCall(network, fmt.Sprintf("%s-call-%d", network, i), 100+i, when,
+			fmt.Sprintf("g1caller%d", i%3), "gno.land/r/demo/board", "Post", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+	for i := 0; i < realms; i++ {
+		if err := db.UpsertPackage(network, fmt.Sprintf("gno.land/r/%s/pkg%d", network, i), "pkg",
+			"g1creator", fmt.Sprintf("%s-dep-%d", network, i), 200+i, when, true, 2); err != nil {
+			t.Fatalf("UpsertPackage: %v", err)
+		}
+	}
+	for i := 0; i < sends; i++ {
+		if err := db.InsertBankSend(network, fmt.Sprintf("%s-send-%d", network, i), 300+i, when,
+			"g1from", "g1to", "1000ugnot", true); err != nil {
+			t.Fatalf("InsertBankSend: %v", err)
+		}
+	}
+}
+
+func get(t *testing.T, h http.HandlerFunc, target string) (*httptest.ResponseRecorder, []byte) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest("GET", target, nil))
+	return rec, rec.Body.Bytes()
+}
+
+// The storage-backed handlers, exercised end to end over HTTP. None had a test.
+func TestStorageBackedHandlers(t *testing.T) {
+	api, db := newTestAPI(t)
+	seedActivity(t, db, "alpha", 5, 3, 2)
+	seedActivity(t, db, "beta", 2, 1, 1)
+
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		target  string
+		// check receives the decoded body; nil means "any valid JSON will do".
+		check func(t *testing.T, body []byte)
+	}{
+		{
+			name:    "stats scoped to one network",
+			handler: api.HandleStats,
+			target:  "/api/stats?network=alpha",
+			check: func(t *testing.T, body []byte) {
+				var s Stats
+				mustJSON(t, body, &s)
+				if s.TotalCalls != 5 {
+					t.Errorf("calls = %d, want 5", s.TotalCalls)
+				}
+				if s.TotalRealms != 3 {
+					t.Errorf("realms = %d, want 3", s.TotalRealms)
+				}
+			},
+		},
+		{
+			name:    "stats across all configured networks",
+			handler: api.HandleStats,
+			target:  "/api/stats",
+			check: func(t *testing.T, body []byte) {
+				var s Stats
+				mustJSON(t, body, &s)
+				if s.TotalCalls != 7 {
+					t.Errorf("calls = %d, want 5+2", s.TotalCalls)
+				}
+			},
+		},
+		{
+			name:    "accounts carry their network",
+			handler: api.HandleAccounts,
+			target:  "/api/accounts",
+			check: func(t *testing.T, body []byte) {
+				var accounts []AccountInfo
+				mustJSON(t, body, &accounts)
+				if len(accounts) == 0 {
+					t.Fatal("no accounts")
+				}
+				for _, a := range accounts {
+					if a.Network == "" {
+						t.Errorf("account %s has no network — the row dot cannot render", a.Address)
+					}
+				}
+			},
+		},
+		{
+			name:    "realms list",
+			handler: api.HandleRealms,
+			target:  "/api/realms?limit=10&network=alpha",
+			check: func(t *testing.T, body []byte) {
+				var page struct {
+					Items []PackageInfo `json:"items"`
+					Total int           `json:"total"`
+				}
+				mustJSON(t, body, &page)
+				if page.Total != 3 {
+					t.Errorf("total = %d, want 3", page.Total)
+				}
+				for _, r := range page.Items {
+					if r.Network != "alpha" {
+						t.Errorf("realm from %q leaked into the alpha view", r.Network)
+					}
+				}
+			},
+		},
+		{
+			name:    "validators come from storage, no client needed",
+			handler: api.HandleValidators,
+			target:  "/api/validators",
+			check: func(t *testing.T, body []byte) {
+				var regs []ValoperRegistration
+				mustJSON(t, body, &regs) // empty is correct; it must not 500
+			},
+		},
+		{
+			name:    "tokens",
+			handler: api.HandleTokens,
+			target:  "/api/tokens",
+			check:   nil,
+		},
+		{
+			name:    "analytics",
+			handler: api.HandleAnalytics,
+			target:  "/api/analytics?network=alpha",
+			check:   nil,
+		},
+		{
+			name:    "bank stats",
+			handler: api.HandleBankStats,
+			target:  "/api/bankstats?network=alpha",
+			check:   nil,
+		},
+		{
+			name:    "gas",
+			handler: api.HandleGas,
+			target:  "/api/gas?network=alpha",
+			check:   nil,
+		},
+		{
+			name:    "transactions time series",
+			handler: api.HandleTimeSeriesTransactions,
+			target:  "/api/timeseries/transactions?days=7&granularity=daily&network=alpha",
+			check:   nil,
+		},
+		{
+			name:    "gas time series",
+			handler: api.HandleTimeSeriesGas,
+			target:  "/api/timeseries/gas?days=7&granularity=daily&network=alpha",
+			check:   nil,
+		},
+		{
+			name:    "callers time series",
+			handler: api.HandleTimeSeriesCallers,
+			target:  "/api/timeseries/callers?days=7&granularity=daily&network=alpha",
+			check:   nil,
+		},
+		{
+			name:    "packages time series",
+			handler: api.HandleTimeSeriesPackages,
+			target:  "/api/timeseries/packages?days=7&granularity=daily&network=alpha",
+			check:   nil,
+		},
+		{
+			name:    "active addresses time series",
+			handler: api.HandleTimeSeriesActiveAddresses,
+			target:  "/api/timeseries/active-addresses?days=7&granularity=daily&network=alpha",
+			check:   nil,
+		},
+		{
+			name:    "search",
+			handler: api.HandleSearch,
+			target:  "/api/search?q=pkg&network=alpha",
+			check:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec, body := get(t, tt.handler, tt.target)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", rec.Code, body)
+			}
+			if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", ct)
+			}
+			if !json.Valid(body) {
+				t.Fatalf("body is not valid JSON: %s", body)
+			}
+			if tt.check != nil {
+				tt.check(t, body)
+			}
+		})
+	}
+}
+
+// Handlers that need a live chain must say so rather than answering from an
+// arbitrary one. This is the #86 class of bug, pinned.
+func TestHandlersThatRequireANetwork(t *testing.T) {
+	api, _ := newTestAPI(t)
+
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		target  string
+		want    int
+	}{
+		{
+			// A height identifies a different block on every chain.
+			name:    "a block height needs a network",
+			handler: api.HandleBlock,
+			target:  "/api/block/100",
+			want:    http.StatusBadRequest,
+		},
+		{
+			// Storage figures are denominated amounts; blending chains is the
+			// category error #86 is about.
+			name:    "storage figures need a network",
+			handler: api.HandleStorage,
+			target:  "/api/storage/r/demo/boards",
+			want:    http.StatusBadRequest,
+		},
+		{
+			name:    "an unconfigured network is not found",
+			handler: api.HandleBlock,
+			target:  "/api/block/100?network=nope",
+			want:    http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec, body := get(t, tt.handler, tt.target)
+			if rec.Code != tt.want {
+				t.Errorf("status = %d, want %d (body %s)", rec.Code, tt.want, body)
+			}
+			var e struct {
+				Error string `json:"error"`
+			}
+			mustJSON(t, body, &e)
+			if e.Error == "" {
+				t.Error("rejection carries no message for the caller to act on")
+			}
+		})
+	}
+}
+
+// An empty database must produce empty results, not errors and not nulls: the
+// frontend iterates these.
+func TestHandlersOnAnEmptyDatabase(t *testing.T) {
+	api, _ := newTestAPI(t)
+
+	for _, tc := range []struct {
+		name    string
+		handler http.HandlerFunc
+		target  string
+	}{
+		{"accounts", api.HandleAccounts, "/api/accounts"},
+		{"tokens", api.HandleTokens, "/api/tokens"},
+		{"validators", api.HandleValidators, "/api/validators"},
+		{"realms", api.HandleRealms, "/api/realms?limit=10"},
+		{"stats", api.HandleStats, "/api/stats"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, body := get(t, tc.handler, tc.target)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d on an empty database, body = %s", rec.Code, body)
+			}
+			if string(body) == "null\n" || string(body) == "null" {
+				t.Error("returned null; the frontend iterates this and would throw")
+			}
+		})
+	}
+}
+
+func mustJSON(t *testing.T, body []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(body, v); err != nil {
+		t.Fatalf("decode %s: %v", body, err)
+	}
+}


### PR DESCRIPTION
`api.go` is the largest file in the repo and had 45 of its 52 functions at 0% coverage. This covers the storage-backed half of it — and the tests found two live bugs on the way in.

Coverage: **29.0% → 45.4%** overall; `api.go` from 45 functions untested to 22.

## The search box has been broken in production

```
$ curl 'https://mygnoscan.moul.p2p.team/api/search?q=demo&network=sapphire'
{"error":"sql: expected 8 destination arguments in Scan, not 11"}
```

`DB.Search` selected eight columns and scanned eleven destinations. Every search, on every network, returned a 500 — the site's search box did nothing at all.

`PackageInfo` gained `Calls`, `Importers` and `Imports` at some point and the scan was updated to match; the query was not. Now selected properly as correlated counts, and scoped through `networkFilter` like every other reader.

## An unknown network returned 500

`HandleAddress`, `HandleBlocks` and `HandleBlock` still answered `no client available` with a 500 when given a network that is not configured. #93 moved the other handlers to a 404; these three were missed. By the time they run the middleware has already validated the name, so a nil client means exactly one thing.

## The tests

**`handlers_test.go`** — the storage-backed handlers over `httptest`, against a real temp database and **no indexer clients at all**. That absence is the point: it proves these endpoints answer without the indexer, which is what keeps them up when it is slow or down.

Fifteen endpoints in a table, each asserting a 200, a JSON content type and a well-formed body, with specific checks where there is something worth pinning — stats scoped to one network versus summed across configured ones, accounts carrying the network the dot needs, realms not leaking across networks.

Two more groups:

- *Handlers that require a network* — `/api/block/{height}` and `/api/storage/{path}` must refuse rather than answer from an arbitrary chain, and must say why. This is the #86 failure mode pinned so it cannot come back.
- *Handlers on an empty database* — must return `[]`, not `null` and not a 500. The frontend iterates these, and `null` throws.

**`fanout_test.go`** gains the edges the existing cases did not reach: a single failure must not open the breaker, networks are tracked independently, an unknown network is attempted, a nil tracker is inert (`api.go` guards for it — the guard is only useful if it works), and concurrent `record`/`shouldSkip` is safe under `-race`. Plus fan-out with a network that has no client, and with no networks at all.

I nearly duplicated the existing fan-out tests wholesale before checking what was already there; only the genuinely missing cases are added.

Full suite passes under `-race`.

## Not covered

The 22 remaining functions in `api.go` are the indexer-dependent handlers — `HandleTx`, `HandleTxs`, `HandleAddress`, the events and blocks paths. Those need a fake indexer rather than a database, which is a different fixture and worth its own change. `ws.go` is still entirely untested.
