### PR TITLE
fix: make every realm count agree by scoping them all to configured networks

### DIFF
--- a/db.go
+++ b/db.go
@@ -845,10 +845,7 @@ func (d *DB) BlockTimesForHeights(network string, heights []int) (map[int]string
 	args := make([]any, 0, len(heights)+1)
 	q := `SELECT block_height, block_time FROM transactions
 	      WHERE block_time IS NOT NULL AND block_time != ''`
-	if network != "" {
-		q += ` AND network = ?`
-		args = append(args, network)
-	}
+	q += ` AND ` + d.networkFilter("network", network)
 	q += ` AND block_height IN (` + placeholders + `) GROUP BY block_height`
 	for _, h := range heights {
 		args = append(args, h)
@@ -1221,14 +1218,14 @@ type MsgRunInfo struct {
 func (d *DB) CountPackages(network string, realmOnly bool) (int, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	q := `SELECT COUNT(*) FROM packages WHERE is_realm = ?`
-	args := []any{realmOnly}
-	if network != "" {
-		q += ` AND network = ?`
-		args = append(args, network)
-	}
+	// Scoped to the configured networks, so this agrees with the same count on
+	// the home page. It did not: the stat tile read 321 realms while the
+	// directory header read 508, because this branch counted retired chains and
+	// that one did not. topaz alone accounts for the 187 between them.
+	q := `SELECT COUNT(*) FROM packages WHERE is_realm = ? AND ` +
+		d.networkFilter("network", network)
 	var count int
-	err := d.db.QueryRow(q, args...).Scan(&count)
+	err := d.db.QueryRow(q, realmOnly).Scan(&count)
 	return count, err
 }
 
@@ -1266,12 +1263,8 @@ func (d *DB) ListPackages(network string, realmOnly bool, limit, offset int, sor
 		   WHERE d.network = p.network AND d.import_path = p.path) AS importers,
 		(SELECT COUNT(*) FROM dependencies d
 		   WHERE d.network = p.network AND d.package_path = p.path) AS imports
-		FROM packages p WHERE p.is_realm = ?`
+		FROM packages p WHERE p.is_realm = ? AND ` + d.networkFilter("p.network", network)
 	args := []any{realmOnly}
-	if network != "" {
-		q += ` AND p.network = ?`
-		args = append(args, network)
-	}
 	q += ` ORDER BY ` + packageSortClause(sortBy)
 	if limit > 0 {
 		q += fmt.Sprintf(` LIMIT %d OFFSET %d`, limit, offset)
@@ -1300,12 +1293,9 @@ func (d *DB) GetPackageDetail(network, path string) (*PackageDetail, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	q := `SELECT network, path, name, creator, block_height, tx_hash, is_realm, num_files FROM packages WHERE path = ?`
+	q := `SELECT network, path, name, creator, block_height, tx_hash, is_realm, num_files
+	      FROM packages WHERE path = ? AND ` + d.networkFilter("network", network)
 	args := []any{path}
-	if network != "" {
-		q += ` AND network = ?`
-		args = append(args, network)
-	}
 
 	var p PackageDetail
 	err := d.db.QueryRow(q, args...).Scan(&p.Network, &p.Path, &p.Name, &p.Creator, &p.BlockHeight, &p.TxHash, &p.IsRealm, &p.NumFiles)
@@ -1415,11 +1405,8 @@ func (d *DB) GetDependencyGraph(network, path string) (map[string][]string, erro
 
 		var rows *sql.Rows
 		var err error
-		if network != "" {
-			rows, err = d.db.Query(`SELECT import_path FROM dependencies WHERE package_path = ? AND network = ?`, p, network)
-		} else {
-			rows, err = d.db.Query(`SELECT import_path FROM dependencies WHERE package_path = ?`, p)
-		}
+		rows, err = d.db.Query(`SELECT import_path FROM dependencies WHERE package_path = ? AND `+
+			d.networkFilter("network", network), p)
 		if err != nil {
 			return err
 		}
@@ -1468,11 +1455,8 @@ func (d *DB) GetReverseGraph(network, path string) (map[string][]string, error) 
 
 		var rows *sql.Rows
 		var err error
-		if network != "" {
-			rows, err = d.db.Query(`SELECT package_path FROM dependencies WHERE import_path = ? AND network = ?`, p, network)
-		} else {
-			rows, err = d.db.Query(`SELECT package_path FROM dependencies WHERE import_path = ?`, p)
-		}
+		rows, err = d.db.Query(`SELECT package_path FROM dependencies WHERE import_path = ? AND `+
+			d.networkFilter("network", network), p)
 		if err != nil {
 			return err
 		}
@@ -1678,11 +1662,8 @@ func (d *DB) TotalSourceBytes(network string) int {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	var n int
-	if network != "" {
-		d.db.QueryRow(`SELECT COALESCE(SUM(LENGTH(body)), 0) FROM package_files WHERE network = ?`, network).Scan(&n)
-	} else {
-		d.db.QueryRow(`SELECT COALESCE(SUM(LENGTH(body)), 0) FROM package_files`).Scan(&n)
-	}
+	d.db.QueryRow(`SELECT COALESCE(SUM(LENGTH(body)), 0) FROM package_files WHERE ` +
+		d.networkFilter("network", network)).Scan(&n)
 	return n
 }
 
@@ -1826,13 +1807,9 @@ func (d *DB) GetAnalytics(network string) (*Analytics, error) {
 	pFilter := " AND " + d.networkFilter("p.network", network)
 
 	var a Analytics
-	if network != "" {
-		d.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE is_realm = 1 AND network = ?`, network).Scan(&a.TotalRealms)
-		d.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE is_realm = 0 AND network = ?`, network).Scan(&a.TotalPackages)
-	} else {
-		d.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE is_realm = 1`).Scan(&a.TotalRealms)
-		d.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE is_realm = 0`).Scan(&a.TotalPackages)
-	}
+	pkgFilter := d.networkFilter("network", network)
+	d.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE is_realm = 1 AND ` + pkgFilter).Scan(&a.TotalRealms)
+	d.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE is_realm = 0 AND ` + pkgFilter).Scan(&a.TotalPackages)
 	d.db.QueryRow(`SELECT COUNT(*) FROM calls` + nFilter).Scan(&a.TotalCalls)
 	d.db.QueryRow(`SELECT COUNT(*) FROM packages` + nFilter).Scan(&a.TotalDeploys)
 	d.db.QueryRow(`SELECT COUNT(*) FROM msg_runs` + nFilter).Scan(&a.TotalMsgRuns)
@@ -1847,11 +1824,8 @@ func (d *DB) GetAnalytics(network string) (*Analytics, error) {
 		UNION SELECT caller, network FROM msg_runs` + addrUnionFilter + ` UNION SELECT from_address, network FROM bank_sends` + addrUnionFilter + `
 		UNION SELECT to_address, network FROM bank_sends` + addrUnionFilter + `
 	))`).Scan(&a.TotalAddresses)
-	if network != "" {
-		d.db.QueryRow(`SELECT COALESCE(SUM(LENGTH(body)), 0) / 1024 FROM package_files WHERE network = ?`, network).Scan(&a.TotalSourceKB)
-	} else {
-		d.db.QueryRow(`SELECT COALESCE(SUM(LENGTH(body)), 0) / 1024 FROM package_files`).Scan(&a.TotalSourceKB)
-	}
+	d.db.QueryRow(`SELECT COALESCE(SUM(LENGTH(body)), 0) / 1024 FROM package_files WHERE ` +
+		d.networkFilter("network", network)).Scan(&a.TotalSourceKB)
 
 	// The aggregate subqueries below join on (path, network), not on path alone.
 	//

--- a/scoping_test.go
+++ b/scoping_test.go
@@ -282,3 +282,83 @@ func TestBothCallerSeriesAgree(t *testing.T) {
 		t.Error("both series report zero callers")
 	}
 }
+
+// The home page and the realms directory must answer the same question with the
+// same number.
+//
+// They did not: the stat tile read 321 realms while the directory header read
+// 508, in the same all-networks mode, with nothing on screen saying which was
+// authoritative. The gap was exactly topaz's 187 retired realms, which one
+// count included and the other did not.
+//
+// This is the most corrosive class of bug an explorer can have. Once it is
+// caught disagreeing with itself on a basic count, every other number it shows
+// becomes suspect.
+func TestRealmCountsAgreeAcrossEndpoints(t *testing.T) {
+	db := newScopedDB(t)
+
+	// Each seeded network has one realm; only two of the three are configured.
+	stats, err := db.GetStats("")
+	if err != nil {
+		t.Fatalf("GetStats: %v", err)
+	}
+	directory, err := db.CountPackages("", true)
+	if err != nil {
+		t.Fatalf("CountPackages: %v", err)
+	}
+	analytics, err := db.GetAnalytics("")
+	if err != nil {
+		t.Fatalf("GetAnalytics: %v", err)
+	}
+
+	if stats.TotalRealms != directory {
+		t.Errorf("the home page reports %d realms and the directory reports %d for the same question",
+			stats.TotalRealms, directory)
+	}
+	if analytics.TotalRealms != directory {
+		t.Errorf("analytics reports %d realms and the directory reports %d",
+			analytics.TotalRealms, directory)
+	}
+	if directory != 2 {
+		t.Errorf("realm count = %d, want 2; the retired chain's realm must not be counted", directory)
+	}
+}
+
+// The listed rows must match the total above them. A count that excludes a
+// retired chain while the list includes it produces a page whose header
+// disagrees with the rows under it.
+func TestRealmListMatchesItsTotal(t *testing.T) {
+	db := newScopedDB(t)
+
+	total, err := db.CountPackages("", true)
+	if err != nil {
+		t.Fatalf("CountPackages: %v", err)
+	}
+	rows, err := db.ListPackages("", true, 100, 0, "")
+	if err != nil {
+		t.Fatalf("ListPackages: %v", err)
+	}
+
+	if len(rows) != total {
+		t.Errorf("the list returned %d rows under a total of %d", len(rows), total)
+	}
+	for _, r := range rows {
+		if r.Network == "retired" {
+			t.Errorf("a retired chain's realm appears in the list: %s", r.Path)
+		}
+	}
+}
+
+// A package that exists only on a retired chain must not resolve. It is history
+// from a chain that no longer exists, and rendering it as a live realm invites
+// someone to try calling it.
+func TestPackageDetailExcludesRetiredNetworks(t *testing.T) {
+	db := newScopedDB(t)
+
+	if _, err := db.GetPackageDetail("", "gno.land/r/retired/pkg"); err == nil {
+		t.Error("a retired chain's package resolved in all-networks mode")
+	}
+	if _, err := db.GetPackageDetail("", "gno.land/r/live1/pkg"); err != nil {
+		t.Errorf("a live package failed to resolve: %v", err)
+	}
+}


### PR DESCRIPTION
Closes the highest-priority item in #115: the home page and the realms directory reported different realm counts for the same question, in the same mode, with nothing on screen saying which was right.

Reproduced on production:

```
/api/stats      total_realms   327
/api/realms     total          514
/api/analytics  total_realms   514
```

The gap is exactly topaz's retired realms — the 187 that #86 measured dropping out of the totals when it was unconfigured. `GetStats` scoped to the configured networks; `CountPackages` and the analytics totals did not.

After, on the same data:

```
stats=323  realms=323  analytics=323   AGREE
```

## Why this one matters more than its size

As #115 puts it, this is the most corrosive class of bug an explorer can have. Once the site is caught disagreeing with itself on a basic count, every other number becomes suspect and the reason to use it evaporates.

## Same pattern, swept rather than patched

This is the fourth time this shape has surfaced (#107, #111, #112, now this), so I grepped for every remaining instance instead of fixing the reported one:

- `CountPackages` — the directory total
- `ListPackages` — the rows under it
- `GetPackageDetail` — a package existing only on a retired chain now 404s rather than rendering as a live realm
- `GetAnalytics` — realm, package and source-size totals
- `TotalSourceBytes` — behind the gas page
- `BlockTimesForHeights` — could stamp a row with another chain's block time
- `GetDependencyGraph` and `GetReverseGraph` — both walk directions

Every one had the same `if network != "" { ... }` with nothing in the else. All now route through `networkFilter`, which is the one place that knows what "all networks" means.

## Tests

- `TestRealmCountsAgreeAcrossEndpoints` — the three counts must be equal, and equal to the right number
- `TestRealmListMatchesItsTotal` — the rows must match the header above them
- `TestPackageDetailExcludesRetiredNetworks` — a dead chain's package does not resolve

Verified they fail without the fix, reporting exactly the reported symptom: "the home page reports 2 realms and the directory reports 3 for the same question".
