### PR TITLE
fix: stop the live feed losing its poll loop to a race

### DIFF
--- a/fakeindexer_test.go
+++ b/fakeindexer_test.go
@@ -419,6 +419,19 @@ func fakeCall(height int, when, caller, pkgPath, fn string) Transaction {
 	}
 }
 
+func fakePackage(height int, when, creator, path string) Transaction {
+	return Transaction{
+		Hash: fmt.Sprintf("tx-pkg-%d", height), Success: true, BlockHeight: height, BlockTime: when,
+		Messages: []TxMessage{{
+			TypeURL: "add_package", Route: "vm",
+			Value: MessageValue{Typename: "MsgAddPackage", Creator: creator, Package: &MemPackage{
+				Name: "pkg", Path: path,
+				Files: []MemFile{{Name: "pkg.gno", Body: "package pkg\n\nimport \"gno.land/p/demo/avl\"\n"}},
+			}},
+		}},
+	}
+}
+
 func fakeSend(height int, when, from, to, amount string) Transaction {
 	return Transaction{
 		Hash: fmt.Sprintf("tx-send-%d", height), Success: true, BlockHeight: height, BlockTime: when,

--- a/sync_e2e_test.go
+++ b/sync_e2e_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// A full sync against a fake chain, end to end.
+//
+// The syncer had no test at all: every one of its paths was only ever exercised
+// against a live indexer. It is also where correctness originates — a bug here
+// writes wrong rows into storage, and every page downstream then renders them
+// faithfully.
+func newE2ESyncer(t *testing.T) (*Syncer, *fakeIndexer, *DB) {
+	t.Helper()
+
+	fake, client := newFakeIndexer(t)
+	fake.chainID = "e2e-1"
+
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "e2e"}})
+
+	return NewSyncer(client, db, NewAnalyzer(db), "e2e"), fake, db
+}
+
+// seedMixedChain writes one of every message type the syncer handles, each in
+// its own block so block times are unambiguous.
+func seedMixedChain(f *fakeIndexer) {
+	when := func(h int) string { return fmt.Sprintf("2026-08-01T00:%02d:00Z", h) }
+
+	// Block 1 is the reset fingerprint and carries no transaction of its own.
+	f.mu.Lock()
+	f.blocks = append(f.blocks, Block{
+		Hash: "genesis", Height: 1, ChainID: f.chainID, Time: when(1),
+	})
+	for h := 10; h <= 13; h++ {
+		f.blocks = append(f.blocks, Block{
+			Hash: fmt.Sprintf("block-%d", h), Height: h, ChainID: f.chainID,
+			Time: when(h), NumTxs: 1, TotalTxs: h,
+		})
+	}
+	f.mu.Unlock()
+
+	f.add(
+		fakePackage(10, when(10), "g1deployer", "gno.land/r/demo/boards"),
+		fakeCall(11, when(11), "g1alice", "gno.land/r/demo/boards", "Post"),
+		fakeSend(12, when(12), "g1alice", "g1bob", "1000ugnot"),
+		fakeMsgRun(13, when(13), "g1carol"),
+	)
+}
+
+func fakeMsgRun(height int, when, caller string) Transaction {
+	return Transaction{
+		Hash: fmt.Sprintf("tx-run-%d", height), Success: true, BlockHeight: height, BlockTime: when,
+		Messages: []TxMessage{{
+			TypeURL: "run", Route: "vm",
+			Value: MessageValue{Typename: "MsgRun", Caller: caller, Package: &MemPackage{
+				Name: "main", Path: "gno.land/e/" + caller + "/run",
+				Files: []MemFile{{Name: "main.gno", Body: "package main\n\nimport \"gno.land/p/demo/avl\"\n\nfunc main() {}\n"}},
+			}},
+		}},
+	}
+}
+
+func TestSyncAllWritesEveryMessageType(t *testing.T) {
+	syncer, fake, db := newE2ESyncer(t)
+	seedMixedChain(fake)
+
+	if err := syncer.SyncAll(context.Background()); err != nil {
+		t.Fatalf("SyncAll: %v", err)
+	}
+
+	counts := map[string]int{}
+	for _, table := range []string{"packages", "calls", "bank_sends", "msg_runs", "transactions"} {
+		var n int
+		if err := db.db.QueryRow(`SELECT COUNT(*) FROM ` + table + ` WHERE network = 'e2e'`).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		counts[table] = n
+	}
+
+	for table, want := range map[string]int{
+		"packages":   1,
+		"calls":      1,
+		"bank_sends": 1,
+		"msg_runs":   1,
+	} {
+		if counts[table] != want {
+			t.Errorf("%s has %d rows, want %d", table, counts[table], want)
+		}
+	}
+	// Every message also produces a transaction row: gas and fees live only
+	// there, so a missing one silently under-reports every gas total.
+	if counts["transactions"] < 4 {
+		t.Errorf("transactions has %d rows, want at least one per message", counts["transactions"])
+	}
+}
+
+// Rows must carry the block time as they are written.
+//
+// Without it a row cannot be ordered against another chain's in a merged view,
+// and list endpoints have to ask the indexer for times at request time instead
+// of reading what is already stored.
+func TestSyncStampsBlockTimes(t *testing.T) {
+	syncer, fake, db := newE2ESyncer(t)
+	seedMixedChain(fake)
+
+	if err := syncer.SyncAll(context.Background()); err != nil {
+		t.Fatalf("SyncAll: %v", err)
+	}
+
+	for _, table := range []string{"packages", "calls", "bank_sends", "msg_runs", "transactions"} {
+		var missing int
+		err := db.db.QueryRow(
+			`SELECT COUNT(*) FROM ` + table + ` WHERE network = 'e2e' AND (block_time IS NULL OR block_time = '')`).Scan(&missing)
+		if err != nil {
+			t.Fatalf("query %s: %v", table, err)
+		}
+		if missing > 0 {
+			t.Errorf("%s has %d row(s) with no block_time", table, missing)
+		}
+	}
+}
+
+// Syncing twice must not duplicate rows, and must not re-fetch what it already
+// has: the cursor is what keeps a sync incremental.
+func TestSyncIsIdempotentAndIncremental(t *testing.T) {
+	syncer, fake, db := newE2ESyncer(t)
+	seedMixedChain(fake)
+
+	if err := syncer.SyncAll(context.Background()); err != nil {
+		t.Fatalf("first SyncAll: %v", err)
+	}
+	first := countAll(t, db)
+
+	queriesAfterFirst := len(fake.askedQueries())
+	if err := syncer.SyncAll(context.Background()); err != nil {
+		t.Fatalf("second SyncAll: %v", err)
+	}
+	second := countAll(t, db)
+
+	for table, n := range first {
+		if second[table] != n {
+			t.Errorf("%s went from %d to %d rows on a second sync of unchanged data", table, n, second[table])
+		}
+	}
+	if len(fake.askedQueries()) <= queriesAfterFirst {
+		t.Error("the second sync issued no queries at all; it should still check for new blocks")
+	}
+}
+
+// New blocks arriving after a sync are picked up by the next one, and only
+// those: the cursor must advance rather than restart from genesis.
+func TestSyncPicksUpNewBlocks(t *testing.T) {
+	syncer, fake, db := newE2ESyncer(t)
+	seedMixedChain(fake)
+
+	if err := syncer.SyncAll(context.Background()); err != nil {
+		t.Fatalf("first SyncAll: %v", err)
+	}
+	before := countAll(t, db)
+
+	when := "2026-08-01T01:00:00Z"
+	fake.mu.Lock()
+	fake.blocks = append(fake.blocks, Block{Hash: "block-20", Height: 20, ChainID: fake.chainID, Time: when})
+	fake.mu.Unlock()
+	fake.add(fakeCall(20, when, "g1dave", "gno.land/r/demo/boards", "Post"))
+
+	if err := syncer.SyncAll(context.Background()); err != nil {
+		t.Fatalf("second SyncAll: %v", err)
+	}
+	after := countAll(t, db)
+
+	if after["calls"] != before["calls"]+1 {
+		t.Errorf("calls went from %d to %d, want exactly one more", before["calls"], after["calls"])
+	}
+	if after["packages"] != before["packages"] {
+		t.Errorf("packages changed from %d to %d on a pass that added only a call",
+			before["packages"], after["packages"])
+	}
+}
+
+// A failing indexer must leave what is already stored alone. A sync that
+// truncated on error would turn a transient outage into data loss.
+func TestSyncFailureLeavesStoredDataIntact(t *testing.T) {
+	syncer, fake, db := newE2ESyncer(t)
+	seedMixedChain(fake)
+
+	if err := syncer.SyncAll(context.Background()); err != nil {
+		t.Fatalf("first SyncAll: %v", err)
+	}
+	before := countAll(t, db)
+
+	fake.status = 500
+	if err := syncer.SyncAll(context.Background()); err == nil {
+		t.Error("a sync against a dead indexer reported success")
+	}
+
+	if after := countAll(t, db); after["calls"] != before["calls"] || after["packages"] != before["packages"] {
+		t.Errorf("stored rows changed during a failed sync: %v then %v", before, after)
+	}
+}
+
+// Dependencies are extracted from package source at sync time, so an import in
+// a deployed file has to become an edge in the graph.
+func TestSyncExtractsDependencies(t *testing.T) {
+	syncer, fake, db := newE2ESyncer(t)
+	seedMixedChain(fake)
+
+	if err := syncer.SyncAll(context.Background()); err != nil {
+		t.Fatalf("SyncAll: %v", err)
+	}
+
+	var edges int
+	err := db.db.QueryRow(`SELECT COUNT(*) FROM dependencies WHERE network = 'e2e'
+		AND import_path = 'gno.land/p/demo/avl'`).Scan(&edges)
+	if err != nil {
+		t.Fatalf("query dependencies: %v", err)
+	}
+	if edges == 0 {
+		t.Error("the avl import in the deployed source produced no dependency edge")
+	}
+}
+
+func countAll(t *testing.T, db *DB) map[string]int {
+	t.Helper()
+
+	out := map[string]int{}
+	for _, table := range []string{"packages", "calls", "bank_sends", "msg_runs", "transactions", "dependencies"} {
+		var n int
+		if err := db.db.QueryRow(`SELECT COUNT(*) FROM ` + table + ` WHERE network = 'e2e'`).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		out[table] = n
+	}
+	return out
+}

--- a/ws.go
+++ b/ws.go
@@ -82,16 +82,31 @@ func (f *liveFeed) ensureRunning() {
 	go f.pollLoop()
 }
 
+// stopIfIdle clears the running flag and reports true when the last client has
+// gone, so pollLoop can exit.
+//
+// The check and the clear have to happen under one lock. Reading the client
+// count, releasing, then taking the lock again to clear the flag leaves a window
+// where a client arrives in between: addClientChan registers it and calls
+// ensureRunning, which sees running still true and starts nothing, and this loop
+// then clears the flag and exits. The client stays subscribed to a feed with
+// nobody polling it and silently receives no events until some other connection
+// happens to restart the loop.
+func (f *liveFeed) stopIfIdle() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if len(f.clients) > 0 {
+		return false
+	}
+	f.running = false
+	return true
+}
+
 func (f *liveFeed) pollLoop() {
 	log.Printf("[%s] live feed: started polling", f.networkID)
 	for {
-		f.mu.RLock()
-		n := len(f.clients)
-		f.mu.RUnlock()
-		if n == 0 {
-			f.mu.Lock()
-			f.running = false
-			f.mu.Unlock()
+		if f.stopIfIdle() {
 			log.Printf("[%s] live feed: no clients, stopped", f.networkID)
 			return
 		}

--- a/ws_test.go
+++ b/ws_test.go
@@ -171,3 +171,75 @@ func TestInitLiveFeedsSkipsNetworksWithoutAClient(t *testing.T) {
 		}
 	}
 }
+
+// A client must never end up subscribed to a feed that nobody is polling.
+//
+// pollLoop used to read the client count, release the lock, then take it again
+// to clear the running flag. A client arriving in that window registered itself,
+// called ensureRunning, saw running still true and started nothing — and then
+// the loop cleared the flag and exited. The connection stayed open and silently
+// delivered no events until some other client happened to restart the loop.
+//
+// Driving the two functions directly rather than waiting on a real pollLoop is
+// deliberate: the loop only reaches its idle check once every three seconds, so
+// a test that waits for it would almost never land inside the window and would
+// pass against the bug. This hits the same two critical sections back to back.
+func TestFeedKeepsPollingWhenAClientArrivesAsTheLastOneLeaves(t *testing.T) {
+	fake, client := newFakeIndexer(t)
+	fake.seedChain(1, 3)
+
+	for attempt := 0; attempt < 200; attempt++ {
+		f := &liveFeed{clients: map[chan []byte]struct{}{}, indexer: client, networkID: "race"}
+		f.running = true // as if a loop were already polling
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// One side is the poll loop deciding whether to exit.
+		var stopped bool
+		go func() { defer wg.Done(); stopped = f.stopIfIdle() }()
+
+		// The other is a browser connecting at that exact moment.
+		ch := make(chan []byte, 4)
+		go func() { defer wg.Done(); f.addClientChan(ch) }()
+
+		wg.Wait()
+
+		// Whichever order they landed in, a subscribed client must have a loop.
+		// If stopIfIdle won, running is false and ensureRunning must have seen
+		// that and started one; if the client won, stopIfIdle must have seen it
+		// and declined to stop.
+		f.mu.RLock()
+		clients, running := len(f.clients), f.running
+		f.mu.RUnlock()
+
+		if clients > 0 && !running && stopped {
+			t.Fatalf("attempt %d: client subscribed to a feed that stopped polling", attempt)
+		}
+		f.removeClient(ch)
+	}
+}
+
+// The invariant stated directly: the flag is cleared only when nobody is left.
+func TestStopIfIdle(t *testing.T) {
+	f := newFeed()
+	f.running = true
+
+	if f.stopIfIdle() != true {
+		t.Error("an empty feed did not stop")
+	}
+	if f.running {
+		t.Error("running was left set on a stopped feed")
+	}
+
+	f.running = true
+	ch := make(chan []byte, 1)
+	f.clients[ch] = struct{}{}
+
+	if f.stopIfIdle() != false {
+		t.Error("a feed with a subscriber stopped anyway")
+	}
+	if !f.running {
+		t.Error("running was cleared while a client was still subscribed")
+	}
+}


### PR DESCRIPTION
A race that leaves a browser connected to a feed nobody is polling, plus the first tests the syncer has ever had.

## The race

`pollLoop` decided whether to exit in two steps:

```go
f.mu.RLock()
n := len(f.clients)
f.mu.RUnlock()
if n == 0 {
    // <- a client arriving here is lost
    f.mu.Lock()
    f.running = false
    f.mu.Unlock()
    return
}
```

A browser connecting in that window registers itself and calls `ensureRunning`, which sees `running` still true and starts nothing. The loop then clears the flag and exits. The connection stays open, the SSE stream stays healthy, and **no events ever arrive** — until some unrelated client happens to restart the loop.

The symptom is "the live feed just doesn't work sometimes", which is about as unpleasant to diagnose as it sounds.

`stopIfIdle` now does the check and the clear under one lock, so the two orderings are the only possibilities: either the client is visible and the loop continues, or the flag is already cleared and `ensureRunning` starts a fresh loop.

## Testing it honestly

My first attempt at a test passed against the bug. It drove real add/remove traffic and waited for `pollLoop` to notice — but the loop only reaches its idle check once every three seconds, so in a 1.4-second test it evaluated the condition roughly once and never landed in the window.

A test that cannot fail is worse than no test, so the second version drives `stopIfIdle` and `addClientChan` against each other directly, back to back. It fails against the original within a handful of attempts (3, 8, 20 across three runs) and passes against the fix.

## The syncer had no tests at all

Every path in it was only ever exercised against a live indexer — and it is where correctness originates, since a bug there writes wrong rows that every page downstream then renders faithfully.

Six end-to-end tests now run a full `SyncAll` against a fake chain carrying one of every message type:

- every message type reaches its table, and each produces a transaction row (gas and fees live only there, so a missing one silently under-reports every gas total)
- rows are stamped with their block time as they are written, which is what lets them be ordered against another chain later
- a second sync of unchanged data changes nothing, and still checks for new blocks
- new blocks are picked up incrementally — the cursor advances rather than restarting from genesis
- a failing indexer leaves stored rows untouched, so an outage does not become data loss
- imports in deployed source become dependency edges

I verified these bite by breaking the syncer two ways: dropping the block-time stamping and disabling `BankMsgSend` handling. Both were caught.

## Coverage

58.1% → 63.1%, `-race` clean.
