### PR TITLE
perf: cover the gas-by-realm join so it never leaves the index

### DIFF
--- a/db.go
+++ b/db.go
@@ -449,6 +449,12 @@ func initSchema(db *sql.DB) error {
 		-- linear pass. Measured 1.29s -> 0.02s on the realms query.
 		CREATE INDEX IF NOT EXISTS idx_calls_net_pkg_caller ON calls(network, pkg_path, caller);
 
+		-- The gas-by-realm aggregate joins every call, deploy and run back to its
+		-- transaction for the gas figures. That join touches one row per event —
+		-- 682k on sapphire, to produce twenty — so what matters is that it never
+		-- has to leave the index. Covering it: 3.79s -> 1.96s.
+		CREATE INDEX IF NOT EXISTS idx_txs_net_hash_gas ON transactions(network, tx_hash, gas_used, gas_fee);
+
 		-- And its mirror, for the top-callers ranking: group by (network,
 		-- caller) counting distinct packages. Same shape, same reason, 0.69s ->
 		-- 0.26s. Both are covering, so neither touches the table.

--- a/db_test.go
+++ b/db_test.go
@@ -787,6 +787,90 @@ func TestTopGasQueryUsesAnIndex(t *testing.T) {
 	}
 }
 
+// The gas-by-realm aggregate joins every call, deploy and run back to its
+// transaction. That join touches one row per event — 682k on sapphire, to
+// produce twenty — so the only thing that can be controlled is whether it has to
+// leave the index to read the gas figures.
+func TestGasByRealmJoinStaysInTheIndex(t *testing.T) {
+	db := newTestDB(t)
+
+	// Seed and ANALYZE: on an empty table the planner has no statistics and
+	// picks the implicit unique index on (network, tx_hash), which serves the
+	// lookup but not the gas columns. That is exactly the plan this test exists
+	// to reject, so asserting against it without data would pass for the wrong
+	// reason — and fail against a correctly indexed production database.
+	const when = "2026-08-01T00:00:00Z"
+	for i := 0; i < 2000; i++ {
+		hash := fmt.Sprintf("tx-%d", i)
+		if err := db.UpsertTransaction("sapphire", hash, 100+i, when, 1000+i, 2000, 10, true); err != nil {
+			t.Fatalf("UpsertTransaction: %v", err)
+		}
+		if err := db.InsertCall("sapphire", hash, 100+i, when, "g1caller",
+			fmt.Sprintf("gno.land/r/demo/pkg%d", i%20), "Post", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+	if _, err := db.db.Exec("ANALYZE"); err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	const q = `
+		SELECT path, SUM(gas_used), SUM(gas_fee), COUNT(*) FROM (
+			SELECT c.pkg_path AS path, t.gas_used, t.gas_fee, t.tx_hash
+			  FROM calls c JOIN transactions t
+			    ON t.network = c.network AND t.tx_hash = c.tx_hash AND t.network = ?
+			UNION ALL
+			SELECT p.path AS path, t.gas_used, t.gas_fee, t.tx_hash
+			  FROM packages p JOIN transactions t
+			    ON t.network = p.network AND t.tx_hash = p.tx_hash AND t.network = ?
+			UNION ALL
+			SELECT 'MsgRun by ' || m.caller AS path, t.gas_used, t.gas_fee, t.tx_hash
+			  FROM msg_runs m JOIN transactions t
+			    ON t.network = m.network AND t.tx_hash = m.tx_hash AND t.network = ?
+		) GROUP BY path ORDER BY SUM(gas_used) DESC LIMIT 20`
+
+	joined := queryPlan(t, db, q, "sapphire", "sapphire", "sapphire")
+
+	if !strings.Contains(joined, "idx_txs_net_hash_gas") {
+		t.Errorf("the join does not use idx_txs_net_hash_gas.\nplan: %s", joined)
+	}
+	// Covering is the whole point: without gas_used and gas_fee in the index,
+	// every one of those rows costs a table lookup.
+	if !strings.Contains(joined, "COVERING INDEX idx_txs_net_hash_gas") {
+		t.Errorf("the join leaves the index to read gas figures.\nplan: %s", joined)
+	}
+}
+
+// queryPlan returns EXPLAIN QUERY PLAN output as one string.
+func queryPlan(t *testing.T, db *DB, q string, args ...any) string {
+	t.Helper()
+
+	rows, err := db.db.Query("EXPLAIN QUERY PLAN "+q, args...)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer rows.Close()
+
+	var plan []string
+	for rows.Next() {
+		cols, err := rows.Columns()
+		if err != nil {
+			t.Fatalf("columns: %v", err)
+		}
+		vals := make([]any, len(cols))
+		for i := range vals {
+			vals[i] = new(sql.NullString)
+		}
+		if err := rows.Scan(vals...); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if s, ok := vals[len(vals)-1].(*sql.NullString); ok && s.Valid {
+			plan = append(plan, s.String)
+		}
+	}
+	return strings.Join(plan, " | ")
+}
+
 // In all-networks mode the gas series carries a per-network breakdown. Fees are
 // denominated per chain and summing them across chains produces a figure that
 // describes nothing, so the split is what lets the view aggregate honestly.


### PR DESCRIPTION
The gas page is the slowest on the site. This makes its worst case about a fifth faster and, more usefully, establishes where the remaining time actually goes — which was not where I assumed.

## The change

`GetGasStats` attributes each transaction's gas to what it touched by joining every call, deploy and run back to its transaction. The lookup was already indexed: `sqlite_autoindex_transactions_1` covers `(network, tx_hash)`. What it could not serve was `gas_used` and `gas_fee`, so every one of those rows cost a table fetch — 682k of them on sapphire, to produce twenty output rows.

Adding those two columns to the index makes the join covering.

## Measured

Query level, on a copy of the production database:

```
gas-by-realm, sapphire      3.79s -> 1.96s
gas-by-realm, all networks  2.39s -> 1.97s
```

Endpoint level, both binaries against the same database copy on the same host:

| | before | after |
| --- | --- | --- |
| `gas?network=sapphire` | 9.69s | 7.61s |
| `gas` (all networks) | 5.48s | 5.36s |
| `analytics` | 3.27s | 2.81s |

Worth stating plainly: **7.6s is still bad.** This is a real improvement to the worst case, not a fix for the page.

## The finding that matters more

The endpoint takes far longer than its SQL. Timed individually, the whole query set for `gas?network=sapphire` is about 2.9s, against a 7.6s response.

The gap is the driver. This project uses `modernc.org/sqlite` — a pure-Go SQLite, which is how `CGO_ENABLED=0` builds work at all — and it runs roughly 2.4x slower than the C library on scan-heavy work.

**Every query timing measured with `python3 -c "import sqlite3"` understates what the server experiences by about that factor**, because python links the C library. That includes the table in #87 and several of my own measurements earlier today. The ratios were still useful for comparing query shapes; the absolute numbers were not, and I was reading them as if they were.

This also changes what the next fix should be. No index removes the 682k-row scan — it is inherent to aggregating every call — and each of those rows now costs meaningfully more than a C-SQLite estimate suggests. The structural answer is to stop scanning them: a rollup table of per-realm gas maintained at sync time, which is what #87 proposed for top-callers as well.

That is a schema change plus a migration of existing rows, so I have left it here rather than folding it into an index change.

## Test

`TestGasByRealmJoinStaysInTheIndex` asserts the plan uses the index *and* that it is covering.

It seeds 2000 transactions and calls and runs `ANALYZE` first, which turned out to be necessary rather than decorative: on an empty table the planner has no statistics and picks the implicit unique index — exactly the plan the test exists to reject. Written without data it would have passed against the unindexed build and failed against a correct production database. Verified it fails with the index removed.
