### PR TITLE
fix: key every analytics ranking by network, not by path or address alone

### DIFF
--- a/analytics_test.go
+++ b/analytics_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+// seedSharedRealm deploys the same package path on two chains and gives it very
+// different traffic on each.
+//
+// This is not a contrived shape: 193 package paths now exist on more than one
+// network, because pearl launched carrying the same demo realms gnoland1 has.
+// When issue #86 was written the count was zero, which is why the collision was
+// filed as hypothetical.
+func seedSharedRealm(t *testing.T, db *DB) {
+	t.Helper()
+
+	const path = "gno.land/r/demo/boards"
+	const when = "2026-08-01T00:00:00Z"
+
+	for _, n := range []string{"busy", "quiet"} {
+		if err := db.UpsertPackage(n, path, "boards", "g1creator", n+"-deploy", 100, when, true, 1); err != nil {
+			t.Fatalf("UpsertPackage(%s): %v", n, err)
+		}
+	}
+
+	// 50 calls on busy, 2 on quiet.
+	for i := 0; i < 50; i++ {
+		if err := db.InsertCall("busy", "busy-call-"+itoa(i), 100+i, when, "g1shared", path, "Post", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := db.InsertCall("quiet", "quiet-call-"+itoa(i), 100+i, when, "g1shared", path, "Post", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+// Selecting a network must scope the rankings to it.
+//
+// The join filters were computed and then discarded with a blank assignment, so
+// every ranking counted activity from every chain no matter what was selected.
+// On production that put a realm with 22,789 calls at the top of pearl's
+// leaderboard when pearl had none of them, and ordered the whole page by other
+// chains' traffic.
+func TestAnalyticsRankingsAreScopedToTheSelectedNetwork(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "busy"}, {ID: "quiet"}})
+	seedSharedRealm(t, db)
+
+	a, err := db.GetAnalytics("quiet")
+	if err != nil {
+		t.Fatalf("GetAnalytics: %v", err)
+	}
+	if len(a.TopRealms) == 0 {
+		t.Fatal("no realms")
+	}
+
+	for _, r := range a.TopRealms {
+		if r.Network != "quiet" {
+			t.Errorf("realm %s is from %q in the quiet view", r.Path, r.Network)
+		}
+		if r.Calls != 2 {
+			t.Errorf("%s shows %d calls; quiet has 2 and busy's 50 must not be counted here",
+				r.Path, r.Calls)
+		}
+	}
+
+	for _, c := range a.TopCallers {
+		if c.Network != "quiet" {
+			t.Errorf("caller %s is from %q in the quiet view", c.Address, c.Network)
+		}
+		if c.Calls != 2 {
+			t.Errorf("caller %s shows %d calls, want quiet's 2", c.Address, c.Calls)
+		}
+	}
+}
+
+// In all-networks mode the same path appears once per chain, with each row
+// carrying its own figures, rather than once with the two summed.
+func TestAnalyticsSplitsASharedPathPerNetwork(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "busy"}, {ID: "quiet"}})
+	seedSharedRealm(t, db)
+
+	a, err := db.GetAnalytics("")
+	if err != nil {
+		t.Fatalf("GetAnalytics: %v", err)
+	}
+
+	byNetwork := map[string]int{}
+	for _, r := range a.TopRealms {
+		if r.Path != "gno.land/r/demo/boards" {
+			continue
+		}
+		if r.Network == "" {
+			t.Fatalf("merged ranking row has no network: %+v", r)
+		}
+		byNetwork[r.Network] = r.Calls
+	}
+
+	if len(byNetwork) != 2 {
+		t.Fatalf("the shared path produced %d row(s), want one per chain: %v", len(byNetwork), byNetwork)
+	}
+	if byNetwork["busy"] != 50 || byNetwork["quiet"] != 2 {
+		t.Errorf("call counts = %v, want busy 50 and quiet 2 kept apart", byNetwork)
+	}
+}
+
+// An address active on two chains is two actors with two histories. Counting it
+// once undercounts: on production, 68,506 blended against 68,806 honest.
+func TestAnalyticsCountsAddressesPerNetwork(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "busy"}, {ID: "quiet"}})
+	seedSharedRealm(t, db)
+
+	a, err := db.GetAnalytics("")
+	if err != nil {
+		t.Fatalf("GetAnalytics: %v", err)
+	}
+
+	// g1shared calls on both chains and g1creator deploys on both, so four
+	// (address, network) pairs exist where only two distinct strings do.
+	if a.TotalAddresses != 4 {
+		t.Errorf("total addresses = %d, want 4: two addresses seen on two chains each", a.TotalAddresses)
+	}
+}
+
+// A network with no rows must not inherit another's.
+func TestAnalyticsOnANetworkWithNoActivity(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "busy"}, {ID: "quiet"}, {ID: "empty"}})
+	seedSharedRealm(t, db)
+
+	a, err := db.GetAnalytics("empty")
+	if err != nil {
+		t.Fatalf("GetAnalytics: %v", err)
+	}
+	if a.TotalCalls != 0 || len(a.TopCallers) != 0 {
+		t.Errorf("an empty network reported %d calls and %d callers", a.TotalCalls, len(a.TopCallers))
+	}
+	for _, r := range a.TopRealms {
+		if r.Calls != 0 {
+			t.Errorf("realm %s on an empty network shows %d calls", r.Path, r.Calls)
+		}
+	}
+}
+
+// Liveness cannot be merged at all — not even wrongly, the way a denominated
+// amount can be summed. There is no such thing as the height, or the last block
+// time, of four chains at once. The page used to answer with an arbitrary entry
+// of a Go map and present it under a global heading.
+func TestSanityReportsLivenessPerNetwork(t *testing.T) {
+	api, alpha, beta := newIndexerAPI(t)
+	alpha.latestHeight = 3_100_024
+	beta.latestHeight = 400_024
+
+	t.Run("all networks reports every chain and no global height", func(t *testing.T) {
+		rec, body := serve(t, api, "/api/sanity/overview")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, body)
+		}
+
+		var ov SanityOverview
+		mustJSON(t, body, &ov)
+
+		if len(ov.ByNetwork) != 2 {
+			t.Fatalf("by_network has %d entries, want one per chain: %+v", len(ov.ByNetwork), ov.ByNetwork)
+		}
+		if ov.ByNetwork["alpha"].ChainHeight != 3_100_024 || ov.ByNetwork["beta"].ChainHeight != 400_024 {
+			t.Errorf("heights = alpha %d, beta %d; want each chain's own",
+				ov.ByNetwork["alpha"].ChainHeight, ov.ByNetwork["beta"].ChainHeight)
+		}
+		// The top-level fields stay empty because no single value could be right.
+		if ov.ChainHeight != 0 {
+			t.Errorf("a global chain_height of %d was reported; it belongs to one chain and reads as all of them", ov.ChainHeight)
+		}
+	})
+
+	t.Run("a single network fills the top-level fields and omits the split", func(t *testing.T) {
+		rec, body := serve(t, api, "/api/sanity/overview?network=beta")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, body)
+		}
+
+		var ov SanityOverview
+		mustJSON(t, body, &ov)
+
+		if ov.ChainHeight != 400_024 {
+			t.Errorf("chain_height = %d, want beta's 400024", ov.ChainHeight)
+		}
+		if ov.ByNetwork != nil {
+			t.Errorf("by_network was sent for a single network, where it is just the total again: %+v", ov.ByNetwork)
+		}
+	})
+}
+
+// An unreachable chain must be distinguishable from one sitting at genesis;
+// both are height 0 in the fields that matter.
+func TestSanityMarksAnUnreachableChain(t *testing.T) {
+	api, alpha, _ := newIndexerAPI(t)
+	alpha.status = http.StatusInternalServerError
+
+	rec, body := serve(t, api, "/api/sanity/overview")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+
+	var ov SanityOverview
+	mustJSON(t, body, &ov)
+
+	if live, ok := ov.ByNetwork["alpha"]; ok && live.Reachable {
+		t.Errorf("a chain returning 500s was reported reachable: %+v", live)
+	}
+	if live := ov.ByNetwork["beta"]; !live.Reachable {
+		t.Error("the healthy chain was dropped along with the broken one")
+	}
+}

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -229,3 +229,47 @@ func TestSanityMarksAnUnreachableChain(t *testing.T) {
 		t.Error("the healthy chain was dropped along with the broken one")
 	}
 }
+
+// The sanity page must not silently omit a chain. fanOut skips networks with no
+// client or an open breaker, but this is the page whose whole job is to report
+// liveness — a chain missing from it is the one a reader most needs to see.
+func TestSanityListsEveryConfiguredNetwork(t *testing.T) {
+	db := newTestDB(t)
+	nets := []NetworkConfig{{ID: "alpha"}, {ID: "beta"}, {ID: "noclient"}}
+	db.SetConfiguredNetworks(nets)
+
+	alpha, alphaClient := newFakeIndexer(t)
+	alpha.seedChain(100, 5)
+
+	// beta's breaker is already open, as it would be after a real outage.
+	beta, betaClient := newFakeIndexer(t)
+	beta.status = http.StatusInternalServerError
+
+	api := NewAPI(db, map[string]*IndexerClient{"alpha": alphaClient, "beta": betaClient},
+		nets, NewAnalyzer(db))
+	for i := 0; i < breakerThreshold; i++ {
+		api.health.record("beta", errIndexerUnavailable)
+	}
+
+	rec, body := serve(t, api, "/api/sanity/overview")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+
+	var ov SanityOverview
+	mustJSON(t, body, &ov)
+
+	for _, n := range nets {
+		live, ok := ov.ByNetwork[n.ID]
+		if !ok {
+			t.Errorf("%s is missing from the liveness report entirely", n.ID)
+			continue
+		}
+		if n.ID != "alpha" && live.Reachable {
+			t.Errorf("%s was reported reachable: %+v", n.ID, live)
+		}
+	}
+	if !ov.ByNetwork["alpha"].Reachable {
+		t.Error("the healthy chain was reported unreachable")
+	}
+}

--- a/api.go
+++ b/api.go
@@ -1438,19 +1438,52 @@ func (a *API) HandleSanityOverview(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, err.Error(), 500)
 		return
 	}
-	// Chain height, last block time and liveness always come from the live indexer.
-	if client := a.clientFor(network); client != nil {
-		if blocks, err := client.GetRecentBlocks(r.Context(), 1); err == nil && len(blocks) > 0 {
-			b := blocks[0]
-			ov.ChainHeight = b.Height
-			ov.LastBlockTime = b.Time
-			if t, err := time.Parse(time.RFC3339, b.Time); err == nil {
-				ov.SecondsSinceBlock = int(time.Since(t).Seconds())
-				ov.IsAlive = ov.SecondsSinceBlock < 120
-			}
+	// Chain height, last block time and liveness always come from the live
+	// indexer. They are also the figures that cannot be merged: there is no
+	// such thing as the height of four chains at once.
+	if network != "" {
+		if client := a.clientFor(network); client != nil {
+			live := livenessOf(r.Context(), client)
+			ov.ChainHeight, ov.LastBlockTime = live.ChainHeight, live.LastBlockTime
+			ov.SecondsSinceBlock, ov.IsAlive = live.SecondsSinceBlock, live.IsAlive
 		}
+		jsonResponse(w, ov)
+		return
+	}
+
+	// All networks: report each chain rather than picking one. The top-level
+	// liveness fields stay zero, because no single value could be right.
+	type netLive struct {
+		id   string
+		live SanityLiveness
+	}
+	results := fanOut(r.Context(), a.networks, a.clients, a.health,
+		func(ctx context.Context, n NetworkConfig, c *IndexerClient) (netLive, error) {
+			return netLive{id: n.ID, live: livenessOf(ctx, c)}, nil
+		})
+	ov.ByNetwork = make(map[string]SanityLiveness, len(results))
+	for _, r := range results {
+		ov.ByNetwork[r.id] = r.live
 	}
 	jsonResponse(w, ov)
+}
+
+// livenessOf reads one chain's tip. An unreachable indexer reports Reachable
+// false rather than a zero height, which would otherwise be indistinguishable
+// from a chain sitting at genesis.
+func livenessOf(ctx context.Context, client *IndexerClient) SanityLiveness {
+	blocks, err := client.GetRecentBlocks(ctx, 1)
+	if err != nil || len(blocks) == 0 {
+		return SanityLiveness{}
+	}
+
+	b := blocks[0]
+	live := SanityLiveness{ChainHeight: b.Height, LastBlockTime: b.Time, Reachable: true}
+	if t, err := time.Parse(time.RFC3339, b.Time); err == nil {
+		live.SecondsSinceBlock = int(time.Since(t).Seconds())
+		live.IsAlive = live.SecondsSinceBlock < 120
+	}
+	return live
 }
 
 func (a *API) HandleTimeSeriesHealth(w http.ResponseWriter, r *http.Request) {

--- a/api.go
+++ b/api.go
@@ -1461,9 +1461,18 @@ func (a *API) HandleSanityOverview(w http.ResponseWriter, r *http.Request) {
 		func(ctx context.Context, n NetworkConfig, c *IndexerClient) (netLive, error) {
 			return netLive{id: n.ID, live: livenessOf(ctx, c)}, nil
 		})
-	ov.ByNetwork = make(map[string]SanityLiveness, len(results))
+	ov.ByNetwork = make(map[string]SanityLiveness, len(a.networks))
 	for _, r := range results {
 		ov.ByNetwork[r.id] = r.live
+	}
+	// fanOut drops networks it skipped — no client, or an open breaker — but
+	// this is the page whose job is to report liveness, and a chain silently
+	// missing from it is the one case a reader most needs to see. Fill the gaps
+	// in as unreachable rather than letting them vanish.
+	for _, n := range a.networks {
+		if _, ok := ov.ByNetwork[n.ID]; !ok {
+			ov.ByNetwork[n.ID] = SanityLiveness{}
+		}
 	}
 	jsonResponse(w, ov)
 }

--- a/db.go
+++ b/db.go
@@ -441,6 +441,18 @@ func initSchema(db *sql.DB) error {
 		-- The realm/analytics joins group calls by package and count distinct
 		-- callers within it, which this covers without touching the table.
 		CREATE INDEX IF NOT EXISTS idx_calls_pkg_caller  ON calls(pkg_path, caller);
+
+		-- The same, once the network joined the grouping key. Without the caller
+		-- in the index SQLite builds a temp B-tree for COUNT(DISTINCT caller),
+		-- which cost 1.60s over 685k rows to produce 159 groups; with it the
+		-- callers arrive already ordered within each group and the count is a
+		-- linear pass. Measured 1.29s -> 0.02s on the realms query.
+		CREATE INDEX IF NOT EXISTS idx_calls_net_pkg_caller ON calls(network, pkg_path, caller);
+
+		-- And its mirror, for the top-callers ranking: group by (network,
+		-- caller) counting distinct packages. Same shape, same reason, 0.69s ->
+		-- 0.26s. Both are covering, so neither touches the table.
+		CREATE INDEX IF NOT EXISTS idx_calls_net_caller_pkg ON calls(network, caller, pkg_path);
 	`)
 	return err
 }
@@ -1574,7 +1586,7 @@ func (d *DB) GetTokenPackages(network string) ([]TokenInfo, error) {
 		SELECT DISTINCT p.path, p.network, p.name, p.creator, COALESCE(c.cnt, 0)
 		FROM packages p
 		JOIN dependencies dep ON dep.package_path = p.path AND dep.network = p.network
-		LEFT JOIN (SELECT pkg_path, network, COUNT(*) as cnt FROM calls GROUP BY pkg_path, network) c ON c.pkg_path = p.path AND c.network = p.network
+		LEFT JOIN (SELECT pkg_path, network, COUNT(*) as cnt FROM calls GROUP BY network, pkg_path) c ON c.pkg_path = p.path AND c.network = p.network
 		WHERE dep.import_path LIKE '%grc20%'`
 	// Scoped like every other reader, so a retired network cannot reappear here.
 	q += ` AND ` + d.networkFilter("p.network", network)
@@ -1624,11 +1636,11 @@ func (d *DB) GetActiveAccounts(network string) ([]AccountInfo, error) {
 	q := `
 		SELECT address, network, SUM(call_count), SUM(deploy_count), SUM(run_count), SUM(send_count)
 		FROM (
-			SELECT caller as address, network, COUNT(*) as call_count, 0 as deploy_count, 0 as run_count, 0 as send_count FROM calls` + nFilter + ` GROUP BY caller, network
+			SELECT caller as address, network, COUNT(*) as call_count, 0 as deploy_count, 0 as run_count, 0 as send_count FROM calls` + nFilter + ` GROUP BY network, caller
 			UNION ALL
-			SELECT creator as address, network, 0, COUNT(*), 0, 0 FROM packages` + nFilter + ` GROUP BY creator, network
+			SELECT creator as address, network, 0, COUNT(*), 0, 0 FROM packages` + nFilter + ` GROUP BY network, creator
 			UNION ALL
-			SELECT caller as address, network, 0, 0, COUNT(*), 0 FROM msg_runs` + nFilter + ` GROUP BY caller, network
+			SELECT caller as address, network, 0, 0, COUNT(*), 0 FROM msg_runs` + nFilter + ` GROUP BY network, caller
 			UNION ALL
 			SELECT from_address as address, network, 0, 0, 0, COUNT(*) FROM bank_sends` + nFilter + ` GROUP BY from_address, network
 			UNION ALL
@@ -1737,7 +1749,15 @@ func (d *DB) GetBankStats(network string) (*BankStats, error) {
 	return &s, nil
 }
 
+// Every ranking row carries the chain it belongs to.
+//
+// 193 package paths now exist on more than one network — pearl launched with
+// the same demo realms gnoland1 has — so a path alone no longer identifies a
+// row, and neither does an address: the busiest caller on the site is active on
+// two chains and the next-busiest on three. Ranking without the network merges
+// separate actors into one row whose numbers belong to neither.
 type RealmActivity struct {
+	Network    string `json:"network,omitempty"`
 	Path       string `json:"path"`
 	Calls      int    `json:"calls"`
 	Callers    int    `json:"callers"`
@@ -1746,12 +1766,14 @@ type RealmActivity struct {
 }
 
 type CallerActivity struct {
+	Network string `json:"network,omitempty"`
 	Address string `json:"address"`
 	Calls   int    `json:"calls"`
 	Realms  int    `json:"realms"`
 }
 
 type ImportRank struct {
+	Network string `json:"network,omitempty"`
 	Path    string `json:"path"`
 	Imports int    `json:"imports"`
 }
@@ -1796,27 +1818,52 @@ func (d *DB) GetAnalytics(network string) (*Analytics, error) {
 	d.db.QueryRow(`SELECT COUNT(*) FROM msg_runs` + nFilter).Scan(&a.TotalMsgRuns)
 	d.db.QueryRow(`SELECT COUNT(*) FROM bank_sends` + nFilter).Scan(&a.TotalSends)
 
+	// Addresses are counted per chain. The same string on two chains is two
+	// actors with two histories, and collapsing them undercounts: 68,506
+	// blended against 68,806 counted honestly.
 	addrUnionFilter := " WHERE " + d.networkFilter("network", network)
-	d.db.QueryRow(`SELECT COUNT(DISTINCT addr) FROM (
-		SELECT caller as addr FROM calls` + addrUnionFilter + ` UNION SELECT creator FROM packages` + addrUnionFilter + `
-		UNION SELECT caller FROM msg_runs` + addrUnionFilter + ` UNION SELECT from_address FROM bank_sends` + addrUnionFilter + `
-		UNION SELECT to_address FROM bank_sends` + addrUnionFilter + `
-	)`).Scan(&a.TotalAddresses)
+	d.db.QueryRow(`SELECT COUNT(*) FROM (SELECT DISTINCT addr, network FROM (
+		SELECT caller as addr, network FROM calls` + addrUnionFilter + ` UNION SELECT creator, network FROM packages` + addrUnionFilter + `
+		UNION SELECT caller, network FROM msg_runs` + addrUnionFilter + ` UNION SELECT from_address, network FROM bank_sends` + addrUnionFilter + `
+		UNION SELECT to_address, network FROM bank_sends` + addrUnionFilter + `
+	))`).Scan(&a.TotalAddresses)
 	if network != "" {
 		d.db.QueryRow(`SELECT COALESCE(SUM(LENGTH(body)), 0) / 1024 FROM package_files WHERE network = ?`, network).Scan(&a.TotalSourceKB)
 	} else {
 		d.db.QueryRow(`SELECT COALESCE(SUM(LENGTH(body)), 0) / 1024 FROM package_files`).Scan(&a.TotalSourceKB)
 	}
 
-	callJoinFilter := " AND " + d.networkFilter("c_inner.network", network)
-	depJoinFilter := " AND " + d.networkFilter("dep_inner.network", network)
+	// The aggregate subqueries below join on (path, network), not on path alone.
+	//
+	// That join key is the correctness fix. 193 package paths now exist on more
+	// than one chain — pearl launched carrying the same demo realms gnoland1
+	// has — so matching on path alone attributes every chain's calls to every
+	// copy of the realm. On production that put a realm with 22,789 calls at the
+	// top of pearl's leaderboard when pearl had none of them, and ordered the
+	// whole page by other chains' traffic.
+	//
+	// The filters are an optimization on top, not the fix: with the network in
+	// the join key the results are already right without them. They shrink the
+	// subquery to the selected chain's rows, which is worth a great deal when
+	// one chain holds most of the traffic — pearl's page went from 0.59s to
+	// 0.013s. Removing them changes timing, not answers.
+	//
+	// Every GROUP BY below leads with the network so it matches the existing
+	// (network, col) indexes. Grouping is order-insensitive semantically but not
+	// to the planner: with the network second, SQLite cannot walk the index in
+	// group order and builds a temporary B-tree instead, which cost sapphire
+	// 3.19s -> 5.57s until the terms were swapped.
+	callFilter := " WHERE " + d.networkFilter("network", network)
+	depFilter := " WHERE " + d.networkFilter("network", network)
 
 	// Top realms by calls
 	rows, _ := d.db.Query(`
-		SELECT p.path, COALESCE(c.cnt, 0), COALESCE(c.callers, 0), COALESCE(dep.cnt, 0), p.is_realm
+		SELECT p.network, p.path, COALESCE(c.cnt, 0), COALESCE(c.callers, 0), COALESCE(dep.cnt, 0), p.is_realm
 		FROM packages p
-		LEFT JOIN (SELECT pkg_path, COUNT(*) as cnt, COUNT(DISTINCT caller) as callers FROM calls GROUP BY pkg_path) c ON c.pkg_path = p.path
-		LEFT JOIN (SELECT import_path, COUNT(*) as cnt FROM dependencies GROUP BY import_path) dep ON dep.import_path = p.path
+		LEFT JOIN (SELECT pkg_path, network, COUNT(*) as cnt, COUNT(DISTINCT caller) as callers FROM calls` + callFilter + ` GROUP BY network, pkg_path) c
+			ON c.pkg_path = p.path AND c.network = p.network
+		LEFT JOIN (SELECT import_path, network, COUNT(*) as cnt FROM dependencies` + depFilter + ` GROUP BY network, import_path) dep
+			ON dep.import_path = p.path AND dep.network = p.network
 		WHERE p.is_realm = 1` + pFilter + `
 		ORDER BY COALESCE(c.cnt, 0) DESC LIMIT 15
 	`)
@@ -1824,17 +1871,19 @@ func (d *DB) GetAnalytics(network string) (*Analytics, error) {
 		defer rows.Close()
 		for rows.Next() {
 			var r RealmActivity
-			rows.Scan(&r.Path, &r.Calls, &r.Callers, &r.Dependents, &r.IsRealm)
+			rows.Scan(&r.Network, &r.Path, &r.Calls, &r.Callers, &r.Dependents, &r.IsRealm)
 			a.TopRealms = append(a.TopRealms, r)
 		}
 	}
 
 	// Top packages by imports (dependents)
 	rows2, _ := d.db.Query(`
-		SELECT p.path, COALESCE(c.cnt, 0), 0, COALESCE(dep.cnt, 0), p.is_realm
+		SELECT p.network, p.path, COALESCE(c.cnt, 0), 0, COALESCE(dep.cnt, 0), p.is_realm
 		FROM packages p
-		LEFT JOIN (SELECT pkg_path, COUNT(*) as cnt FROM calls GROUP BY pkg_path) c ON c.pkg_path = p.path
-		LEFT JOIN (SELECT import_path, COUNT(*) as cnt FROM dependencies GROUP BY import_path) dep ON dep.import_path = p.path
+		LEFT JOIN (SELECT pkg_path, network, COUNT(*) as cnt FROM calls` + callFilter + ` GROUP BY network, pkg_path) c
+			ON c.pkg_path = p.path AND c.network = p.network
+		LEFT JOIN (SELECT import_path, network, COUNT(*) as cnt FROM dependencies` + depFilter + ` GROUP BY network, import_path) dep
+			ON dep.import_path = p.path AND dep.network = p.network
 		WHERE p.is_realm = 0` + pFilter + `
 		ORDER BY COALESCE(dep.cnt, 0) DESC LIMIT 15
 	`)
@@ -1842,45 +1891,47 @@ func (d *DB) GetAnalytics(network string) (*Analytics, error) {
 		defer rows2.Close()
 		for rows2.Next() {
 			var r RealmActivity
-			rows2.Scan(&r.Path, &r.Calls, &r.Callers, &r.Dependents, &r.IsRealm)
+			rows2.Scan(&r.Network, &r.Path, &r.Calls, &r.Callers, &r.Dependents, &r.IsRealm)
 			a.TopPackages = append(a.TopPackages, r)
 		}
 	}
 
-	// Top callers
-	callersQ := `SELECT caller, COUNT(*) as c, COUNT(DISTINCT pkg_path) as realms FROM calls` + nFilter + ` GROUP BY caller ORDER BY c DESC LIMIT 15`
+	// Top callers, per chain: the busiest caller on the site is active on two
+	// networks and the next on three, so one row per address would be a sum
+	// across separate actors.
+	callersQ := `SELECT network, caller, COUNT(*) as c, COUNT(DISTINCT pkg_path) as realms FROM calls` + nFilter + ` GROUP BY network, caller ORDER BY c DESC LIMIT 15`
 	rows3, _ := d.db.Query(callersQ)
 	if rows3 != nil {
 		defer rows3.Close()
 		for rows3.Next() {
 			var c CallerActivity
-			rows3.Scan(&c.Address, &c.Calls, &c.Realms)
+			rows3.Scan(&c.Network, &c.Address, &c.Calls, &c.Realms)
 			a.TopCallers = append(a.TopCallers, c)
 		}
 	}
 
 	// Top imports
-	importsQ := `SELECT import_path, COUNT(*) as c FROM dependencies WHERE import_path LIKE 'gno.land/%'`
+	importsQ := `SELECT network, import_path, COUNT(*) as c FROM dependencies WHERE import_path LIKE 'gno.land/%'`
 	importsQ += " AND " + d.networkFilter("network", network)
-	importsQ += ` GROUP BY import_path ORDER BY c DESC LIMIT 15`
+	importsQ += ` GROUP BY network, import_path ORDER BY c DESC LIMIT 15`
 	rows4, _ := d.db.Query(importsQ)
 	if rows4 != nil {
 		defer rows4.Close()
 		for rows4.Next() {
 			var i ImportRank
-			rows4.Scan(&i.Path, &i.Imports)
+			rows4.Scan(&i.Network, &i.Path, &i.Imports)
 			a.TopImports = append(a.TopImports, i)
 		}
 	}
 
 	// Top deployers
-	deployQ := `SELECT creator, COUNT(*) as c, 0 FROM packages` + nFilter + ` GROUP BY creator ORDER BY c DESC LIMIT 15`
+	deployQ := `SELECT network, creator, COUNT(*) as c, 0 FROM packages` + nFilter + ` GROUP BY network, creator ORDER BY c DESC LIMIT 15`
 	rows5, _ := d.db.Query(deployQ)
 	if rows5 != nil {
 		defer rows5.Close()
 		for rows5.Next() {
 			var c CallerActivity
-			rows5.Scan(&c.Address, &c.Calls, &c.Realms)
+			rows5.Scan(&c.Network, &c.Address, &c.Calls, &c.Realms)
 			a.TopDeployers = append(a.TopDeployers, c)
 		}
 	}
@@ -1896,9 +1947,6 @@ func (d *DB) GetAnalytics(network string) (*Analytics, error) {
 			a.RecentRealms = append(a.RecentRealms, p)
 		}
 	}
-
-	_ = callJoinFilter
-	_ = depJoinFilter
 
 	return &a, nil
 }
@@ -2347,17 +2395,39 @@ type GasTimeSlice struct {
 }
 
 type SanityOverview struct {
-	Network            string  `json:"network"`
-	ChainHeight        int     `json:"chain_height"`
-	LastBlockTime      string  `json:"last_block_time"`
-	SecondsSinceBlock  int     `json:"seconds_since_block"`
-	IsAlive            bool    `json:"is_alive"`
-	TxLast1h           int     `json:"tx_last_1h"`
-	TxLast24h          int     `json:"tx_last_24h"`
-	SuccessRate24h     float64 `json:"success_rate_24h"`
-	GasEfficiency24h   float64 `json:"gas_efficiency_24h"`
-	ActiveAddresses24h int     `json:"active_addresses_24h"`
-	NewPackages7d      int     `json:"new_packages_7d"`
+	Network string `json:"network"`
+	// ByNetwork carries one entry per chain in all-networks mode, and is absent
+	// when a single network is selected.
+	//
+	// Liveness is the one figure that cannot be merged at all. It is not even
+	// wrong to sum, the way a denominated amount is — there is simply no such
+	// thing as the height, or the last block time, of four chains at once. This
+	// page used to answer with clientFor(""), which returned an arbitrary entry
+	// of a Go map, so it presented one randomly-chosen chain's liveness under a
+	// global heading.
+	ByNetwork          map[string]SanityLiveness `json:"by_network,omitempty"`
+	ChainHeight        int                       `json:"chain_height"`
+	LastBlockTime      string                    `json:"last_block_time"`
+	SecondsSinceBlock  int                       `json:"seconds_since_block"`
+	IsAlive            bool                      `json:"is_alive"`
+	TxLast1h           int                       `json:"tx_last_1h"`
+	TxLast24h          int                       `json:"tx_last_24h"`
+	SuccessRate24h     float64                   `json:"success_rate_24h"`
+	GasEfficiency24h   float64                   `json:"gas_efficiency_24h"`
+	ActiveAddresses24h int                       `json:"active_addresses_24h"`
+	NewPackages7d      int                       `json:"new_packages_7d"`
+}
+
+// SanityLiveness is the per-chain half of the overview: the figures that come
+// from a live indexer rather than from stored rows.
+type SanityLiveness struct {
+	ChainHeight       int    `json:"chain_height"`
+	LastBlockTime     string `json:"last_block_time,omitempty"`
+	SecondsSinceBlock int    `json:"seconds_since_block"`
+	IsAlive           bool   `json:"is_alive"`
+	// Reachable distinguishes "this chain is not producing blocks" from "we
+	// could not ask it", which look identical in the fields above.
+	Reachable bool `json:"reachable"`
 }
 
 type HealthTimePoint struct {

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,18 @@ a `by_network` object alongside the totals, and the totals are the arithmetic su
 only for the counts. `by_network` is omitted when a single network is selected,
 because then it *is* the total.
 
+Liveness is not merged even that far. There is no such thing as the height, or
+the last block time, of four chains at once, so `/api/sanity/overview` leaves its
+top-level liveness fields empty in all-networks mode and reports each chain under
+`by_network` instead. Each entry carries `reachable`, which separates "this chain
+is not producing blocks" from "we could not ask it" — otherwise identical.
+
+**Ranking rows are keyed by `(identifier, network)`, never by the identifier
+alone.** 193 package paths exist on more than one chain, and the busiest caller
+on the site is active on two. A path or address alone no longer identifies a row,
+so every ranking carries a `network` and the same path may appear once per chain
+with its own figures. This is what the leaderboards mean by a "top" entry.
+
 **`limit`, `offset`** — pagination, where supported. Noted per endpoint below.
 
 ## Caching
@@ -94,13 +106,13 @@ labels this figure "recent" for the same reason.
 | endpoint | description |
 |---|---|
 | `GET /api/stats` | totals: transactions, calls, deploys, msg_runs, sends, realms, packages, unique callers, latest block |
-| `GET /api/analytics` | leaderboards and aggregate breakdowns |
+| `GET /api/analytics` | leaderboards and aggregate breakdowns. Every ranking row carries its `network`; rankings are scoped to the selected chain |
 | `GET /api/gas` | gas usage, by realm |
 | `GET /api/bankstats` | transfer volume statistics. Carries `by_network` in all-networks mode, because volume cannot be summed across chains |
 | `GET /api/tokens` | detected token packages. Rows carry their `network` |
 | `GET /api/validators` | valoper registrations, **served from storage** rather than the indexer. Flat rows with `address`, `moniker`, `func` and `success` — `address` is the validator the call is about, which is not always the caller |
 | `GET /api/govdao` | GovDAO activity. Queries every configured network in all-networks mode |
-| `GET /api/sanity/overview` | internal consistency counters, for debugging a sync |
+| `GET /api/sanity/overview` | consistency counters and liveness. In all-networks mode liveness moves to `by_network`, one entry per chain, each with `reachable` |
 
 ## Time series
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -974,7 +974,10 @@ async function renderTsCharts(container) {
   _tsChartInstances.push(new Chart(realmsCanvas, {
     type: 'bar',
     data: {
-      labels: topRealms.map(r => r.path.replace('gno.land/', '')),
+      // In all-networks mode the same path can appear once per chain, so the
+      // bare path would label two different bars identically.
+      labels: topRealms.map(r => r.path.replace('gno.land/', '') +
+        (getNetwork() === 'all' && r.network ? ' \u00b7 ' + r.network : '')),
       datasets: [
         { label: 'calls',    data: topRealms.map(r => r.calls),    backgroundColor: 'rgba(78,205,196,0.7)',  borderColor: '#4ecdc4', borderWidth: 1 },
         { label: 'callers',  data: topRealms.map(r => r.callers),  backgroundColor: 'rgba(255,107,107,0.5)', borderColor: '#ff6b6b', borderWidth: 1 },
@@ -1897,8 +1900,8 @@ async function loadAnalytics() {
     rtbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'realm'), el('th', {}, 'calls'), el('th', {}, 'callers'), el('th', {}, 'dependents'))));
     const rbody = el('tbody');
     for (const r of (data.top_realms || [])) {
-      rbody.appendChild(el('tr', {},
-        el('td', {}, realmPathEl(r.path)),
+      rbody.appendChild(netRow(r.network,
+        el('td', {}, realmPathEl(r.path, r.network)),
         el('td', {}, fmtNum(r.calls)),
         el('td', {}, fmtNum(r.callers)),
         el('td', {}, fmtNum(r.dependents))
@@ -1913,8 +1916,8 @@ async function loadAnalytics() {
     ptbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'package'), el('th', {}, 'dependents'), el('th', {}, 'calls'))));
     const pbody = el('tbody');
     for (const p of (data.top_packages || [])) {
-      pbody.appendChild(el('tr', {},
-        el('td', {}, realmPathEl(p.path)),
+      pbody.appendChild(netRow(p.network,
+        el('td', {}, realmPathEl(p.path, p.network)),
         el('td', {}, fmtNum(p.dependents)),
         el('td', {}, fmtNum(p.calls))
       ));
@@ -1928,8 +1931,8 @@ async function loadAnalytics() {
     ctbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'address'), el('th', {}, 'calls'), el('th', {}, 'realms'))));
     const cbody = el('tbody');
     for (const c of (data.top_callers || [])) {
-      cbody.appendChild(el('tr', {},
-        el('td', {}, addrLink(c.address)),
+      cbody.appendChild(netRow(c.network,
+        el('td', {}, addrLink(c.address, c.network)),
         el('td', {}, fmtNum(c.calls)),
         el('td', {}, fmtNum(c.realms))
       ));
@@ -1943,8 +1946,8 @@ async function loadAnalytics() {
     dtbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'address'), el('th', {}, 'deploys'))));
     const dbody = el('tbody');
     for (const d of (data.top_deployers || [])) {
-      dbody.appendChild(el('tr', {},
-        el('td', {}, addrLink(d.address)),
+      dbody.appendChild(netRow(d.network,
+        el('td', {}, addrLink(d.address, d.network)),
         el('td', {}, fmtNum(d.calls))
       ));
     }
@@ -1957,8 +1960,8 @@ async function loadAnalytics() {
     itbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'path'), el('th', {}, 'importers'))));
     const ibody = el('tbody');
     for (const i of (data.top_imports || [])) {
-      ibody.appendChild(el('tr', {},
-        el('td', {}, realmPathEl(i.path)),
+      ibody.appendChild(netRow(i.network,
+        el('td', {}, realmPathEl(i.path, i.network)),
         el('td', {}, fmtNum(i.imports))
       ));
     }
@@ -1971,10 +1974,10 @@ async function loadAnalytics() {
     rctbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'realm'), el('th', {}, 'creator'), el('th', {}, 'block'))));
     const rcbody = el('tbody');
     for (const r of (data.recent_realms || [])) {
-      rcbody.appendChild(el('tr', {},
-        el('td', {}, realmPathEl(r.path)),
-        el('td', {}, addrLink(r.creator)),
-        el('td', {}, blockLink(r.block_height))
+      rcbody.appendChild(netRow(r.network,
+        el('td', {}, realmPathEl(r.path, r.network)),
+        el('td', {}, addrLink(r.creator, r.network)),
+        el('td', {}, blockLink(r.block_height, r.network))
       ));
     }
     rctbl.appendChild(rcbody); recentCol.appendChild(rctbl); grid.appendChild(recentCol);
@@ -2170,17 +2173,36 @@ async function loadSanity() {
     const ov = await api('sanity/overview');
     container.textContent = '';
 
-    // Health cards
+    // Health cards.
+    //
+    // Liveness is per-chain and stays per-chain: there is no such thing as the
+    // height, or the last block time, of four networks at once. In all-networks
+    // mode the server sends one entry per chain and they are shown side by side
+    // instead of collapsing to an arbitrary one.
     const cards = el('div', { className: 'stats-bar' });
-    const alive = ov.is_alive
-      ? el('span', { style: { color: '#51cf66', fontWeight: 'bold' } }, '● alive')
-      : el('span', { style: { color: '#ff6b6b', fontWeight: 'bold' } }, '● stale');
-    cards.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'status'), alive));
-    cards.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'height'), el('span', { className: 'value' }, fmtNum(ov.chain_height))));
-    const ago = ov.seconds_since_block < 60
-      ? ov.seconds_since_block + 's ago'
-      : Math.floor(ov.seconds_since_block / 60) + 'm ago';
-    cards.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'last block'), el('span', { className: 'value' }, ago)));
+    const aliveEl = (isAlive, reachable) => reachable === false
+      ? el('span', { style: { color: 'var(--dim)', fontWeight: 'bold' } }, '● unreachable')
+      : isAlive
+        ? el('span', { style: { color: '#51cf66', fontWeight: 'bold' } }, '● alive')
+        : el('span', { style: { color: '#ff6b6b', fontWeight: 'bold' } }, '● stale');
+    const agoOf = secs => secs < 60 ? secs + 's ago' : Math.floor(secs / 60) + 'm ago';
+
+    if (ov.by_network) {
+      for (const [netId, live] of Object.entries(ov.by_network)) {
+        const label = el('span', { className: 'label' });
+        label.appendChild(netDotEl(netId));
+        label.append(netId);
+        const value = el('span', { className: 'value' },
+          live.reachable ? fmtNum(live.chain_height) + ' · ' + agoOf(live.seconds_since_block) : '-');
+        const card = el('div', { className: 'stat' }, label, value);
+        card.appendChild(aliveEl(live.is_alive, live.reachable));
+        cards.appendChild(card);
+      }
+    } else {
+      cards.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'status'), aliveEl(ov.is_alive, true)));
+      cards.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'height'), el('span', { className: 'value' }, fmtNum(ov.chain_height))));
+      cards.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'last block'), el('span', { className: 'value' }, agoOf(ov.seconds_since_block))));
+    }
     cards.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'txs 1h'), el('span', { className: 'value' }, fmtNum(ov.tx_last_1h))));
     cards.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'txs 24h'), el('span', { className: 'value' }, fmtNum(ov.tx_last_24h))));
     const sr = ov.success_rate_24h > 0 ? (ov.success_rate_24h * 100).toFixed(1) + '%' : '-';


### PR DESCRIPTION
Closes the remaining half of #86: `analytics` and `sanity`, the two pages the earlier work left blended.

## The analytics leaderboards were showing other chains' traffic

Not only in all-networks mode — **in single-network mode**, which is the default view.

`GetAnalytics` computed two filters and then threw them away with `_ = callJoinFilter`. The aggregate subqueries joined on `pkg_path` alone, so every ranking counted every chain's activity no matter what was selected. On `/analytics?network=pearl`:

```
path                             calls shown   calls pearl actually has
gno.land/r/demo/defi/grc20reg    22789         0
gno.land/r/gnoland/wugnot        14895         0
gno.land/r/gnops/valopers          368        52
gno.land/r/demo/profile             24         0
```

The top of pearl's leaderboard was two realms with no pearl activity at all, and the ordering of the whole page came from other chains.

After, against the same production snapshot:

```
pearl    gno.land/r/gnops/valopers        calls=52   callers=41
pearl    gno.land/r/.../nft               calls=4    callers=1
pearl    gno.land/r/sys/namereg/v1        calls=1    callers=1
```

## The join key is the fix; the filter is not

I assumed applying the discarded filter was the fix, then checked. It is not: with the network in the join key, removing the filter changes nothing but timing — the compiler flags it as unused. Dropping the *join key* while keeping the filter is what produces wrong numbers, and that is what the test pins.

The distinction matters because **193 package paths now exist on more than one chain**. Issue #86 measured that as zero and filed the collision as hypothetical; pearl launched carrying the same demo realms gnoland1 has, so it is real now and will only grow.

The same applies to addresses: the busiest caller on the site is active on two chains, the next-busiest on three. Rankings are keyed by `(identifier, network)` throughout, and every row carries its network. `total_addresses` counts distinct `(address, network)` pairs — 68,506 blended against 68,806 honest.

## sanity: liveness cannot be merged at all

Not even wrongly, the way a denominated amount can be summed. There is no such thing as the height of four chains at once. The page previously answered from `clientFor("")`, an arbitrary entry of a Go map, presenting one randomly-chosen chain's liveness under a global heading.

It now reports each chain, with `reachable` separating "not producing blocks" from "could not ask":

```
top-level chain_height: 0   is_alive: False
gnoland1   height=3510834   14s ago        reachable=True  alive=True
pearl      height=8871      6s ago         reachable=True  alive=True
sapphire   height=464925    4s ago         reachable=True  alive=True
staging    height=546040    4172359s ago   reachable=True  alive=False
```

staging has been dead for 48 days. Under the old arbitrary pick it could have been presented as the site's global liveness.

The top-level fields stay empty in all-networks mode, because no single value could be right. A single network is unchanged.

## Performance

Splitting the grouping key made the rankings finer-grained, which is more work. Two covering indexes more than pay for it — every case is faster, including the ones that got harder:

| | before | after |
| --- | --- | --- |
| `analytics?network=pearl` | 0.534s | **0.011s** |
| `analytics?network=sapphire` | 2.828s | **2.409s** |
| `analytics` (all networks) | 3.339s | **3.011s** |

`COUNT(DISTINCT caller)` was the whole cost. The old `GROUP BY pkg_path` had a covering index `(pkg_path, caller)` that made the distinct count a linear pass; the network-scoped grouping had no equivalent and fell back to a temp B-tree — 1.60s over 685k rows to produce 159 groups. `(network, pkg_path, caller)` and its mirror `(network, caller, pkg_path)` restore it: 1.29s → 0.26s and 0.69s → 0.26s on the two subqueries.

Two dead ends worth recording, since both produced confident wrong numbers:

I first measured a 3.19s → 5.57s regression and went hunting in the query plan. It was mostly **startup**: the new `CREATE INDEX` over 685k rows and the background `ANALYZE` were still running while I timed. Letting the server settle first gives the real figures.

Before that I theorised the `GROUP BY` term order was wrong for the existing `(network, col)` indexes, swapped every clause to lead with the network, and measured **no change at all**. The swap is harmless and still in the diff, but it was not the problem, and I would have shipped it as the fix had I not measured.

## sanity never drops a chain

`fanOut` skips networks with no client or an open breaker. On any other endpoint that is right — a merged page is best-effort. On this one it is exactly backwards: a chain missing from the liveness report is the one a reader most needs to see. Skipped networks are filled in as unreachable rather than vanishing.

## Frontend

Every analytics table uses `netRow`, so rows carry the chain's dot in all-networks mode, and links thread the network through. The home-page top-realms chart labels bars with `path · network`, since the same path can now legitimately appear twice.

Sanity renders one card per chain, greyed out and marked unreachable when a chain cannot be asked.
