### PR TITLE
fix: scope every aggregate to configured networks and count addresses per chain

### DIFF
--- a/db.go
+++ b/db.go
@@ -1530,7 +1530,9 @@ func (d *DB) GetStats(network string) (*Stats, error) {
 	d.db.QueryRow(`SELECT COUNT(*) FROM msg_runs` + nf).Scan(&s.TotalMsgRuns)
 	d.db.QueryRow(`SELECT COUNT(*) FROM bank_sends` + nf).Scan(&s.TotalSends)
 	s.TotalTxs = s.TotalCalls + s.TotalDeploys + s.TotalMsgRuns + s.TotalSends
-	d.db.QueryRow(`SELECT COUNT(DISTINCT caller) FROM calls` + nf).Scan(&s.UniqueCallers)
+	// Per (caller, network): the same address on two chains is two actors, and
+	// collapsing them undercounts. 19,054 blended against 19,117 on production.
+	d.db.QueryRow(`SELECT COUNT(*) FROM (SELECT DISTINCT caller, network FROM calls` + nf + `)`).Scan(&s.UniqueCallers)
 	d.db.QueryRow(`SELECT COALESCE(MAX(block_height), 0) FROM packages` + nf).Scan(&s.LatestBlock)
 	return &s, nil
 }
@@ -2066,10 +2068,13 @@ func (d *DB) GetTransactionTimeSeries(network, granularity string, days int) ([]
 	sqlFmt, step, truncFn := timeseriesFormat(granularity)
 	startTime := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
 
-	netFilter := ""
-	if network != "" {
-		netFilter = " AND t.network = ?"
-	}
+	// Scope to the configured networks, always.
+	//
+	// An empty filter is not "all networks" — it is "every network ever synced",
+	// including retired ones whose rows are still here. topaz has been gone for
+	// months and still holds 3,093 transactions, 2,945 calls and 272 packages in
+	// production, and every unfiltered series above was quietly counting them.
+	netFilter := " AND " + d.networkFilter("t.network", network)
 
 	subq := func(table, typ string) string {
 		return fmt.Sprintf(
@@ -2086,13 +2091,7 @@ func (d *DB) GetTransactionTimeSeries(network, granularity string, days int) ([]
 		" UNION ALL " + subq("bank_sends", "sends") +
 		" ORDER BY bucket ASC"
 
-	var args []any
-	for range 4 {
-		args = append(args, startTime)
-		if network != "" {
-			args = append(args, network)
-		}
-	}
+	args := []any{startTime, startTime, startTime, startTime}
 
 	rows, err := d.db.Query(q, args...)
 	if err != nil {
@@ -2140,10 +2139,13 @@ func (d *DB) GetPackageTimeSeries(network, granularity string, days int) ([]PkgT
 	sqlFmt, step, truncFn := timeseriesFormat(granularity)
 	startTime := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
 
-	netFilter := ""
-	if network != "" {
-		netFilter = " AND t.network = ?"
-	}
+	// Scope to the configured networks, always.
+	//
+	// An empty filter is not "all networks" — it is "every network ever synced",
+	// including retired ones whose rows are still here. topaz has been gone for
+	// months and still holds 3,093 transactions, 2,945 calls and 272 packages in
+	// production, and every unfiltered series above was quietly counting them.
+	netFilter := " AND " + d.networkFilter("t.network", network)
 
 	subq := func(typ string, isRealm int) string {
 		return fmt.Sprintf(
@@ -2158,13 +2160,7 @@ func (d *DB) GetPackageTimeSeries(network, granularity string, days int) ([]PkgT
 		" UNION ALL " + subq("realms", 1) +
 		" ORDER BY bucket ASC"
 
-	var args []any
-	for range 2 {
-		args = append(args, startTime)
-		if network != "" {
-			args = append(args, network)
-		}
-	}
+	args := []any{startTime, startTime}
 
 	rows, err := d.db.Query(q, args...)
 	if err != nil {
@@ -2201,6 +2197,23 @@ func (d *DB) GetPackageTimeSeries(network, granularity string, days int) ([]PkgT
 	), nil
 }
 
+// perChainBucketCount builds a per-bucket count of distinct addresses, keyed by
+// (address, network) rather than by address alone.
+//
+// The same address on two chains is two actors with two histories, so counting
+// it once undercounts. Every address figure in the project is counted this way;
+// doing it here too is what keeps a series' components consistent with the
+// totals computed beside them, rather than producing a page whose own numbers
+// contradict each other.
+func perChainBucketCount(sqlFmt, typ, column, from, netFilter string) string {
+	return fmt.Sprintf(
+		"SELECT bucket, '%s' as typ, COUNT(*) as cnt FROM ("+
+			" SELECT DISTINCT strftime('%s', t.block_time) as bucket, %s, t.network"+
+			" FROM %s WHERE t.block_time >= ?%s"+
+			") GROUP BY bucket",
+		typ, sqlFmt, column, from, netFilter)
+}
+
 func (d *DB) GetCallerTimeSeries(network, granularity string, days int) ([]CallerTimePoint, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
@@ -2208,40 +2221,26 @@ func (d *DB) GetCallerTimeSeries(network, granularity string, days int) ([]Calle
 	sqlFmt, step, truncFn := timeseriesFormat(granularity)
 	startTime := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
 
-	netFilter := ""
-	if network != "" {
-		netFilter = " AND t.network = ?"
-	}
+	// Scope to the configured networks, always.
+	//
+	// An empty filter is not "all networks" — it is "every network ever synced",
+	// including retired ones whose rows are still here. topaz has been gone for
+	// months and still holds 3,093 transactions, 2,945 calls and 272 packages in
+	// production, and every unfiltered series above was quietly counting them.
+	netFilter := " AND " + d.networkFilter("t.network", network)
 
 	subqs := []string{
-		fmt.Sprintf(
-			"SELECT strftime('%s', t.block_time) as bucket, 'callers' as typ, COUNT(DISTINCT t.caller) as cnt"+
-				" FROM calls t"+
-				" WHERE t.block_time >= ?%s"+
-				" GROUP BY bucket",
-			sqlFmt, netFilter),
-		fmt.Sprintf(
-			"SELECT strftime('%s', t.block_time) as bucket, 'deployers' as typ, COUNT(DISTINCT t.creator) as cnt"+
-				" FROM packages t"+
-				" WHERE t.block_time >= ?%s"+
-				" GROUP BY bucket",
-			sqlFmt, netFilter),
-		fmt.Sprintf(
-			"SELECT strftime('%s', t.block_time) as bucket, 'senders' as typ, COUNT(DISTINCT t.from_address) as cnt"+
-				" FROM bank_sends t"+
-				" WHERE t.block_time >= ?%s"+
-				" GROUP BY bucket",
-			sqlFmt, netFilter),
+		// Counted per (address, network), like every other address figure: the
+		// same address on two chains is two actors. Counting the pair keeps this
+		// consistent with total_active in the active-addresses series, which
+		// would otherwise be computed one way and its components another.
+		perChainBucketCount(sqlFmt, "callers", "t.caller", "calls t", netFilter),
+		perChainBucketCount(sqlFmt, "deployers", "t.creator", "packages t", netFilter),
+		perChainBucketCount(sqlFmt, "senders", "t.from_address", "bank_sends t", netFilter),
 	}
 	q := strings.Join(subqs, " UNION ALL ") + " ORDER BY bucket ASC"
 
-	var args []any
-	for range 3 {
-		args = append(args, startTime)
-		if network != "" {
-			args = append(args, network)
-		}
-	}
+	args := []any{startTime, startTime, startTime}
 
 	rows, err := d.db.Query(q, args...)
 	if err != nil {
@@ -2294,12 +2293,8 @@ func (d *DB) GetStorageTimeSeries(network, realmPath, granularity string, days i
 	sqlFmt, step, truncFn := timeseriesFormat(granularity)
 	startTime := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
 
-	extraFilters := ""
+	extraFilters := " AND " + d.networkFilter("p.network", network)
 	args := []any{startTime}
-	if network != "" {
-		extraFilters += " AND p.network = ?"
-		args = append(args, network)
-	}
 	if realmPath != "" {
 		extraFilters += " AND p.path = ?"
 		args = append(args, realmPath)
@@ -2570,28 +2565,23 @@ func (d *DB) GetSanityOverview(network string) (*SanityOverview, error) {
 
 	ov := &SanityOverview{Network: network}
 
-	netFilter := ""
-	if network != "" {
-		netFilter = " AND network = ?"
-	}
+	// Scope to the configured networks, always.
+	//
+	// An empty filter is not "all networks" — it is "every network ever synced",
+	// including retired ones whose rows are still here. topaz has been gone for
+	// months and still holds 3,093 transactions, 2,945 calls and 272 packages in
+	// production, and every unfiltered series above was quietly counting them.
+	netFilter := " AND " + d.networkFilter("network", network)
 
 	now := time.Now().UTC()
 	since1h := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	since24h := now.Add(-24 * time.Hour).Format(time.RFC3339)
 	since7d := now.Add(-7 * 24 * time.Hour).Format(time.RFC3339)
 
-	args1h := []any{since1h}
-	if network != "" {
-		args1h = append(args1h, network)
-	}
-	d.db.QueryRow(`SELECT COUNT(*) FROM transactions WHERE block_time >= ?`+netFilter, args1h...).Scan(&ov.TxLast1h)
+	d.db.QueryRow(`SELECT COUNT(*) FROM transactions WHERE block_time >= ?`+netFilter, since1h).Scan(&ov.TxLast1h)
 
-	args24h := []any{since24h}
-	if network != "" {
-		args24h = append(args24h, network)
-	}
 	var total24h, success24h, gasUsed24h, gasWanted24h int
-	d.db.QueryRow(`SELECT COUNT(*), SUM(CASE WHEN success THEN 1 ELSE 0 END), SUM(gas_used), SUM(gas_wanted) FROM transactions WHERE block_time >= ?`+netFilter, args24h...).Scan(&total24h, &success24h, &gasUsed24h, &gasWanted24h)
+	d.db.QueryRow(`SELECT COUNT(*), SUM(CASE WHEN success THEN 1 ELSE 0 END), SUM(gas_used), SUM(gas_wanted) FROM transactions WHERE block_time >= ?`+netFilter, since24h).Scan(&total24h, &success24h, &gasUsed24h, &gasWanted24h)
 	ov.TxLast24h = total24h
 	if total24h > 0 {
 		ov.SuccessRate24h = float64(success24h) / float64(total24h)
@@ -2600,27 +2590,21 @@ func (d *DB) GetSanityOverview(network string) (*SanityOverview, error) {
 		ov.GasEfficiency24h = float64(gasUsed24h) / float64(gasWanted24h)
 	}
 
-	addrArgs := []any{since24h, since24h, since24h}
-	addrQuery := `SELECT COUNT(DISTINCT addr) FROM (
-		SELECT caller as addr FROM calls WHERE block_time >= ?
-		UNION SELECT creator FROM packages WHERE block_time >= ?
-		UNION SELECT from_address FROM bank_sends WHERE block_time >= ?
-	)`
-	if network != "" {
-		addrArgs = []any{since24h, network, since24h, network, since24h, network}
-		addrQuery = `SELECT COUNT(DISTINCT addr) FROM (
-			SELECT caller as addr FROM calls WHERE block_time >= ? AND network = ?
-			UNION SELECT creator FROM packages WHERE block_time >= ? AND network = ?
-			UNION SELECT from_address FROM bank_sends WHERE block_time >= ? AND network = ?
-		)`
-	}
-	d.db.QueryRow(addrQuery, addrArgs...).Scan(&ov.ActiveAddresses24h)
+	// Scoped to the configured networks and counted per chain.
+	//
+	// This one was wrong in two directions at once: the all-networks branch had
+	// no network filter at all, so it counted retired topaz, and the distinct
+	// count collapsed an address seen on two chains into one. On production:
+	// 63,404 as written, 63,343 once topaz is excluded, 63,421 counted honestly.
+	addrFilter := " AND " + d.networkFilter("network", network)
+	addrQuery := `SELECT COUNT(*) FROM (SELECT DISTINCT addr, network FROM (
+		SELECT caller as addr, network FROM calls WHERE block_time >= ?` + addrFilter + `
+		UNION SELECT creator, network FROM packages WHERE block_time >= ?` + addrFilter + `
+		UNION SELECT from_address, network FROM bank_sends WHERE block_time >= ?` + addrFilter + `
+	))`
+	d.db.QueryRow(addrQuery, since24h, since24h, since24h).Scan(&ov.ActiveAddresses24h)
 
-	args7d := []any{since7d}
-	if network != "" {
-		args7d = append(args7d, network)
-	}
-	d.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE block_time >= ?`+netFilter, args7d...).Scan(&ov.NewPackages7d)
+	d.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE block_time >= ?`+netFilter, since7d).Scan(&ov.NewPackages7d)
 
 	return ov, nil
 }
@@ -2632,10 +2616,13 @@ func (d *DB) GetHealthTimeSeries(network, granularity string, days int) ([]Healt
 	sqlFmt, step, truncFn := timeseriesFormat(granularity)
 	startTime := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
 
-	netFilter := ""
-	if network != "" {
-		netFilter = " AND t.network = ?"
-	}
+	// Scope to the configured networks, always.
+	//
+	// An empty filter is not "all networks" — it is "every network ever synced",
+	// including retired ones whose rows are still here. topaz has been gone for
+	// months and still holds 3,093 transactions, 2,945 calls and 272 packages in
+	// production, and every unfiltered series above was quietly counting them.
+	netFilter := " AND " + d.networkFilter("t.network", network)
 
 	q := fmt.Sprintf(
 		"SELECT strftime('%s', t.block_time) as bucket,"+
@@ -2647,12 +2634,7 @@ func (d *DB) GetHealthTimeSeries(network, granularity string, days int) ([]Healt
 			" GROUP BY bucket ORDER BY bucket ASC",
 		sqlFmt, netFilter)
 
-	args := []any{startTime}
-	if network != "" {
-		args = append(args, network)
-	}
-
-	rows, err := d.db.Query(q, args...)
+	rows, err := d.db.Query(q, startTime)
 	if err != nil {
 		return nil, err
 	}
@@ -2707,13 +2689,9 @@ func (d *DB) GetRealmsWithStorage(network string, days int) ([]string, error) {
 		FROM package_files pf
 		JOIN packages p ON p.network = pf.network AND p.path = pf.package_path
 		WHERE p.block_time >= ? AND p.is_realm = 1`
-	args := []any{startTime}
-	if network != "" {
-		q += " AND p.network = ?"
-		args = append(args, network)
-	}
+	q += " AND " + d.networkFilter("p.network", network)
 	q += " ORDER BY p.path ASC"
-	rows, err := d.db.Query(q, args...)
+	rows, err := d.db.Query(q, startTime)
 	if err != nil {
 		return nil, err
 	}
@@ -2736,26 +2714,24 @@ func (d *DB) GetActiveAddressTimeSeries(network, granularity string, days int) (
 	sqlFmt, step, truncFn := timeseriesFormat(granularity)
 	startTime := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
 
-	netFilter := ""
-	if network != "" {
-		netFilter = " AND t.network = ?"
-	}
+	// Scope to the configured networks, always.
+	//
+	// An empty filter is not "all networks" — it is "every network ever synced",
+	// including retired ones whose rows are still here. topaz has been gone for
+	// months and still holds 3,093 transactions, 2,945 calls and 272 packages in
+	// production, and every unfiltered series above was quietly counting them.
+	netFilter := " AND " + d.networkFilter("t.network", network)
 
-	// Individual counts: callers, deployers, senders
+	// Individual counts: callers, deployers, senders — counted the same way as
+	// the union total below, so the parts agree with the whole.
 	subqs := []string{
-		fmt.Sprintf("SELECT strftime('%s', t.block_time) as bucket, 'callers' as typ, COUNT(DISTINCT t.caller) as cnt FROM calls t WHERE t.block_time >= ?%s GROUP BY bucket", sqlFmt, netFilter),
-		fmt.Sprintf("SELECT strftime('%s', t.block_time) as bucket, 'deployers' as typ, COUNT(DISTINCT t.creator) as cnt FROM packages t WHERE t.block_time >= ?%s GROUP BY bucket", sqlFmt, netFilter),
-		fmt.Sprintf("SELECT strftime('%s', t.block_time) as bucket, 'senders' as typ, COUNT(DISTINCT t.from_address) as cnt FROM bank_sends t WHERE t.block_time >= ?%s GROUP BY bucket", sqlFmt, netFilter),
+		perChainBucketCount(sqlFmt, "callers", "t.caller", "calls t", netFilter),
+		perChainBucketCount(sqlFmt, "deployers", "t.creator", "packages t", netFilter),
+		perChainBucketCount(sqlFmt, "senders", "t.from_address", "bank_sends t", netFilter),
 	}
 	q := strings.Join(subqs, " UNION ALL ") + " ORDER BY bucket ASC"
 
-	var args []any
-	for range 3 {
-		args = append(args, startTime)
-		if network != "" {
-			args = append(args, network)
-		}
-	}
+	args := []any{startTime, startTime, startTime}
 
 	rows, err := d.db.Query(q, args...)
 	if err != nil {
@@ -2788,24 +2764,23 @@ func (d *DB) GetActiveAddressTimeSeries(network, granularity string, days int) (
 		return nil, err
 	}
 
-	// Union total active addresses per bucket
-	var unionNetFilter string
-	var unionArgs []any
-	if network != "" {
-		unionNetFilter = " AND network = ?"
-		unionArgs = []any{startTime, network, startTime, network, startTime, network}
-	} else {
-		unionArgs = []any{startTime, startTime, startTime}
-	}
+	// Union total active addresses per bucket, counted per chain.
+	//
+	// COUNT(DISTINCT addr) collapses an address seen on two chains into one, but
+	// it is two actors with two histories — the same reasoning as everywhere
+	// else. The inner query already carries the network, so counting the pair
+	// costs nothing extra.
+	unionNetFilter := " AND " + d.networkFilter("network", network)
 	unionQ := fmt.Sprintf(
-		"SELECT strftime('%s', block_time) as bucket, COUNT(DISTINCT addr) as cnt FROM ("+
-			" SELECT caller as addr, block_time, network FROM calls WHERE block_time >= ?%s"+
-			" UNION SELECT creator, block_time, network FROM packages WHERE block_time >= ?%s"+
-			" UNION SELECT from_address, block_time, network FROM bank_sends WHERE block_time >= ?%s"+
-			") GROUP BY bucket ORDER BY bucket ASC",
+		"SELECT bucket, COUNT(*) as cnt FROM ("+
+			" SELECT DISTINCT strftime('%s', block_time) as bucket, addr, network FROM ("+
+			"  SELECT caller as addr, block_time, network FROM calls WHERE block_time >= ?%s"+
+			"  UNION SELECT creator, block_time, network FROM packages WHERE block_time >= ?%s"+
+			"  UNION SELECT from_address, block_time, network FROM bank_sends WHERE block_time >= ?%s"+
+			" )) GROUP BY bucket ORDER BY bucket ASC",
 		sqlFmt, unionNetFilter, unionNetFilter, unionNetFilter)
 
-	urows, err := d.db.Query(unionQ, unionArgs...)
+	urows, err := d.db.Query(unionQ, startTime, startTime, startTime)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,7 +12,9 @@ All responses are JSON. Errors are `{"error": "..."}` with a non-200 status.
 | `all`, or omitted | every **configured** network |
 | anything else | `404 {"error": "network not found"}` |
 
-"Every configured network" is not the same as "no filter". Rows survive a network
+This applies to the time series and the sanity counters too, which until
+recently used no filter at all in that mode and so reported every network ever
+synced. "Every configured network" is not the same as "no filter". Rows survive a network
 being removed from the config — a retired testnet keeps its history in the
 database — and those rows are excluded. Removing topaz from the config dropped
 4,101 transactions and 187 realms out of the all-networks totals, which is

--- a/scoping_test.go
+++ b/scoping_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Every aggregate must be scoped to the configured networks and must count
+// addresses per chain.
+//
+// Two distinct defects hid behind the same code shape, `netFilter := ""` when no
+// network is selected:
+//
+//   - An empty filter is not "all networks", it is "every network ever synced".
+//     Retired chains keep their rows — topaz has been gone for months and still
+//     holds 3,093 transactions in production — and every unfiltered aggregate
+//     was counting them.
+//   - COUNT(DISTINCT addr) collapses an address seen on two chains into one
+//     actor, which undercounts. On production, 63,404 active addresses reported
+//     against 63,421 counted honestly.
+//
+// These queries also ignore their errors: a malformed one leaves the destination
+// at zero rather than failing. So this asserts on values, not on error returns —
+// a broken query shows up as a zero where a number belongs, which is exactly how
+// it would reach a user.
+func seedThreeNetworks(t *testing.T, db *DB) {
+	t.Helper()
+
+	when := time.Now().UTC().Add(-time.Hour).Format("2006-01-02T15:04:05Z")
+
+	// "shared" acts on both live chains; "solo" on only one. "retired" is a
+	// chain that is no longer configured but whose rows remain.
+	for _, net := range []string{"live1", "live2", "retired"} {
+		for i := 0; i < 3; i++ {
+			hash := fmt.Sprintf("%s-tx-%d", net, i)
+			if err := db.UpsertTransaction(net, hash, 100+i, when, 1000, 2000, 10, true); err != nil {
+				t.Fatalf("UpsertTransaction: %v", err)
+			}
+			if err := db.InsertCall(net, hash, 100+i, when, "g1shared",
+				"gno.land/r/demo/boards", "Post", true); err != nil {
+				t.Fatalf("InsertCall: %v", err)
+			}
+		}
+		if err := db.InsertCall(net, net+"-solo", 200, when, "g1"+net, "gno.land/r/demo/boards", "Post", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+		if err := db.UpsertPackage(net, "gno.land/r/"+net+"/pkg", "pkg", "g1shared",
+			net+"-deploy", 300, when, true, 1); err != nil {
+			t.Fatalf("UpsertPackage: %v", err)
+		}
+		if err := db.InsertBankSend(net, net+"-send", 400, when, "g1shared", "g1recv", "5ugnot", true); err != nil {
+			t.Fatalf("InsertBankSend: %v", err)
+		}
+	}
+}
+
+func newScopedDB(t *testing.T) *DB {
+	t.Helper()
+
+	db := newTestDB(t)
+	// "retired" is deliberately absent: its rows exist, its configuration does not.
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "live1"}, {ID: "live2"}})
+	seedThreeNetworks(t, db)
+	return db
+}
+
+func TestStatsExcludeRetiredNetworksAndCountCallersPerChain(t *testing.T) {
+	db := newScopedDB(t)
+
+	s, err := db.GetStats("")
+	if err != nil {
+		t.Fatalf("GetStats: %v", err)
+	}
+
+	// 4 calls per network on two live networks.
+	if s.TotalCalls != 8 {
+		t.Errorf("total calls = %d, want 8; retired rows must not be counted", s.TotalCalls)
+	}
+	// g1shared on both chains plus g1live1 and g1live2 = four actors.
+	if s.UniqueCallers != 4 {
+		t.Errorf("unique callers = %d, want 4: g1shared counts once per chain", s.UniqueCallers)
+	}
+}
+
+func TestSanityOverviewIsScopedAndCountsPerChain(t *testing.T) {
+	db := newScopedDB(t)
+
+	ov, err := db.GetSanityOverview("")
+	if err != nil {
+		t.Fatalf("GetSanityOverview: %v", err)
+	}
+
+	if ov.TxLast24h != 6 {
+		t.Errorf("txs in 24h = %d, want 6 across the two live chains", ov.TxLast24h)
+	}
+	// Per (address, network): g1shared and the two solo callers on their own
+	// chain, plus g1shared as a deployer — all already counted — over 2 chains.
+	if ov.ActiveAddresses24h != 4 {
+		t.Errorf("active addresses = %d, want 4 counted per chain", ov.ActiveAddresses24h)
+	}
+	if ov.NewPackages7d != 2 {
+		t.Errorf("new packages = %d, want 2; the retired chain's deploy must not count", ov.NewPackages7d)
+	}
+}
+
+// Each time series, exercised end to end. A query with the wrong argument count
+// returns no rows rather than an error, so an empty series is the symptom.
+func TestTimeSeriesAreScopedToConfiguredNetworks(t *testing.T) {
+	db := newScopedDB(t)
+
+	tests := []struct {
+		name string
+		run  func() (int, int, error) // points, total counted
+	}{
+		{
+			name: "transactions",
+			run: func() (int, int, error) {
+				pts, err := db.GetTransactionTimeSeries("", "daily", 7)
+				total := 0
+				for _, p := range pts {
+					total += p.Calls
+				}
+				return len(pts), total, err
+			},
+		},
+		{
+			name: "packages",
+			run: func() (int, int, error) {
+				pts, err := db.GetPackageTimeSeries("", "daily", 7)
+				total := 0
+				for _, p := range pts {
+					total += p.Total
+				}
+				return len(pts), total, err
+			},
+		},
+		{
+			name: "callers",
+			run: func() (int, int, error) {
+				pts, err := db.GetCallerTimeSeries("", "daily", 7)
+				total := 0
+				for _, p := range pts {
+					total += p.UniqueCallers
+				}
+				return len(pts), total, err
+			},
+		},
+		{
+			name: "health",
+			run: func() (int, int, error) {
+				pts, err := db.GetHealthTimeSeries("", "daily", 7)
+				total := 0
+				for _, p := range pts {
+					total += p.Total
+				}
+				return len(pts), total, err
+			},
+		},
+		{
+			name: "active addresses",
+			run: func() (int, int, error) {
+				pts, err := db.GetActiveAddressTimeSeries("", "daily", 7)
+				total := 0
+				for _, p := range pts {
+					total += p.TotalActive
+				}
+				return len(pts), total, err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			points, total, err := tt.run()
+			if err != nil {
+				t.Fatalf("%s series: %v", tt.name, err)
+			}
+			if points == 0 {
+				t.Fatalf("%s series is empty; a query with the wrong argument count "+
+					"returns no rows instead of failing", tt.name)
+			}
+			if total == 0 {
+				t.Errorf("%s series has points but counts nothing", tt.name)
+			}
+		})
+	}
+}
+
+// The retired chain's rows must be absent from the totals, not merely unlabelled.
+func TestTimeSeriesDropRetiredNetworkRows(t *testing.T) {
+	db := newScopedDB(t)
+
+	scoped, err := db.GetHealthTimeSeries("", "daily", 7)
+	if err != nil {
+		t.Fatalf("GetHealthTimeSeries: %v", err)
+	}
+	scopedTotal := 0
+	for _, p := range scoped {
+		scopedTotal += p.Total
+	}
+
+	// Configuring the retired chain as well must add exactly its rows back,
+	// which proves the difference was the filter rather than a coincidence.
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "live1"}, {ID: "live2"}, {ID: "retired"}})
+	withRetired, err := db.GetHealthTimeSeries("", "daily", 7)
+	if err != nil {
+		t.Fatalf("GetHealthTimeSeries: %v", err)
+	}
+	retiredTotal := 0
+	for _, p := range withRetired {
+		retiredTotal += p.Total
+	}
+
+	if scopedTotal != 6 {
+		t.Errorf("scoped total = %d, want 6 from the two live chains", scopedTotal)
+	}
+	if retiredTotal != 9 {
+		t.Errorf("total with the retired chain configured = %d, want 9", retiredTotal)
+	}
+}
+
+// The per-bucket address counts must agree with the totals computed beside
+// them. Counting components one way and the total another produces a page whose
+// own numbers contradict each other.
+func TestCallerSeriesCountsAddressesPerChain(t *testing.T) {
+	db := newScopedDB(t)
+
+	pts, err := db.GetCallerTimeSeries("", "daily", 7)
+	if err != nil {
+		t.Fatalf("GetCallerTimeSeries: %v", err)
+	}
+	if len(pts) == 0 {
+		t.Fatal("empty series")
+	}
+
+	callers, senders := 0, 0
+	for _, p := range pts {
+		callers += p.UniqueCallers
+		senders += p.UniqueSenders
+	}
+
+	// g1shared calls on both live chains, plus one solo caller each: four.
+	if callers != 4 {
+		t.Errorf("unique callers = %d, want 4: g1shared counts once per chain", callers)
+	}
+	// g1shared sends on both live chains: two.
+	if senders != 2 {
+		t.Errorf("unique senders = %d, want 2 counted per chain", senders)
+	}
+}
+
+// The two series that report unique callers must agree. They are computed by
+// different functions, and for a while one counted per chain while the other
+// blended — production showed 4,492 on one page and 4,490 on the other.
+func TestBothCallerSeriesAgree(t *testing.T) {
+	db := newScopedDB(t)
+
+	callerSeries, err := db.GetCallerTimeSeries("", "daily", 7)
+	if err != nil {
+		t.Fatalf("GetCallerTimeSeries: %v", err)
+	}
+	activeSeries, err := db.GetActiveAddressTimeSeries("", "daily", 7)
+	if err != nil {
+		t.Fatalf("GetActiveAddressTimeSeries: %v", err)
+	}
+
+	sum := func(get func(int) int, n int) int {
+		total := 0
+		for i := 0; i < n; i++ {
+			total += get(i)
+		}
+		return total
+	}
+	a := sum(func(i int) int { return callerSeries[i].UniqueCallers }, len(callerSeries))
+	b := sum(func(i int) int { return activeSeries[i].UniqueCallers }, len(activeSeries))
+
+	if a != b {
+		t.Errorf("unique callers = %d from the caller series but %d from the active-address series", a, b)
+	}
+	if a == 0 {
+		t.Error("both series report zero callers")
+	}
+}


### PR DESCRIPTION
Two defects hiding behind one code shape, found by sweeping for the pattern after fixing it three times individually (#107, #111).

Every time series and the sanity counters opened with:

```go
netFilter := ""
if network != "" {
    netFilter = " AND t.network = ?"
}
```

## 1. An empty filter is not "all networks"

It is *every network ever synced*. Retired chains keep their rows — topaz has been gone for months and still holds **3,093 transactions, 2,945 calls, 670 sends and 272 packages** in the production database — and six functions were counting them: the transaction, package, caller, health, storage and active-address series, plus `/api/sanity/overview`.

This is the rule #80 established and `docs/api.md` documents; these were simply never brought in line.

## 2. Addresses were still being blended across chains

`COUNT(DISTINCT addr)` collapses an address seen on two chains into one actor. The same defect as #107 and #111, in the places those PRs did not reach.

`/api/sanity/overview` had **both** at once: 63,404 active addresses as written, 63,343 once topaz is excluded, 63,421 counted honestly.

## Verified endpoint by endpoint

Deployed build against this one, same production data:

```
stats                        total_calls  683,926 -> 683,906
sanity/overview              tx_last_1h       735 -> 727
timeseries/transactions      calls        322,585 -> 322,565
timeseries/callers           senders       35,209 -> 35,204
timeseries/health            total        151,550 -> 151,533
timeseries/active-addresses  total_active  36,992 -> 36,989

timeseries/packages          unchanged
timeseries/storage           unchanged
timeseries/storage/realms    unchanged
```

The unchanged rows matter as much as the changed ones: topaz deployed nothing in the window, so those figures should not move, and they do not.

## A half-fix I caught in verification

After the first pass, `/api/timeseries/callers` reported **4,492** unique callers while `/api/timeseries/active-addresses` reported **4,490** — two pages contradicting each other, because I had converted one function's counts to per-chain and not the other's. That is worse than either consistent answer.

Both now use one shared `perChainBucketCount` helper and agree. `TestBothCallerSeriesAgree` pins it.

## Testing queries that swallow their errors

These call `QueryRow(...).Scan(...)` without checking the error, so a malformed query leaves the destination at zero rather than failing. Removing the `?` placeholders without removing the matching arguments would have produced silent zeros, not a crash — and `go build` cannot see it.

So the tests assert on **values**, not on error returns. A broken query shows up as a zero where a number belongs, which is exactly how it would reach a user.

`TestTimeSeriesDropRetiredNetworkRows` also configures the retired chain afterwards and checks the total goes from 6 to exactly 9, proving the difference is the filter rather than a coincidence.

I verified each fix independently by reverting it: the blended caller count reports 3 instead of 4, and the empty filter reports 9 instead of 6.
