### PR TITLE
test: cover the dependency graph, remaining handlers and the live feed stream

### DIFF
--- a/api_indexer_test.go
+++ b/api_indexer_test.go
@@ -313,3 +313,45 @@ func str(v any) string {
 	s, _ := v.(string)
 	return s
 }
+
+// The per-package events endpoint, which reaches the indexer rather than
+// storage. In all-networks mode it queries every chain and tags each row.
+func TestPackageEventsHandler(t *testing.T) {
+	api, _, _ := newIndexerAPI(t)
+
+	for _, tc := range []struct{ name, target string }{
+		{"one network", "/api/events/r/demo/boards?network=alpha&limit=5"},
+		{"every network", "/api/events/r/demo/boards?limit=5"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, body := serve(t, api, tc.target)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", rec.Code, body)
+			}
+
+			rows, _ := page(t, body)
+			for _, row := range rows {
+				if str(row["network"]) == "" {
+					t.Errorf("event row carries no network: %v", row)
+				}
+				if str(row["block_time"]) == "" {
+					t.Errorf("event row lost its timestamp; the merged view sorts on it: %v", row)
+				}
+			}
+		})
+	}
+}
+
+// An unknown package is an empty list, not a failure: the events view for a
+// realm nobody has called yet should render empty rather than error.
+func TestPackageEventsOnAnUnknownPackage(t *testing.T) {
+	api, _, _ := newIndexerAPI(t)
+
+	rec, body := serve(t, api, "/api/events/r/demo/nothing-here?limit=5")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	if string(body) == "null\n" || string(body) == "null" {
+		t.Error("returned null; the frontend iterates this and would throw")
+	}
+}

--- a/graph_test.go
+++ b/graph_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// The dependency graph walks recursively from a root, which makes it the one
+// query in the project that can loop forever on real data: gno packages import
+// each other, and a cycle is legal.
+//
+// It is also where 232 phantom edges once lived — more than a tenth of the
+// graph, including self-edges — because imports were extracted with a regex
+// that matched any quoted gno.land path, comments and strings included.
+func seedGraph(t *testing.T, db *DB) *DB {
+	t.Helper()
+
+	const when = "2026-08-01T00:00:00Z"
+	// app -> lib -> util, plus a cycle between a and b, on two networks.
+	edges := map[string][]string{
+		"gno.land/r/demo/app":  {"gno.land/p/demo/lib"},
+		"gno.land/p/demo/lib":  {"gno.land/p/demo/util"},
+		"gno.land/p/demo/util": {},
+		"gno.land/r/demo/a":    {"gno.land/r/demo/b"},
+		"gno.land/r/demo/b":    {"gno.land/r/demo/a"},
+	}
+
+	for _, net := range []string{"alpha", "beta"} {
+		for pkg, imports := range edges {
+			if err := db.UpsertPackage(net, pkg, "pkg", "g1creator", net+"-"+pkg, 100, when, true, 1); err != nil {
+				t.Fatalf("UpsertPackage: %v", err)
+			}
+			if len(imports) > 0 {
+				if err := db.SetDependencies(net, pkg, imports); err != nil {
+					t.Fatalf("SetDependencies: %v", err)
+				}
+			}
+		}
+	}
+	return db
+}
+
+func newGraphDB(t *testing.T) *DB {
+	t.Helper()
+
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "alpha"}, {ID: "beta"}})
+	return seedGraph(t, db)
+}
+
+func TestDependencyGraphWalksTransitively(t *testing.T) {
+	db := newGraphDB(t)
+
+	graph, err := db.GetDependencyGraph("alpha", "gno.land/r/demo/app")
+	if err != nil {
+		t.Fatalf("GetDependencyGraph: %v", err)
+	}
+
+	if got := graph["gno.land/r/demo/app"]; len(got) != 1 || got[0] != "gno.land/p/demo/lib" {
+		t.Errorf("app imports = %v, want [gno.land/p/demo/lib]", got)
+	}
+	// The walk has to follow the edge it just found, or the graph is one level
+	// deep and the page shows a dependency with no dependencies.
+	if got := graph["gno.land/p/demo/lib"]; len(got) != 1 || got[0] != "gno.land/p/demo/util" {
+		t.Errorf("lib imports = %v, want [gno.land/p/demo/util]; the walk stopped at depth 1", got)
+	}
+}
+
+// A cycle is legal in gno and must not hang the request.
+func TestDependencyGraphTerminatesOnACycle(t *testing.T) {
+	db := newGraphDB(t)
+
+	type result struct {
+		graph map[string][]string
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		g, err := db.GetDependencyGraph("alpha", "gno.land/r/demo/a")
+		done <- result{g, err}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("GetDependencyGraph: %v", r.err)
+		}
+		if len(r.graph) != 2 {
+			t.Errorf("graph has %d nodes, want the two in the cycle: %v", len(r.graph), r.graph)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetDependencyGraph did not return: the walk is following the cycle forever")
+	}
+}
+
+func TestReverseGraphFindsDependents(t *testing.T) {
+	db := newGraphDB(t)
+
+	graph, err := db.GetReverseGraph("alpha", "gno.land/p/demo/util")
+	if err != nil {
+		t.Fatalf("GetReverseGraph: %v", err)
+	}
+
+	if got := graph["gno.land/p/demo/util"]; len(got) != 1 || got[0] != "gno.land/p/demo/lib" {
+		t.Errorf("util dependents = %v, want [gno.land/p/demo/lib]", got)
+	}
+	if got := graph["gno.land/p/demo/lib"]; len(got) != 1 || got[0] != "gno.land/r/demo/app" {
+		t.Errorf("lib dependents = %v, want [gno.land/r/demo/app]; the reverse walk stopped at depth 1", got)
+	}
+}
+
+// Selecting a network must not pull in another chain's edges. The same paths
+// exist on both here, which is the shape that made this worth checking: 193
+// package paths now live on more than one chain.
+func TestGraphIsScopedToOneNetwork(t *testing.T) {
+	db := newGraphDB(t)
+
+	// Give beta an extra edge that alpha does not have.
+	if err := db.SetDependencies("beta", "gno.land/r/demo/app",
+		[]string{"gno.land/p/demo/lib", "gno.land/p/beta/only"}); err != nil {
+		t.Fatalf("SetDependencies: %v", err)
+	}
+
+	alpha, err := db.GetDependencyGraph("alpha", "gno.land/r/demo/app")
+	if err != nil {
+		t.Fatalf("GetDependencyGraph(alpha): %v", err)
+	}
+	for _, imp := range alpha["gno.land/r/demo/app"] {
+		if imp == "gno.land/p/beta/only" {
+			t.Errorf("beta's edge leaked into the alpha graph: %v", alpha["gno.land/r/demo/app"])
+		}
+	}
+
+	beta, err := db.GetDependencyGraph("beta", "gno.land/r/demo/app")
+	if err != nil {
+		t.Fatalf("GetDependencyGraph(beta): %v", err)
+	}
+	if len(beta["gno.land/r/demo/app"]) != 2 {
+		t.Errorf("beta app imports = %v, want both edges", beta["gno.land/r/demo/app"])
+	}
+}
+
+// An unknown root is an empty graph, not an error: a typo in a URL should render
+// an empty page rather than a 500.
+func TestGraphOnAnUnknownPackage(t *testing.T) {
+	db := newGraphDB(t)
+
+	for _, tc := range []struct {
+		name string
+		run  func() (map[string][]string, error)
+	}{
+		{"forward", func() (map[string][]string, error) {
+			return db.GetDependencyGraph("alpha", "gno.land/r/demo/nope")
+		}},
+		{"reverse", func() (map[string][]string, error) {
+			return db.GetReverseGraph("alpha", "gno.land/r/demo/nope")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			graph, err := tc.run()
+			if err != nil {
+				t.Fatalf("unknown package returned an error: %v", err)
+			}
+			for _, edges := range graph {
+				if len(edges) != 0 {
+					t.Errorf("unknown package produced edges: %v", graph)
+				}
+			}
+		})
+	}
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -308,5 +309,139 @@ func mustJSON(t *testing.T, body []byte, v any) {
 	t.Helper()
 	if err := json.Unmarshal(body, v); err != nil {
 		t.Fatalf("decode %s: %v", body, err)
+	}
+}
+
+// The handlers left over after the storage-backed and indexer-backed sweeps.
+// All of these read from the database and were reachable in production without
+// ever having been exercised by a test.
+func TestRemainingStorageHandlers(t *testing.T) {
+	api, db := newTestAPI(t)
+	seedActivity(t, db, "alpha", 4, 2, 1)
+	seedActivity(t, db, "beta", 1, 1, 1)
+
+	// seedActivity writes realms; /api/packages lists the non-realms, so it
+	// needs one of those to have anything to show.
+	if err := db.UpsertPackage("alpha", "gno.land/p/alpha/lib", "lib", "g1creator",
+		"alpha-lib", 400, "2026-08-01T00:00:00Z", false, 1); err != nil {
+		t.Fatalf("UpsertPackage: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	tests := []struct {
+		name   string
+		target string
+		check  func(t *testing.T, body []byte)
+	}{
+		{
+			name:   "packages list",
+			target: "/api/packages?limit=10",
+			check: func(t *testing.T, body []byte) {
+				var p struct {
+					Items []PackageInfo `json:"items"`
+					Total int           `json:"total"`
+				}
+				mustJSON(t, body, &p)
+				if p.Total == 0 {
+					t.Error("no packages")
+				}
+				for _, r := range p.Items {
+					if r.Network == "" {
+						t.Errorf("package %s carries no network", r.Path)
+					}
+				}
+			},
+		},
+		{
+			name:   "one realm's detail",
+			target: "/api/realm/r/alpha/pkg0?network=alpha",
+			check: func(t *testing.T, body []byte) {
+				var d map[string]any
+				mustJSON(t, body, &d)
+				if d["path"] == nil && d["package"] == nil {
+					t.Errorf("no package in the response: %s", body)
+				}
+			},
+		},
+		{
+			name:   "dependency graph",
+			target: "/api/deps/r/alpha/pkg0?network=alpha",
+		},
+		{
+			name:   "reverse dependency graph",
+			target: "/api/deps/r/alpha/pkg0?network=alpha&dir=dependents",
+		},
+		{
+			name:   "storage time series",
+			target: "/api/timeseries/storage?days=7&network=alpha",
+		},
+		{
+			name:   "storage realms selector",
+			target: "/api/timeseries/storage/realms?days=7&network=alpha",
+		},
+		{
+			name:   "health time series",
+			target: "/api/timeseries/health?days=7&network=alpha",
+		},
+		{
+			name:   "sanity overview for one network",
+			target: "/api/sanity/overview?network=alpha",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest("GET", tt.target, nil))
+			body := rec.Body.Bytes()
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", rec.Code, body)
+			}
+			if !json.Valid(body) {
+				t.Fatalf("body is not valid JSON: %s", body)
+			}
+			if string(body) == "null\n" || string(body) == "null" {
+				t.Error("returned null; the frontend iterates this and would throw")
+			}
+			if tt.check != nil {
+				tt.check(t, body)
+			}
+		})
+	}
+}
+
+// The live feed is an SSE stream, so it must set the streaming headers and stay
+// open rather than answering and closing like a normal endpoint.
+func TestLiveFeedHandlerOpensAStream(t *testing.T) {
+	handler := liveFeedHandler()
+
+	req := httptest.NewRequest("GET", "/api/live?network=nonexistent", nil)
+	ctx, cancel := context.WithTimeout(req.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler(rec, req.WithContext(ctx))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the handler did not return after its request was cancelled")
+	}
+
+	// A subscription naming a network with no feed is accepted but silent: the
+	// connection stays open and delivers nothing, rather than erroring at a
+	// browser that cannot do anything useful with the error.
+	if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", got)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache: a cached SSE stream never updates", got)
 	}
 }


### PR DESCRIPTION
Closes the last of the untested surface. 63.9% → **71.9%**, with only wiring left uncovered: `main`, `run`, a one-time schema migration, `stampPackageTimes` and `GetStorageEvents`.

## The dependency graph

Worth its own file. It is the only recursive query in the project, so it is the only one that can loop forever on legitimate data — gno packages import each other and a cycle is legal. It is also where 232 phantom edges once lived, more than a tenth of the graph including self-edges, from a regex that matched any quoted `gno.land` path including ones in comments.

- the walk is transitive, not one level deep — a page showing a dependency whose own dependencies are missing is the failure mode
- a cycle terminates, asserted with a real timeout rather than by hoping
- forward and reverse walks are scoped to one chain, tested with the same paths present on both, since 193 paths now live on more than one
- an unknown root is an empty graph rather than a 500

## Remaining handlers

`/api/packages`, `/api/realm/{path}`, `/api/deps` in both directions, the storage and health series, the storage-realms selector, single-network sanity, and per-package events on one chain and across all of them.

Three of these failed on first run and all three were my fixtures, not the code:

- `/api/packages` lists non-realms, and the shared seed writes only realms, so an empty result was correct
- the route strips the `gno.land` prefix, which the handler re-adds — the target is `/api/realm/r/alpha/pkg0`
- `/api/events` reaches the indexer, so it belongs with the indexer-backed tests, not the storage-backed ones

## The live feed stream

`liveFeedHandler` is SSE, so what matters is that it sets `text/event-stream`, sets `no-cache` — a cached event stream never updates — and stays open until its request is cancelled rather than answering and closing.

It also pins the documented behaviour for a subscription naming a network with no feed: accepted and silent. A browser cannot do anything useful with an error there, and the connection staying open is deliberate rather than an oversight.
