### PR TITLE
docs: bring the API contract back in line with the code

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,16 +4,43 @@ All responses are JSON. Errors are `{"error": "..."}` with a non-200 status.
 
 ## Common parameters
 
-**`network`** — accepted by most endpoints. A configured network ID restricts
-results to that network. `all`, or omitting it, applies **no filter**, so results
-span every configured network.
+**`network`** — accepted by most endpoints.
 
-Careful with the unfiltered case on anything address-related: a balance or RPC
-lookup has to resolve against exactly one network, and with no filter it uses the
-first configured network that has an RPC URL, regardless of where the address is
-actually active.
+| value | meaning |
+|---|---|
+| a configured network ID | restrict to that network |
+| `all`, or omitted | every **configured** network |
+| anything else | `404 {"error": "network not found"}` |
+
+"Every configured network" is not the same as "no filter". Rows survive a network
+being removed from the config — a retired testnet keeps its history in the
+database — and those rows are excluded. Removing topaz from the config dropped
+4,101 transactions and 187 realms out of the all-networks totals, which is
+correct: they belong to a chain that no longer exists.
+
+**Some endpoints refuse the unfiltered case rather than guessing.** A block height
+identifies a different block on every chain, and storage figures are denominated
+per chain, so `/api/block/{height}` and `/api/storage/{path...}` answer `400` when
+no network is given. This is deliberate: they used to answer from an arbitrary
+chain, which looked like data and was not.
+
+**Aggregates that cannot be summed are split, not blended.** Counts (transactions,
+realms, addresses) add up meaningfully across chains. Denominated amounts do not —
+one chain's ugnot is not another's — so in all-networks mode those endpoints carry
+a `by_network` object alongside the totals, and the totals are the arithmetic sum
+only for the counts. `by_network` is omitted when a single network is selected,
+because then it *is* the total.
 
 **`limit`, `offset`** — pagination, where supported. Noted per endpoint below.
+
+## Caching
+
+Successful `GET /api/*` responses are cached in memory for 30 seconds, keyed on
+path plus query string, and served with `X-Cache: HIT` or `MISS`. The TTL matches
+the sync interval, so it costs no freshness the pipeline could have delivered.
+
+Errors are never cached — a cached 500 would pin a transient indexer failure for
+the whole window. `/api/live` and `/api/version` bypass the cache entirely.
 
 **Time-series parameters**, on every `/api/timeseries/*` endpoint:
 
@@ -37,25 +64,30 @@ actually active.
 | `GET /api/packages` | list all packages, realms and pure packages. `limit`, `offset` |
 | `GET /api/realm/{path...}` | detail for one package: metadata, source files, imports, dependents, callers, MsgRun references |
 | `GET /api/deps/{path...}` | dependency graph as `{path: [imports]}`. `dir=dependents` reverses direction |
-| `GET /api/storage/{path...}` | storage events for a package |
-| `GET /api/events/{path...}` | events emitted by a package |
+| `GET /api/storage/{path...}` | storage events for a package. **Requires `network`**: the figures are denominated amounts and blending chains would be meaningless |
+| `GET /api/events/{path...}` | events emitted by a package. Bounded: `limit` defaults to 200, capped at 2000. In all-networks mode it queries every chain and tags each row with its `network` |
 
 ## Transactions and blocks
 
 | endpoint | description |
 |---|---|
-| `GET /api/txs` | recent transactions. Queried live from the indexer |
+| `GET /api/txs` | **recent** transactions, from the indexer. `limit` defaults to 500 and is capped at 2000; `offset` pages within that window |
 | `GET /api/tx/{hash}` | one transaction: messages, events, errors |
 | `GET /api/blocks` | recent blocks. `limit` |
-| `GET /api/block/{height}` | one block and its transactions |
-| `GET /api/allevents` | recent events across all packages |
+| `GET /api/block/{height}` | one block and its transactions. **Requires `network`**: a height alone does not identify a block across chains |
+| `GET /api/allevents` | recent events across all packages. `limit` defaults to 200, capped at 2000. Rows carry their `network` |
+
+`total` on `/api/txs` is the size of the fetched window, **not** the chain's
+transaction count. It never could be: the indexer caps a result set at 10,000
+records and exposes no count, so there is no way to ask how many exist. The UI
+labels this figure "recent" for the same reason.
 
 ## Addresses and accounts
 
 | endpoint | description |
 |---|---|
 | `GET /api/address/{addr}` | activity for an address: calls, deploys, runs, sends, and balance |
-| `GET /api/accounts` | most active accounts. **Returns the top 100 by total activity, with no pagination or sort controls** |
+| `GET /api/accounts` | most active accounts. **Top 100 by total activity, no pagination or sort controls.** One row per `(address, network)`: the same key on two chains is two different actors, and each row carries its `network` |
 
 ## Aggregates
 
@@ -64,10 +96,10 @@ actually active.
 | `GET /api/stats` | totals: transactions, calls, deploys, msg_runs, sends, realms, packages, unique callers, latest block |
 | `GET /api/analytics` | leaderboards and aggregate breakdowns |
 | `GET /api/gas` | gas usage, by realm |
-| `GET /api/bankstats` | transfer volume statistics |
-| `GET /api/tokens` | detected token packages |
-| `GET /api/validators` | validator set |
-| `GET /api/govdao` | GovDAO activity |
+| `GET /api/bankstats` | transfer volume statistics. Carries `by_network` in all-networks mode, because volume cannot be summed across chains |
+| `GET /api/tokens` | detected token packages. Rows carry their `network` |
+| `GET /api/validators` | valoper registrations, **served from storage** rather than the indexer. Flat rows with `address`, `moniker`, `func` and `success` — `address` is the validator the call is about, which is not always the caller |
+| `GET /api/govdao` | GovDAO activity. Queries every configured network in all-networks mode |
 | `GET /api/sanity/overview` | internal consistency counters, for debugging a sync |
 
 ## Time series
@@ -79,7 +111,7 @@ All accept `days` and `granularity`.
 | `GET /api/timeseries/transactions` | transaction counts |
 | `GET /api/timeseries/packages` | deployments |
 | `GET /api/timeseries/callers` | unique callers |
-| `GET /api/timeseries/gas` | gas consumption |
+| `GET /api/timeseries/gas` | gas consumption. Buckets carry `by_network` in all-networks mode, so fees can be shown per chain rather than summed |
 | `GET /api/timeseries/active-addresses` | active addresses |
 | `GET /api/timeseries/health` | chain health indicators |
 | `GET /api/timeseries/storage` | storage growth. `realm=<path>` scopes it to one realm |
@@ -106,5 +138,10 @@ GET /api/live?network=<id>
 
 Server-Sent Events. Emits `{"type": "block" | "tx", "network_id": ..., "payload": ...}`
 as new blocks arrive, with a keepalive comment every 15s. Omitting `network`, or
-passing `all`, subscribes to every network. The server polls the indexer every 3s
-while at least one client is connected.
+passing `all`, subscribes to every network that has a feed. The server polls the
+indexer every 3s while at least one client is connected, and stops when the last
+one disconnects.
+
+A network configured without an indexer client gets no feed rather than a broken
+one, and a subscription naming a network with no feed is accepted but silent —
+the connection stays open and delivers nothing.


### PR DESCRIPTION
`docs/api.md` is the contract, and a day of behaviour changes left it wrong in ways that would cost an integrator real time. Every claim below was verified against production before writing it.

## What was stated and is no longer true

**"`all`, or omitting it, applies no filter, so results span every configured network."** Since #80 the unfiltered case is scoped *to the configured networks*, which is not the same thing. Rows survive a network leaving the config, and those rows are now excluded — removing topaz dropped 4,101 transactions and 187 realms out of the all-networks totals.

**"With no filter it uses the first configured network that has an RPC URL."** That was `clientFor`'s arbitrary-map fallback, removed in #93 precisely because it produced answers that looked right and were not — the home page reported staging's block height as the global figure. Endpoints that need one chain now refuse instead of guessing.

**"`GET /api/txs` — recent transactions."** True in intent, false in practice until today: no limit meant every transaction the chain had ever had, and a 500 after ten seconds. Now bounded, and `total` is documented as the window size rather than a chain count — it never could have been one, since the indexer caps results and exposes no count.

## What was missing entirely

- `404` for an unknown network, `400` for the two endpoints that need one
- `by_network` on `/api/bankstats` and `/api/timeseries/gas`, and the rule behind it: counts sum across chains, denominated amounts do not
- Response caching, the 30s TTL, `X-Cache`, and that errors are never cached
- `/api/accounts` returning one row per `(address, network)` rather than per address
- `/api/validators` being served from storage, and that its `address` is the validator the call is about rather than the caller
- The `limit` defaults and caps on the event endpoints

## Also corrected

The live feed section claimed a subscription covers "every network". A network configured without an indexer client now gets no feed (#103), and naming a network with no feed is accepted but silent — the connection stays open and delivers nothing. Both are stated.

## Verified, not assumed

Each behaviour was probed against production rather than read off the source:

```
block/100                 400   {"error": ...}
storage/r/gnoland/blog    400   {"error": ...}
stats?network=nope        404   {"error": "network not found"}
accounts                  200   list[100], keys include network
allevents?limit=3         200   list[3],   keys include network
bankstats                 200   by_network: gnoland1, pearl, sapphire, staging
timeseries/gas            200   buckets carry by_network
txs                       200   items=500
X-Cache (1st / 2nd)       MISS / HIT
```

The pre-existing claims I now vouch for were checked in the source too: `days` clamped to 1–365 with a default of 30, `hourly`/`daily`/`weekly` granularity, a 15s keepalive and a 3s poll interval.
