### PR TITLE
fix: order every cross-network list through one predicate

### DIFF
--- a/api.go
+++ b/api.go
@@ -585,11 +585,9 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 			merged = append(merged, tx)
 		}
 	}
-	sort.Slice(merged, func(i, j int) bool {
-		if merged[i].BlockTime != "" && merged[j].BlockTime != "" {
-			return merged[i].BlockTime > merged[j].BlockTime
-		}
-		return merged[i].BlockHeight > merged[j].BlockHeight
+	sort.SliceStable(merged, func(i, j int) bool {
+		return newerFirst(merged[i].BlockTime, merged[j].BlockTime,
+			merged[i].BlockHeight, merged[j].BlockHeight)
 	})
 	total := len(merged)
 	if offset > total {
@@ -629,12 +627,7 @@ func (a *API) HandleAddress(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-		sort.Slice(txs, func(i, j int) bool {
-			if txs[i].BlockTime != "" && txs[j].BlockTime != "" {
-				return txs[i].BlockTime > txs[j].BlockTime
-			}
-			return txs[i].BlockHeight > txs[j].BlockHeight
-		})
+		sortTransactionsByTime(txs)
 	} else {
 		c := a.clientFor(network)
 		if c == nil {
@@ -715,27 +708,49 @@ func eventTxLimit(r *http.Request) int {
 	return limit
 }
 
-// sortTransactionsByTime orders newest first. Block height is only a fallback
-// for rows the block-time backfill has not reached: heights are per-chain, so
-// comparing them across networks lets the chain with the largest numbers win
-// every time and crowd the others out entirely.
+// newerFirst is the ordering every cross-network list uses.
+//
+// Timestamp wins. A row that has one sorts ahead of a row that does not, so
+// undated rows collect at the end rather than being interleaved by a number that
+// means nothing. Height is the last resort, and by then both rows are undated.
+//
+// Heights are per-chain: gnoland1 sits near 3.1M while sapphire is near 400k.
+// Comparing them across networks lets the chain with the largest numbers win
+// every comparison — and in a list that is then truncated to a page, that does
+// not mis-order, it deletes a chain. It did exactly that to sapphire's events.
+func newerFirst(timeA, timeB string, heightA, heightB int) bool {
+	if timeA != "" && timeB != "" {
+		return timeA > timeB
+	}
+	if timeA != timeB {
+		return timeA != ""
+	}
+
+	return heightA > heightB
+}
+
+// sortTransactionsByTime orders newest first.
+//
+// Heights are per-chain and not comparable: gnoland1 sits near 3.1M while
+// sapphire is near 400k, so a height comparison lets the chain with the largest
+// numbers win every time. Dropped into a merged list that is then truncated to a
+// page, that does not merely mis-order — it deletes a chain. It did exactly that
+// to sapphire's events before the block-time stamping was added.
+//
+// So: timestamp first, then rows that have one ahead of rows that do not, and
+// only then height — by which point both rows are undated and any order is a
+// guess, but at least a stable one.
 func sortTransactionsByTime(txs []Transaction) {
-	sort.Slice(txs, func(i, j int) bool {
-		if txs[i].BlockTime != "" && txs[j].BlockTime != "" {
-			return txs[i].BlockTime > txs[j].BlockTime
-		}
-		return txs[i].BlockHeight > txs[j].BlockHeight
+	sort.SliceStable(txs, func(i, j int) bool {
+		return newerFirst(txs[i].BlockTime, txs[j].BlockTime, txs[i].BlockHeight, txs[j].BlockHeight)
 	})
 }
 
-// sortEventResultsByTime orders newest first, with the same height caveat as
+// sortEventResultsByTime orders newest first, on the same rules as
 // sortTransactionsByTime.
 func sortEventResultsByTime(rows []EventResult) {
-	sort.Slice(rows, func(i, j int) bool {
-		if rows[i].BlockTime != "" && rows[j].BlockTime != "" {
-			return rows[i].BlockTime > rows[j].BlockTime
-		}
-		return rows[i].BlockHeight > rows[j].BlockHeight
+	sort.SliceStable(rows, func(i, j int) bool {
+		return newerFirst(rows[i].BlockTime, rows[j].BlockTime, rows[i].BlockHeight, rows[j].BlockHeight)
 	})
 }
 
@@ -861,12 +876,7 @@ func (a *API) HandleAllEvents(w http.ResponseWriter, r *http.Request) {
 
 	// Interleave by time. Heights are not comparable across chains, so they are
 	// only a fallback for rows the block-time backfill has not reached.
-	sort.Slice(merged, func(i, j int) bool {
-		if merged[i].BlockTime != "" && merged[j].BlockTime != "" {
-			return merged[i].BlockTime > merged[j].BlockTime
-		}
-		return merged[i].BlockHeight > merged[j].BlockHeight
-	})
+	sortEventResultsByTime(merged)
 	if len(merged) > limit {
 		merged = merged[:limit]
 	}
@@ -960,11 +970,8 @@ func (a *API) HandleBlocks(w http.ResponseWriter, r *http.Request) {
 		}) {
 		merged = append(merged, blocks...)
 	}
-	sort.Slice(merged, func(i, j int) bool {
-		if merged[i].Time != "" && merged[j].Time != "" {
-			return merged[i].Time > merged[j].Time
-		}
-		return merged[i].Height > merged[j].Height
+	sort.SliceStable(merged, func(i, j int) bool {
+		return newerFirst(merged[i].Time, merged[j].Time, merged[i].Height, merged[j].Height)
 	})
 	if len(merged) > limit {
 		merged = merged[:limit]

--- a/api_test.go
+++ b/api_test.go
@@ -220,3 +220,102 @@ func TestTxWindowCapIsSane(t *testing.T) {
 		t.Errorf("defaultTxs %d would make an absent limit return nothing", defaultTxs)
 	}
 }
+
+// Every cross-network list orders through newerFirst. Heights are per-chain —
+// gnoland1 sits near 3.1M while sapphire is near 400k — so comparing them across
+// networks lets the chain with the largest numbers win every comparison. In a
+// list that is then truncated to a page, that does not mis-order: it deletes a
+// chain. It did exactly that to sapphire's events before block times were
+// stamped, which is what this pins.
+func TestNewerFirst(t *testing.T) {
+	const (
+		older = "2026-08-01T00:00:00Z"
+		newer = "2026-08-27T00:00:00Z"
+	)
+
+	tests := []struct {
+		name             string
+		timeA, timeB     string
+		heightA, heightB int
+		want             bool
+	}{
+		{
+			name: "the newer timestamp wins regardless of height",
+			// The classic cross-chain case: a low-height row from a busy chain
+			// is genuinely more recent than a high-height row from a quiet one.
+			timeA: newer, timeB: older, heightA: 400_000, heightB: 3_100_000,
+			want: true,
+		},
+		{
+			name:  "the older timestamp loses regardless of height",
+			timeA: older, timeB: newer, heightA: 3_100_000, heightB: 400_000,
+			want: false,
+		},
+		{
+			name: "a dated row sorts ahead of an undated one",
+			// Undated rows collect at the end instead of being interleaved by a
+			// number that means nothing across chains.
+			timeA: older, timeB: "", heightA: 1, heightB: 9_999_999,
+			want: true,
+		},
+		{
+			name:  "an undated row sorts behind a dated one",
+			timeA: "", timeB: older, heightA: 9_999_999, heightB: 1,
+			want: false,
+		},
+		{
+			name: "height only decides between two undated rows",
+			// By here both are undated, so any order is a guess — but a stable one.
+			timeA: "", timeB: "", heightA: 200, heightB: 100,
+			want: true,
+		},
+		{
+			// Neither is strictly newer, so this reports false and the stable
+			// sort keeps the input order. Height is deliberately not consulted:
+			// rows sharing a timestamp are in the same block on the same chain,
+			// where height cannot separate them either.
+			name:  "equal timestamps leave the order alone",
+			timeA: newer, timeB: newer, heightA: 200, heightB: 100,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newerFirst(tt.timeA, tt.timeB, tt.heightA, tt.heightB); got != tt.want {
+				t.Errorf("newerFirst(%q, %q, %d, %d) = %v, want %v",
+					tt.timeA, tt.timeB, tt.heightA, tt.heightB, got, tt.want)
+			}
+		})
+	}
+}
+
+// The failure this ordering exists to prevent, end to end: a page-sized
+// truncation must not drop a whole chain.
+func TestMergedListDoesNotDropAChain(t *testing.T) {
+	// sapphire is busier and more recent but numbers its blocks far lower.
+	rows := []Transaction{}
+	for i := 0; i < 40; i++ {
+		rows = append(rows, Transaction{
+			Hash:        fmt.Sprintf("gnoland1-%d", i),
+			BlockHeight: 3_100_000 + i,
+			BlockTime:   "2026-08-01T00:00:00Z",
+		})
+	}
+	for i := 0; i < 40; i++ {
+		rows = append(rows, Transaction{
+			Hash:        fmt.Sprintf("sapphire-%d", i),
+			BlockHeight: 400_000 + i,
+			BlockTime:   "2026-08-27T00:00:00Z",
+		})
+	}
+
+	sortTransactionsByTime(rows)
+	page := rows[:20] // what a limit would keep
+
+	for _, tx := range page {
+		if tx.BlockTime != "2026-08-27T00:00:00Z" {
+			t.Fatalf("page contains an older row (%s) — the newest 20 should all be sapphire's", tx.Hash)
+		}
+	}
+}


### PR DESCRIPTION
Closes #35. Every cross-network list now orders through a single predicate, and the height fallback that made this dangerous is contained.

## Why height is not a tiebreaker

gnoland1 sits near block 3,100,000; sapphire near 400,000. Comparing heights across chains lets the chain with the largest numbers win every comparison. Dropped into a merged list that is then truncated to a page, that does not mis-order — **it deletes a chain**.

It did exactly that. Before block times were stamped in the events fan-out (#92), `/api/allevents` returned 100 rows, all gnoland1, with sapphire — by far the busiest — nowhere in the result despite having been fetched.

## The change

`newerFirst` is now the only ordering used by merged lists:

1. Both dated → newer wins.
2. One dated → the dated row sorts ahead, so undated rows collect at the end instead of being interleaved by a number that means nothing across chains.
3. Neither dated → height, by which point both rows are undated and any order is a guess, but a stable one.

Four inline comparators in `HandleTxs`, `HandleAddress`, `HandleAllEvents` and `HandleBlocks` were near-copies of each other with the raw height fallback; they now call it. `grep -c 'BlockTime != "" && '` over `api.go` is 0.

All sorts moved to `SliceStable`, so rows the predicate calls equal keep their input order rather than being shuffled.

`sortMergedPackages` already had the right shape and is unchanged — it was the model for this.

## Verified against production data

```
txs        rows=100  ordered=True  {sapphire: 100}
allevents  rows=100  ordered=True  {sapphire: 99, pearl: 1}
blocks     rows=100  ordered=True  {sapphire: 38, pearl: 38, gnoland1: 24}
```

`blocks` is the case that matters: three chains interleaved by time, none crowded out. `txs` being all sapphire is correct — it is genuinely the only chain with activity in that window.

## Tests

`TestNewerFirst` — six cases, including the one this exists for: a low-height row from a busy chain beating a high-height row from a quiet one.

`TestMergedListDoesNotDropAChain` — the end-to-end failure. Forty gnoland1 rows at height ~3.1M dated three weeks ago, forty sapphire rows at height ~400k dated today; the first twenty after sorting must all be sapphire's. Under the old comparator with timestamps missing, they would all have been gnoland1's.

I got one expectation wrong writing these: I assumed equal timestamps should fall through to height. They should not — rows sharing a timestamp are in the same block on the same chain, where height cannot separate them either, so the predicate reports false and the stable sort keeps the input order. The test says so now.
