### PR TITLE
test: cover the live feed fan-out, and stop a nil indexer reaching it

### DIFF
--- a/ws.go
+++ b/ws.go
@@ -26,9 +26,17 @@ var liveFeeds = map[string]*liveFeed{}
 
 func initLiveFeeds(networks []NetworkConfig, clients map[string]*IndexerClient) {
 	for _, n := range networks {
+		// A network without a client gets no feed rather than a feed that
+		// panics: pollLoop dereferences f.indexer, so a nil one would take the
+		// process down from a goroutine the moment a browser subscribed.
+		c := clients[n.ID]
+		if c == nil {
+			log.Printf("[%s] live feed: no indexer client, feed disabled", n.ID)
+			continue
+		}
 		liveFeeds[n.ID] = &liveFeed{
 			clients:   make(map[chan []byte]struct{}),
-			indexer:   clients[n.ID],
+			indexer:   c,
 			networkID: n.ID,
 		}
 	}
@@ -47,6 +55,11 @@ func (f *liveFeed) removeClient(ch chan []byte) {
 	f.mu.Unlock()
 }
 
+// broadcast sends to every subscriber, skipping any whose buffer is full.
+//
+// The default case is load-bearing: without it one browser that has stopped
+// reading — a backgrounded tab, a stalled connection — would block the poll loop
+// and stall the feed for everyone else. A slow client loses events instead.
 func (f *liveFeed) broadcast(data []byte) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()

--- a/ws_test.go
+++ b/ws_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// newFeed builds a feed without starting its poll loop, so the fan-out can be
+// tested without an indexer. addClientChan deliberately starts polling, which is
+// why these register directly.
+func newFeed() *liveFeed {
+	return &liveFeed{clients: make(map[chan []byte]struct{}), networkID: "test"}
+}
+
+func (f *liveFeed) register(ch chan []byte) {
+	f.mu.Lock()
+	f.clients[ch] = struct{}{}
+	f.mu.Unlock()
+}
+
+func TestLiveFeedBroadcast(t *testing.T) {
+	t.Parallel()
+
+	t.Run("every subscriber receives the event", func(t *testing.T) {
+		t.Parallel()
+		f := newFeed()
+		a, b := make(chan []byte, 1), make(chan []byte, 1)
+		f.register(a)
+		f.register(b)
+
+		f.broadcast([]byte("block 1"))
+
+		for name, ch := range map[string]chan []byte{"a": a, "b": b} {
+			select {
+			case got := <-ch:
+				if string(got) != "block 1" {
+					t.Errorf("%s got %q", name, got)
+				}
+			default:
+				t.Errorf("%s received nothing", name)
+			}
+		}
+	})
+
+	t.Run("a client that stopped reading does not stall the others", func(t *testing.T) {
+		t.Parallel()
+		f := newFeed()
+		// Unbuffered and never read: a backgrounded tab or a stalled connection.
+		stalled := make(chan []byte)
+		healthy := make(chan []byte, 1)
+		f.register(stalled)
+		f.register(healthy)
+
+		done := make(chan struct{})
+		go func() {
+			f.broadcast([]byte("event"))
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("broadcast blocked on a client that is not reading — one stalled browser would freeze the feed for everyone")
+		}
+
+		select {
+		case got := <-healthy:
+			if string(got) != "event" {
+				t.Errorf("healthy client got %q", got)
+			}
+		default:
+			t.Error("the healthy client was skipped because of the stalled one")
+		}
+	})
+
+	t.Run("events are dropped, not queued, once a buffer is full", func(t *testing.T) {
+		t.Parallel()
+		f := newFeed()
+		ch := make(chan []byte, 1)
+		f.register(ch)
+
+		f.broadcast([]byte("first"))
+		f.broadcast([]byte("second")) // no room; must be dropped
+
+		if got := <-ch; string(got) != "first" {
+			t.Errorf("got %q, want the first event", got)
+		}
+		select {
+		case got := <-ch:
+			t.Errorf("got a second event %q; a full buffer should drop rather than grow", got)
+		default:
+		}
+	})
+
+	t.Run("a removed client stops receiving", func(t *testing.T) {
+		t.Parallel()
+		f := newFeed()
+		ch := make(chan []byte, 1)
+		f.register(ch)
+		f.removeClient(ch)
+
+		f.broadcast([]byte("event"))
+
+		select {
+		case got := <-ch:
+			t.Errorf("a removed client still received %q", got)
+		default:
+		}
+	})
+
+	t.Run("removing an unknown client is harmless", func(t *testing.T) {
+		t.Parallel()
+		newFeed().removeClient(make(chan []byte, 1)) // must not panic
+	})
+
+	t.Run("broadcasting to nobody is harmless", func(t *testing.T) {
+		t.Parallel()
+		newFeed().broadcast([]byte("event")) // must not panic or block
+	})
+
+	t.Run("concurrent subscribe, unsubscribe and broadcast", func(t *testing.T) {
+		t.Parallel()
+		// Meaningful under -race: clients is shared between the poll loop and
+		// every connecting browser.
+		f := newFeed()
+		var wg sync.WaitGroup
+		for i := 0; i < 40; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ch := make(chan []byte, 4)
+				f.register(ch)
+				f.broadcast([]byte("event"))
+				f.removeClient(ch)
+			}()
+		}
+		wg.Wait()
+
+		f.mu.RLock()
+		remaining := len(f.clients)
+		f.mu.RUnlock()
+		if remaining != 0 {
+			t.Errorf("%d clients left registered after every one unsubscribed", remaining)
+		}
+	})
+}
+
+// A network configured without an indexer client must get no feed rather than
+// one that panics: pollLoop dereferences f.indexer from a goroutine, so a nil
+// would take the process down when a browser subscribed.
+func TestInitLiveFeedsSkipsNetworksWithoutAClient(t *testing.T) {
+	original := liveFeeds
+	t.Cleanup(func() { liveFeeds = original })
+	liveFeeds = map[string]*liveFeed{}
+
+	initLiveFeeds(
+		[]NetworkConfig{{ID: "withclient"}, {ID: "noclient"}},
+		map[string]*IndexerClient{"withclient": {}},
+	)
+
+	if _, ok := liveFeeds["withclient"]; !ok {
+		t.Error("a network with a client got no feed")
+	}
+	if f, ok := liveFeeds["noclient"]; ok {
+		t.Errorf("a network with no client got a feed with indexer %v — pollLoop would panic on it", f.indexer)
+	}
+	for id, f := range liveFeeds {
+		if f.indexer == nil {
+			t.Errorf("feed %q has a nil indexer", id)
+		}
+	}
+}


### PR DESCRIPTION
`ws.go` drives the live feed and had no tests at all. Covering the fan-out turned up a crash waiting to happen.

## A nil indexer would take the process down

```go
liveFeeds[n.ID] = &liveFeed{
    indexer: clients[n.ID],   // nil for a network absent from the map
    ...
}
```

`pollLoop` calls `f.indexer.LatestBlockHeight(ctx)` unguarded, from a goroutine. A configured network with no client would panic the moment a browser subscribed to its feed — and a panic in a goroutine takes the whole process with it, not just that request.

It is not reachable today: `main.go` builds `clients` from the same `cfg.Networks` it passes here, so the map is always complete. It is one config path away from being reachable, and the failure mode is a crash rather than a degradation, so `initLiveFeeds` now skips such a network and logs it.

## The tests

The interesting property is the `default:` case in `broadcast`, which had no comment and reads like an oversight:

```go
select {
case ch <- data:
default:
}
```

It is load-bearing. Without it, one browser that has stopped reading — a backgrounded tab, a stalled connection — blocks the poll loop and freezes the feed **for every other client**. A slow client loses events instead. That is now stated in the code and pinned by a test that fails by timing out if the drop is ever removed.

Seven cases: every subscriber receives an event; a stalled client does not stall the others; a full buffer drops rather than queues; a removed client stops receiving; removing an unknown client and broadcasting to nobody are both harmless; and concurrent subscribe/unsubscribe/broadcast is clean under `-race`, which matters because `clients` is shared between the poll loop and every connecting browser.

`initLiveFeeds` gets its own test for the nil-client skip.

Feed tests construct the `liveFeed` directly rather than going through `addClientChan`, which starts the poll loop and would need a live indexer.

`ws.go` goes from 0% to `initLiveFeeds`, `removeClient` and `broadcast` fully covered. The rest — `pollLoop`, `liveFeedHandler`, `ensureRunning` — needs a fake indexer and a streaming response recorder; separate change.

## Noted, not changed

`liveFeeds` is package-level mutable state, which is why the test has to save and restore it. Worth threading through the API struct instead, but that is a refactor rather than a test.

`liveFeedHandler` silently registers nothing when given an unknown network: the browser gets an SSE stream that never delivers and no indication why. Now that `rejectUnknownNetwork` 404s unknown networks on `/api/` routes, this is mostly unreachable — but it is still the wrong shape.
