### PR TITLE
fix: split transfer volume per network instead of blending chains

### DIFF
--- a/db.go
+++ b/db.go
@@ -1681,6 +1681,18 @@ type BankStats struct {
 	TopSenders      []AddrStat `json:"top_senders"`
 	TopReceiversVol []AddrStat `json:"top_receivers_volume"`
 	TopReceiversCnt []AddrStat `json:"top_receivers_count"`
+
+	// ByNetwork splits the totals per chain, populated only in all-networks
+	// mode. Counts are meaningful summed; volume is not — gnoland1 ugnot and
+	// sapphire ugnot are different assets, so the blended figure describes
+	// nothing. The split is what lets the view aggregate honestly.
+	ByNetwork map[string]BankSlice `json:"by_network,omitempty"`
+}
+
+// BankSlice is one network's share of the bank totals.
+type BankSlice struct {
+	TotalSends  int   `json:"total_sends"`
+	TotalVolume int64 `json:"total_volume"`
 }
 
 const amountExpr = `COALESCE(SUM(CAST(REPLACE(REPLACE(amount, 'ugnot', ''), '"', '') AS INTEGER)), 0)`
@@ -1696,6 +1708,23 @@ func (d *DB) GetBankStats(network string) (*BankStats, error) {
 	d.db.QueryRow(`SELECT COUNT(DISTINCT from_address) FROM bank_sends` + nFilter).Scan(&s.UniqueSenders)
 	d.db.QueryRow(`SELECT COUNT(DISTINCT to_address) FROM bank_sends` + nFilter).Scan(&s.UniqueReceivers)
 	d.db.QueryRow(`SELECT ` + amountExpr + ` FROM bank_sends` + nFilter).Scan(&s.TotalVolume)
+
+	// One pass for the per-chain breakdown; the grouping key already leads the
+	// indexes this reads.
+	if network == "" {
+		if rows, err := d.db.Query(`SELECT network, COUNT(*), ` + amountExpr +
+			` FROM bank_sends` + nFilter + ` GROUP BY network`); err == nil {
+			s.ByNetwork = map[string]BankSlice{}
+			for rows.Next() {
+				var net string
+				var slice BankSlice
+				if err := rows.Scan(&net, &slice.TotalSends, &slice.TotalVolume); err == nil {
+					s.ByNetwork[net] = slice
+				}
+			}
+			rows.Close()
+		}
+	}
 
 	andFilter := " AND " + d.networkFilter("network", network)
 	d.db.QueryRow(`SELECT COUNT(DISTINCT addr) FROM (SELECT from_address as addr FROM bank_sends` + nFilter + ` UNION SELECT to_address FROM bank_sends` + nFilter + `)`).Scan(&s.UniqueAddresses)

--- a/db_test.go
+++ b/db_test.go
@@ -910,3 +910,62 @@ func TestActiveAccountsAreScopedPerNetwork(t *testing.T) {
 		}
 	}
 }
+
+// Transfer volume is denominated per chain: one network's ugnot is not another's.
+// Summing them across networks produces a figure that describes nothing, so the
+// all-networks view carries the split and lets the frontend show it instead.
+func TestBankStatsSplitsByNetwork(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "alpha"}, {ID: "beta"}})
+
+	send := func(network, hash, amount string) {
+		t.Helper()
+		if err := db.InsertBankSend(network, hash, 1, "2026-01-01T00:00:00Z",
+			"g1from", "g1to", amount, true); err != nil {
+			t.Fatalf("InsertBankSend: %v", err)
+		}
+	}
+	send("alpha", "a1", "1000ugnot")
+	send("alpha", "a2", "2000ugnot")
+	send("beta", "b1", "500ugnot")
+
+	all, err := db.GetBankStats("")
+	if err != nil {
+		t.Fatalf("GetBankStats: %v", err)
+	}
+	if len(all.ByNetwork) != 2 {
+		t.Fatalf("split covers %d networks, want 2: %+v", len(all.ByNetwork), all.ByNetwork)
+	}
+	if got := all.ByNetwork["alpha"]; got.TotalSends != 2 || got.TotalVolume != 3000 {
+		t.Errorf("alpha = %+v, want 2 sends / 3000", got)
+	}
+	if got := all.ByNetwork["beta"]; got.TotalSends != 1 || got.TotalVolume != 500 {
+		t.Errorf("beta = %+v, want 1 send / 500", got)
+	}
+
+	// The split must reconcile, or the per-chain figures would not add up to the
+	// number they replace.
+	var sends int
+	var volume int64
+	for _, s := range all.ByNetwork {
+		sends += s.TotalSends
+		volume += s.TotalVolume
+	}
+	if sends != all.TotalSends || volume != all.TotalVolume {
+		t.Errorf("split does not sum to the total: sends %d/%d volume %d/%d",
+			sends, all.TotalSends, volume, all.TotalVolume)
+	}
+
+	// With one chain selected the split is the total, so sending it is noise —
+	// and the frontend keys "is this multi-network?" off its absence.
+	one, err := db.GetBankStats("alpha")
+	if err != nil {
+		t.Fatalf("GetBankStats(alpha): %v", err)
+	}
+	if one.ByNetwork != nil {
+		t.Errorf("single-network stats carry a split: %+v", one.ByNetwork)
+	}
+	if one.TotalVolume != 3000 {
+		t.Errorf("alpha volume = %d, want 3000", one.TotalVolume)
+	}
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1658,7 +1658,24 @@ async function loadTokens() {
     statsBar.textContent = ''; statsBar.style.display = 'flex';
     statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'grc20 tokens'), el('span', { className: 'value' }, fmtNum((data || []).length))));
     statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'bank transfers'), el('span', { className: 'value' }, fmtNum(bank.total_sends))));
-    statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'volume'), el('span', { className: 'value' }, fmtNum(Math.floor(bank.total_volume / 1000000)) + ' GNOT')));
+    // Volume is denominated per chain, so a single blended figure across
+    // networks describes nothing — one chain's GNOT is not another's. In
+    // all-networks mode the split is shown instead of the sum.
+    const vol = v => fmtNum(Math.floor(v / 1000000)) + ' GNOT';
+    if (bank.by_network && Object.keys(bank.by_network).length > 1) {
+      const entries = Object.entries(bank.by_network).sort((a, b) => b[1].total_volume - a[1].total_volume);
+      for (const [net, slice] of entries) {
+        const stat = el('div', { className: 'stat' });
+        const label = el('span', { className: 'label' });
+        label.appendChild(netDotEl(net));
+        label.appendChild(document.createTextNode(net + ' volume'));
+        stat.appendChild(label);
+        stat.appendChild(el('span', { className: 'value' }, vol(slice.total_volume)));
+        statsBar.appendChild(stat);
+      }
+    } else {
+      statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'volume'), el('span', { className: 'value' }, vol(bank.total_volume))));
+    }
     statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'unique addresses'), el('span', { className: 'value' }, fmtNum(bank.unique_addresses))));
     statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'senders'), el('span', { className: 'value' }, fmtNum(bank.unique_senders))));
     statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'receivers'), el('span', { className: 'value' }, fmtNum(bank.unique_receivers))));


### PR DESCRIPTION
The last of the aggregate problems in #86. The tokens page reported a single blended transfer volume across chains:

```
all networks   95 590 651 168 895

  gnoland1        199 305 000 000
  pearl            14 140 000 000
  sapphire     95 377 182 168 892
```

gnoland1 ugnot, pearl ugnot and sapphire ugnot are not the same asset and are not fungible. Adding them produces a number that describes nothing — the same category error the gas fees had before #91.

## The split

`GetBankStats` now returns `by_network` alongside the totals when no network is selected, in one extra grouped query whose key already leads the indexes it reads. `omitempty`, and only populated in all-networks mode: with one chain selected the split *is* the total, so sending it would be noise — and the frontend keys "is this multi-network?" off its absence, same as the gas series.

Counts stay summed. Transfers and unique addresses are meaningful added together; denominated amounts are not. That line is the whole point of the change.

## What the page shows now

All networks:

```
GRC20 TOKENS 46 | BANK TRANSFERS 122 181
  ● SAPPHIRE VOLUME  91 852 013 GNOT
  ● GNOLAND1 VOLUME       199 305 GNOT
  ● STAGING VOLUME             24 GNOT
UNIQUE ADDRESSES 50 519 | SENDERS 45 445 | RECEIVERS 50 486
```

One network:

```
GRC20 TOKENS 39 | BANK TRANSFERS 119 612 | VOLUME 91 852 013 GNOT | ...
```

Each per-chain figure carries its network dot, so the colours match the rows and chart segments elsewhere. Sorted by volume so the dominant chain reads first.

## Verified against production data

```
blended total: 95 591 850 268 895
  gnoland1  sends=2562    volume=199 305 000 000
  pearl     sends=65      volume=14 140 000 000
  sapphire  sends=154 506 volume=95 378 381 268 892
  staging   sends=7       volume=24 000 003
split sums to total: True
by_network present for a single network: False
```

## Tests

`TestBankStatsSplitsByNetwork` seeds two networks, checks the per-chain sends and volume, that **the split reconciles with the total** — otherwise the per-chain figures would not add up to the number they replace — and that a single-network query carries no split.

No console errors.

## Still open in #86

`analytics` blends its totals the same way, and `sanity` still has no sensible all-networks rendering — it reports one chain's liveness and height. Both are now the only items left on that issue.
