### PR TITLE
fix: key bank rankings by network so volumes are not summed across chains

### DIFF
--- a/analytics_test.go
+++ b/analytics_test.go
@@ -273,3 +273,100 @@ func TestSanityListsEveryConfiguredNetwork(t *testing.T) {
 		t.Error("the healthy chain was reported unreachable")
 	}
 }
+
+// seedCrossChainSends puts the same address on two chains with very different
+// volumes, which is the shape that produced a leaderboard row summing two
+// chains' ugnot into a figure describing nothing.
+func seedCrossChainSends(t *testing.T, db *DB) {
+	t.Helper()
+
+	const when = "2026-08-01T00:00:00Z"
+	for i := 0; i < 10; i++ {
+		if err := db.InsertBankSend("busy", itoa(i)+"-busy", 100+i, when,
+			"g1shared", "g1receiver", "1000000ugnot", true); err != nil {
+			t.Fatalf("InsertBankSend: %v", err)
+		}
+	}
+	if err := db.InsertBankSend("quiet", "0-quiet", 100, when,
+		"g1shared", "g1receiver", "5ugnot", true); err != nil {
+		t.Fatalf("InsertBankSend: %v", err)
+	}
+}
+
+// One chain's ugnot is not another's, so a row that sums them is meaningless.
+// Rankings are keyed by (address, network) and each row carries its chain.
+func TestBankRankingsAreKeyedByNetwork(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "busy"}, {ID: "quiet"}})
+	seedCrossChainSends(t, db)
+
+	s, err := db.GetBankStats("")
+	if err != nil {
+		t.Fatalf("GetBankStats: %v", err)
+	}
+
+	byNetwork := map[string]int64{}
+	for _, row := range s.TopSenders {
+		if row.Address != "g1shared" {
+			continue
+		}
+		if row.Network == "" {
+			t.Fatalf("ranking row has no network: %+v", row)
+		}
+		byNetwork[row.Network] = row.Total
+	}
+
+	if len(byNetwork) != 2 {
+		t.Fatalf("g1shared produced %d row(s), want one per chain: %v", len(byNetwork), byNetwork)
+	}
+	if byNetwork["busy"] != 10_000_000 || byNetwork["quiet"] != 5 {
+		t.Errorf("volumes = %v, want busy 10000000 and quiet 5 kept apart", byNetwork)
+	}
+}
+
+// The same address on two chains is two actors, so it counts twice.
+func TestBankCountsAddressesPerNetwork(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "busy"}, {ID: "quiet"}})
+	seedCrossChainSends(t, db)
+
+	s, err := db.GetBankStats("")
+	if err != nil {
+		t.Fatalf("GetBankStats: %v", err)
+	}
+
+	// g1shared and g1receiver, on two chains each.
+	if s.UniqueSenders != 2 {
+		t.Errorf("unique senders = %d, want 2: one address seen on two chains", s.UniqueSenders)
+	}
+	if s.UniqueReceivers != 2 {
+		t.Errorf("unique receivers = %d, want 2", s.UniqueReceivers)
+	}
+	if s.UniqueAddresses != 4 {
+		t.Errorf("unique addresses = %d, want 4: two addresses on two chains each", s.UniqueAddresses)
+	}
+}
+
+// Selecting one chain scopes the rankings to it and drops the redundant label.
+func TestBankStatsScopedToOneNetwork(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "busy"}, {ID: "quiet"}})
+	seedCrossChainSends(t, db)
+
+	s, err := db.GetBankStats("quiet")
+	if err != nil {
+		t.Fatalf("GetBankStats: %v", err)
+	}
+
+	if s.TotalVolume != 5 {
+		t.Errorf("total volume = %d, want quiet's 5 with busy's 10000000 excluded", s.TotalVolume)
+	}
+	for _, row := range s.TopSenders {
+		if row.Network != "quiet" {
+			t.Errorf("row from %q leaked into the quiet view: %+v", row.Network, row)
+		}
+	}
+	if s.ByNetwork != nil {
+		t.Errorf("by_network was sent for a single network: %+v", s.ByNetwork)
+	}
+}

--- a/db.go
+++ b/db.go
@@ -1685,6 +1685,13 @@ func (d *DB) TotalSourceBytes(network string) int {
 }
 
 type AddrStat struct {
+	// Network is the chain this row's figures belong to.
+	//
+	// An address is a different actor on each chain, and its ugnot is a
+	// different asset. Ranking by address alone summed both: one top sender was
+	// showing 900,400,000,000 ugnot that was really two chains' balances added
+	// together, which is a figure describing nothing.
+	Network string `json:"network,omitempty"`
 	Address string `json:"address"`
 	Count   int    `json:"count"`
 	Total   int64  `json:"total"`
@@ -1723,8 +1730,6 @@ func (d *DB) GetBankStats(network string) (*BankStats, error) {
 
 	var s BankStats
 	d.db.QueryRow(`SELECT COUNT(*) FROM bank_sends` + nFilter).Scan(&s.TotalSends)
-	d.db.QueryRow(`SELECT COUNT(DISTINCT from_address) FROM bank_sends` + nFilter).Scan(&s.UniqueSenders)
-	d.db.QueryRow(`SELECT COUNT(DISTINCT to_address) FROM bank_sends` + nFilter).Scan(&s.UniqueReceivers)
 	d.db.QueryRow(`SELECT ` + amountExpr + ` FROM bank_sends` + nFilter).Scan(&s.TotalVolume)
 
 	// One pass for the per-chain breakdown; the grouping key already leads the
@@ -1744,14 +1749,21 @@ func (d *DB) GetBankStats(network string) (*BankStats, error) {
 		}
 	}
 
-	andFilter := " AND " + d.networkFilter("network", network)
-	d.db.QueryRow(`SELECT COUNT(DISTINCT addr) FROM (SELECT from_address as addr FROM bank_sends` + nFilter + ` UNION SELECT to_address FROM bank_sends` + nFilter + `)`).Scan(&s.UniqueAddresses)
+	// Addresses are counted per chain, like everywhere else: the same string on
+	// two chains is two actors. Blended, production reports 68,580 against
+	// 68,672 counted honestly.
+	d.db.QueryRow(`SELECT COUNT(*) FROM (SELECT DISTINCT addr, network FROM (
+		SELECT from_address as addr, network FROM bank_sends` + nFilter + `
+		UNION SELECT to_address, network FROM bank_sends` + nFilter + `))`).Scan(&s.UniqueAddresses)
+	d.db.QueryRow(`SELECT COUNT(*) FROM (SELECT DISTINCT from_address, network FROM bank_sends` + nFilter + `)`).Scan(&s.UniqueSenders)
+	d.db.QueryRow(`SELECT COUNT(*) FROM (SELECT DISTINCT to_address, network FROM bank_sends` + nFilter + `)`).Scan(&s.UniqueReceivers)
 
-	s.TopSenders = d.queryAddrStats(`SELECT from_address, COUNT(*), ` + amountExpr + ` FROM bank_sends` + nFilter + ` GROUP BY from_address ORDER BY COUNT(*) DESC LIMIT 10`)
-	s.TopReceiversVol = d.queryAddrStats(`SELECT to_address, COUNT(*), ` + amountExpr + ` FROM bank_sends` + nFilter + ` GROUP BY to_address ORDER BY ` + amountExpr + ` DESC LIMIT 10`)
-	s.TopReceiversCnt = d.queryAddrStats(`SELECT to_address, COUNT(*), ` + amountExpr + ` FROM bank_sends` + nFilter + ` GROUP BY to_address ORDER BY COUNT(*) DESC LIMIT 10`)
+	// Every ranking leads its GROUP BY with the network, which both keys the row
+	// correctly and matches the (network, address) indexes these read.
+	s.TopSenders = d.queryAddrStats(`SELECT network, from_address, COUNT(*), ` + amountExpr + ` FROM bank_sends` + nFilter + ` GROUP BY network, from_address ORDER BY COUNT(*) DESC LIMIT 10`)
+	s.TopReceiversVol = d.queryAddrStats(`SELECT network, to_address, COUNT(*), ` + amountExpr + ` FROM bank_sends` + nFilter + ` GROUP BY network, to_address ORDER BY ` + amountExpr + ` DESC LIMIT 10`)
+	s.TopReceiversCnt = d.queryAddrStats(`SELECT network, to_address, COUNT(*), ` + amountExpr + ` FROM bank_sends` + nFilter + ` GROUP BY network, to_address ORDER BY COUNT(*) DESC LIMIT 10`)
 
-	_ = andFilter
 	return &s, nil
 }
 
@@ -1966,7 +1978,7 @@ func (d *DB) queryAddrStats(query string) []AddrStat {
 	var result []AddrStat
 	for rows.Next() {
 		var s AddrStat
-		if err := rows.Scan(&s.Address, &s.Count, &s.Total); err != nil {
+		if err := rows.Scan(&s.Network, &s.Address, &s.Count, &s.Total); err != nil {
 			continue
 		}
 		result = append(result, s)

--- a/docs/api.md
+++ b/docs/api.md
@@ -108,7 +108,7 @@ labels this figure "recent" for the same reason.
 | `GET /api/stats` | totals: transactions, calls, deploys, msg_runs, sends, realms, packages, unique callers, latest block |
 | `GET /api/analytics` | leaderboards and aggregate breakdowns. Every ranking row carries its `network`; rankings are scoped to the selected chain |
 | `GET /api/gas` | gas usage, by realm |
-| `GET /api/bankstats` | transfer volume statistics. Carries `by_network` in all-networks mode, because volume cannot be summed across chains |
+| `GET /api/bankstats` | transfer volume statistics. Carries `by_network` in all-networks mode, because volume cannot be summed across chains. Every ranking row is keyed by `(address, network)` and carries its `network` |
 | `GET /api/tokens` | detected token packages. Rows carry their `network` |
 | `GET /api/validators` | valoper registrations, **served from storage** rather than the indexer. Flat rows with `address`, `moniker`, `func` and `success` — `address` is the validator the call is about, which is not always the caller |
 | `GET /api/govdao` | GovDAO activity. Queries every configured network in all-networks mode |

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1695,8 +1695,8 @@ async function loadTokens() {
       tbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'address'), el('th', {}, 'txs'), el('th', {}, 'volume'))));
       const body = el('tbody');
       for (const s of bank.top_senders) {
-        body.appendChild(el('tr', {},
-          el('td', {}, addrLink(s.address)),
+        body.appendChild(netRow(s.network,
+          el('td', {}, addrLink(s.address, s.network)),
           el('td', {}, fmtNum(s.count)),
           el('td', {}, fmtNum(Math.floor(s.total / 1000000)) + ' GNOT')
         ));
@@ -1712,8 +1712,8 @@ async function loadTokens() {
       tbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'address'), el('th', {}, 'volume'), el('th', {}, 'txs'))));
       const body = el('tbody');
       for (const s of bank.top_receivers_volume) {
-        body.appendChild(el('tr', {},
-          el('td', {}, addrLink(s.address)),
+        body.appendChild(netRow(s.network,
+          el('td', {}, addrLink(s.address, s.network)),
           el('td', {}, fmtNum(Math.floor(s.total / 1000000)) + ' GNOT'),
           el('td', {}, fmtNum(s.count))
         ));
@@ -1729,8 +1729,8 @@ async function loadTokens() {
       tbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'address'), el('th', {}, 'txs'), el('th', {}, 'volume'))));
       const body = el('tbody');
       for (const s of bank.top_receivers_count) {
-        body.appendChild(el('tr', {},
-          el('td', {}, addrLink(s.address)),
+        body.appendChild(netRow(s.network,
+          el('td', {}, addrLink(s.address, s.network)),
           el('td', {}, fmtNum(s.count)),
           el('td', {}, fmtNum(Math.floor(s.total / 1000000)) + ' GNOT')
         ));


### PR DESCRIPTION
`/api/bankstats` had the same defect #86 catalogued and #107 fixed for analytics: it ranks by address alone and sums each address's ugnot across chains.

It was not in #86's audit, and it kept the shape after that issue was closed.

## What it was showing

The fifth-ranked sender on production, before and after:

```
before   g18qhq2fl54lszhmxeyqlvxnwjzc3xpu4nnakclp   sends=3174   vol=900400000000
after    g18qhq2fl54lszhmxeyqlvxnwjzc3xpu4nnakclp   sends=3111   vol=885700000000   (sapphire)
```

The difference is 63 sends and 14.7 billion ugnot belonging to a **different chain**, folded into one row and one total. That figure was not an approximation of anything — gnoland1 ugnot and sapphire ugnot are not the same asset, so their sum describes nothing. This is the exact category error #86 was opened about, appearing per-row in a leaderboard rather than in a headline total.

The distinct counts had the matching problem, collapsing an address seen on two chains into one:

```
unique senders     61,617 -> 61,637
unique receivers   68,547 -> 68,653
unique addresses   68,580 -> 68,688
```

## The change

`AddrStat` carries a `network`, every ranking groups by `(network, address)`, and the distinct counts count `(address, network)` pairs. The frontend renders the chain dot and threads the network into each address link, same as the other tables.

Leading the `GROUP BY` with the network also matches the existing `(network, from_address)` and `(network, to_address)` indexes, so the correct query is not the slower one.

I also removed a `_ = andFilter` — a computed-then-discarded filter of exactly the kind that turned out to be a live bug in `GetAnalytics`. This one really was only dead code; the filter it duplicated was already applied everywhere it needed to be. I checked rather than assuming, because the same smell had already misled me once today.

## Not fixed here

The endpoint is still ~3.4s. That is unchanged by this PR and is the same underlying problem as #110: seven separate aggregate passes over `bank_sends`, several of them `COUNT(DISTINCT)` over the whole table. Noted there as a candidate for the same rollup treatment.

## Tests

Three, over a fixture where one address sends on two chains with wildly different volumes:

- rankings produce one row per chain, with 10,000,000 and 5 kept apart
- an address on two chains counts twice
- selecting one chain scopes the rankings and drops the now-redundant `by_network`

Verified the first fails against the old grouping — it reports `busy:10000005`, the two chains' ugnot added together.
