### PR TITLE
fix: stop filetests putting self-edges in the dependency graph

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -23,16 +23,12 @@ func NewAnalyzer(db *DB) *Analyzer {
 }
 
 // ExtractImports parses Go source files and extracts gno.land import paths.
-func (a *Analyzer) ExtractImports(files []MemFile) []string {
+func (a *Analyzer) ExtractImports(pkgPath string, files []MemFile) []string {
 	seen := make(map[string]bool)
 	var imports []string
 
 	for _, f := range files {
-		if !strings.HasSuffix(f.Name, ".gno") {
-			continue
-		}
-		// Skip test files
-		if strings.HasSuffix(f.Name, "_test.gno") {
+		if !strings.HasSuffix(f.Name, ".gno") || isTestFile(f.Name) {
 			continue
 		}
 
@@ -42,11 +38,29 @@ func (a *Analyzer) ExtractImports(files []MemFile) []string {
 			if !strings.HasPrefix(imp, "gno.land/") || seen[imp] {
 				continue
 			}
+			// A package cannot import itself at runtime. Test files legitimately
+			// import the package under test, so before filetests were excluded
+			// this produced self-edges that rendered as a realm depending on
+			// itself. Kept as a guard: the graph should never contain one
+			// whatever the extraction does.
+			if imp == pkgPath {
+				continue
+			}
 			seen[imp] = true
 			imports = append(imports, imp)
 		}
 	}
 	return imports
+}
+
+// isTestFile reports whether a file is one of gno's two test conventions.
+//
+// `_filetest.gno` was being missed: it does not end in `_test.gno`, so filetests
+// were parsed as production source. They import the package under test, which is
+// how six self-edges reached the live dependency graph, and they pull in test-only
+// packages that are not part of what the realm actually uses.
+func isTestFile(name string) bool {
+	return strings.HasSuffix(name, "_test.gno") || strings.HasSuffix(name, "_filetest.gno")
 }
 
 // fileImports returns the paths one file imports.
@@ -86,8 +100,11 @@ func fileImports(f MemFile) []string {
 }
 
 // ExtractMsgRunImports parses MsgRun source for gno.land imports.
+//
+// A MsgRun has no package path of its own to exclude — it is ephemeral code, not
+// a deployed package — so there is nothing it could self-import.
 func (a *Analyzer) ExtractMsgRunImports(files []MemFile) []string {
-	return a.ExtractImports(files) // same logic
+	return a.ExtractImports("", files)
 }
 
 // ProcessPackage analyzes a package and stores its dependency info.
@@ -107,7 +124,7 @@ func (a *Analyzer) ProcessPackage(network string, pkg *MemPackage, creator, txHa
 	}
 
 	// Extract and store dependencies
-	imports := a.ExtractImports(pkg.Files)
+	imports := a.ExtractImports(pkg.Path, pkg.Files)
 	if err := a.db.SetDependencies(network, pkg.Path, imports); err != nil {
 		return err
 	}
@@ -124,7 +141,9 @@ func (a *Analyzer) ProcessPackage(network string, pkg *MemPackage, creator, txHa
 // import block. The regex counted commented-out imports and paths that only
 // appeared in string literals, so rows written before it carry edges that do not
 // exist.
-const dependencyExtractorVersion = "2"
+// v3 excludes `_filetest.gno` — gno's other test convention, which the
+// `_test.gno` check did not match — and refuses self-edges outright.
+const dependencyExtractorVersion = "3"
 
 const dependencyExtractorKey = "dependency_extractor_version"
 
@@ -139,6 +158,11 @@ func (a *Analyzer) ReextractDependencies() error {
 	if err == nil && done == dependencyExtractorVersion {
 		return nil
 	}
+
+	// There is work to do, so wait out the startup ANALYZE before taking the
+	// write lock against it. Skipped entirely on the common path above, where
+	// the marker already matches and nothing is rewritten.
+	a.db.WaitBackground()
 
 	refs, err := a.db.StoredPackageRefs()
 	if err != nil {
@@ -156,7 +180,7 @@ func (a *Analyzer) ReextractDependencies() error {
 			failed++
 			continue
 		}
-		imports := a.ExtractImports(files)
+		imports := a.ExtractImports(ref.Path, files)
 		if err := a.db.SetDependencies(ref.Network, ref.Path, imports); err != nil {
 			log.Printf("re-extract %s/%s: %v", ref.Network, ref.Path, err)
 			failed++

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -85,7 +86,7 @@ func TestExtractImports(t *testing.T) {
 	a := NewAnalyzer(nil)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := a.ExtractImports(tt.files)
+			got := a.ExtractImports("", tt.files)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ExtractImports() = %v, want %v", got, tt.want)
 			}
@@ -112,7 +113,7 @@ func TestExtractImportsIgnoresPathsThatAreNotImports(t *testing.T) {
 		}
 	`}}
 
-	got := NewAnalyzer(nil).ExtractImports(files)
+	got := NewAnalyzer(nil).ExtractImports("", files)
 	want := []string{"gno.land/p/demo/avl"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ExtractImports() = %v, want %v", got, want)
@@ -131,7 +132,7 @@ func TestExtractImportsSurvivesAnUnparseableBody(t *testing.T) {
 		func broken( { this is not go at all }
 	`}}
 
-	got := NewAnalyzer(nil).ExtractImports(files)
+	got := NewAnalyzer(nil).ExtractImports("", files)
 	want := []string{"gno.land/p/demo/avl"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ExtractImports() = %v, want %v", got, want)
@@ -146,7 +147,7 @@ func TestExtractImportsFallsBackWhenNothingParses(t *testing.T) {
 		import "gno.land/p/demo/avl"
 	`}}
 
-	got := NewAnalyzer(nil).ExtractImports(files)
+	got := NewAnalyzer(nil).ExtractImports("", files)
 	want := []string{"gno.land/p/demo/avl"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ExtractImports() = %v, want %v", got, want)
@@ -294,4 +295,103 @@ func depsOf(t *testing.T, db *DB, network, pkgPath string) []string {
 		out = append(out, s)
 	}
 	return out
+}
+
+// gno has two test-file conventions and only one of them ends in `_test.gno`.
+//
+// `_filetest.gno` was being parsed as production source, so a filetest's import
+// of the package under test became a self-edge in the dependency graph — six of
+// them reached production, rendering as realms that depend on themselves. Test
+// files also pull in test-only packages that are not part of what a realm uses.
+func TestExtractImportsSkipsBothTestConventions(t *testing.T) {
+	const pkgPath = "gno.land/r/gov/dao/v3/impl"
+
+	files := []MemFile{
+		{Name: "impl.gno", Body: `package impl
+
+import (
+	"gno.land/p/nt/avl/v0"
+	"gno.land/r/gov/dao"
+)
+`},
+		{Name: "impl_test.gno", Body: `package impl
+
+import (
+	"gno.land/p/nt/testutils/v0"
+	"gno.land/r/gov/dao/v3/impl"
+)
+`},
+		{Name: "executor_disclosure_filetest.gno", Body: `package main
+
+import (
+	"gno.land/p/nt/testutils/v0"
+	"gno.land/r/gov/dao/v3/impl"
+)
+`},
+	}
+
+	got := NewAnalyzer(nil).ExtractImports(pkgPath, files)
+
+	want := map[string]bool{"gno.land/p/nt/avl/v0": true, "gno.land/r/gov/dao": true}
+	for _, imp := range got {
+		if imp == pkgPath {
+			t.Errorf("the package imports itself, which cannot happen at runtime")
+		}
+		if strings.Contains(imp, "testutils") {
+			t.Errorf("a test-only import reached the graph: %s", imp)
+		}
+		if !want[imp] {
+			t.Errorf("unexpected import %s", imp)
+		}
+		delete(want, imp)
+	}
+	for missing := range want {
+		t.Errorf("missing production import %s", missing)
+	}
+}
+
+// The self-edge guard holds even if a non-test file somehow names its own path.
+func TestExtractImportsNeverEmitsASelfEdge(t *testing.T) {
+	const pkgPath = "gno.land/r/demo/boards"
+
+	got := NewAnalyzer(nil).ExtractImports(pkgPath, []MemFile{
+		{Name: "boards.gno", Body: `package boards
+
+import (
+	"gno.land/r/demo/boards"
+	"gno.land/p/demo/avl"
+)
+`},
+	})
+
+	for _, imp := range got {
+		if imp == pkgPath {
+			t.Fatalf("self-edge emitted: %v", got)
+		}
+	}
+	if len(got) != 1 || got[0] != "gno.land/p/demo/avl" {
+		t.Errorf("imports = %v, want just the avl edge", got)
+	}
+}
+
+func TestIsTestFile(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"impl.gno", false},
+		{"impl_test.gno", true},
+		{"executor_disclosure_filetest.gno", true},
+		{"govdao_execute_proposal_00_filetest.gno", true},
+		// Not a test: "test" appears in the name but not as the convention.
+		{"testutils.gno", false},
+		{"latest.gno", false},
+		{"gnomod.toml", false},
+	}
+
+	for _, tt := range tests {
+		if got := isTestFile(tt.name); got != tt.want {
+			t.Errorf("isTestFile(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
 }

--- a/db.go
+++ b/db.go
@@ -127,6 +127,17 @@ func NewDB(path string) (*DB, error) {
 	return d, nil
 }
 
+// WaitBackground blocks until the startup work started in NewDB has finished.
+//
+// Only ANALYZE runs there today, and it takes the write lock for the better part
+// of a second on a large database. Anything else that writes during startup has
+// to wait for it or risk SQLITE_BUSY — the one-time dependency re-extraction lost
+// a package that way, which cost it the whole pass, because the version marker is
+// only written once every package succeeds.
+func (d *DB) WaitBackground() {
+	d.background.Wait()
+}
+
 // blockTimeTables are the tables carrying a block_time column.
 var blockTimeTables = []string{"packages", "calls", "msg_runs", "bank_sends", "transactions"}
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -539,9 +539,26 @@ function rawJsonToggle(data) {
   wrapper.appendChild(toggle); wrapper.appendChild(content);
   return wrapper;
 }
-function typeBadge(t) {
+// typeBadge labels a message by its GraphQL typename.
+//
+// `msg` is optional and used only for messages the indexer does not model: those
+// arrive with __typename "UnexpectedMessage", which is an internal detail of the
+// indexer's schema and reads on screen like something broke. The route and
+// typeUrl are carried on every message regardless, and say what it actually is
+// — pearl's unmodelled message is `auth/create_session`, which is informative
+// where "UnexpectedMessage" is not.
+function typeBadge(t, msg) {
   const m = { MsgAddPackage: ['pkg', 'deploy'], MsgCall: ['realm', 'call'], MsgRun: ['ok', 'run'], BankMsgSend: ['fail', 'send'] };
-  const [c, x] = m[t] || ['', t || '?']; return badge(c, x);
+  if (m[t]) { const [c, x] = m[t]; return badge(c, x); }
+  return badge('', msgKind(msg) || 'message');
+}
+// msgKind names a message from the fields the indexer always provides.
+function msgKind(msg) {
+  if (!msg) return '';
+  const route = msg.route || '';
+  const type = (msg.typeUrl || '').split('/').pop();
+  if (route && type) return route + '/' + type;
+  return type || route || '';
 }
 // tx link with block context: "hash (genesis)" or "hash (block N)"
 function txLink(hash, blockHeight, network) {
@@ -574,7 +591,10 @@ function txDetailEl(msg) {
       if (amt) s.appendChild(el('span', { className: 'block-ctx' }, ' ' + amt));
       return s;
     }
-    default: return el('span', {}, v.__typename || '?');
+    default:
+      // Not a type the indexer models. Show what it does tell us rather than
+      // its internal placeholder name.
+      return el('span', {}, msgKind(msg) || v.__typename || 'unknown message');
   }
 }
 function timeAgo(t) {
@@ -1335,7 +1355,7 @@ async function loadHome() {
       const when = tx.block_time ? timeEl(tx.block_time) : blockTime[tx.block_height] ? timeEl(blockTime[tx.block_height]) : (tx.block_height === 0 ? 'genesis' : '');
       txBody.appendChild(netRow(tx.network,
         el('td', {}, blockLink(tx.block_height, tx.network)),
-        el('td', {}, typeBadge(msg?.value?.__typename)),
+        el('td', {}, typeBadge(msg?.value?.__typename, msg)),
         el('td', {}, txDetailEl(msg)),
         el('td', {}, statusBadge(tx.success)),
         el('td', { style: { color: 'var(--fg2)', fontSize: '12px' } }, when)
@@ -1517,7 +1537,7 @@ function renderTxRows() {
     list.appendChild(netRow(tx.network,
       el('td', {}, txLink(tx.hash, tx.block_height, tx.network)),
       el('td', {}, blockLink(tx.block_height, tx.network)),
-      el('td', {}, typeBadge(msg?.value?.__typename)),
+      el('td', {}, typeBadge(msg?.value?.__typename, msg)),
       el('td', {}, txDetailEl(msg)),
       el('td', {}, statusBadge(tx.success))
     ));
@@ -1606,7 +1626,7 @@ async function loadBlockDetail(height) {
         const msg = tx.messages?.[0];
         txBody.appendChild(el('tr', {},
           el('td', {}, txLink(tx.hash, tx.block_height)),
-          el('td', {}, typeBadge(msg?.value?.__typename)),
+          el('td', {}, typeBadge(msg?.value?.__typename, msg)),
           el('td', {}, txDetailEl(msg)),
           el('td', {}, statusBadge(tx.success))
         ));
@@ -2827,8 +2847,10 @@ async function loadRealmDetail(path, initialTab) {
     const depsPath = path.replace('gno.land/', '');
     const [imports, dependents] = await Promise.all([api('deps/' + depsPath), api('deps/' + depsPath + '?dir=dependents')]);
     const grid = el('div', { style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '24px' } });
-    grid.appendChild(buildDepTree('imports (what this uses)', imports, path));
-    grid.appendChild(buildDepTree('dependents (what uses this)', dependents, path));
+    grid.appendChild(buildDepTree('imports (what this uses)', imports, path,
+      'what each of these imports in turn'));
+    grid.appendChild(buildDepTree('dependents (what uses this)', dependents, path,
+      'what else depends on each of these'));
     depsEl.appendChild(grid);
     // Graph
     const graphEl = document.getElementById('tab-graph'); if (activeTab === 'graph') graphEl.classList.add('active'); else graphEl.classList.remove('active');
@@ -2839,19 +2861,43 @@ async function loadRealmDetail(path, initialTab) {
   }
 }
 
-function buildDepTree(title, graph, root) {
-  const div = el('div'); div.appendChild(el('div', { className: 'section-title' }, title));
-  const entries = Object.entries(graph || {});
-  if (!entries.length) { div.appendChild(el('div', { style: { color: 'var(--fg2)' } }, 'none')); return div; }
-  for (const [pkg, deps] of entries) {
+// buildDepTree lists a realm's direct imports or dependents, one per row, with
+// what each of those pulls in on the line beneath it.
+//
+// The list used to render every node of the returned graph, which includes the
+// root itself — so a realm appeared in its own "imports" and its own
+// "dependents" lists, reading as a self-reference that cannot exist in Gno. The
+// data was always right; only this rendering was wrong.
+//
+// `direct` is what the title promises. Everything else in the graph is reached
+// through those, and belongs under them rather than beside them.
+function buildDepTree(title, graph, root, arrowHint) {
+  const div = el('div');
+  div.appendChild(el('div', { className: 'section-title' }, title));
+
+  const direct = (graph || {})[root] || [];
+  if (!direct.length) { div.appendChild(el('div', { style: { color: 'var(--fg2)' } }, 'none')); return div; }
+
+  // The arrow annotation was previously unlabelled, which left readers guessing
+  // whether it meant files, call sites or aliases.
+  div.appendChild(el('div', {
+    style: { color: 'var(--fg2)', fontSize: '11px', marginBottom: '8px' }
+  }, '\u2192 ' + arrowHint));
+
+  for (const pkg of direct) {
     const item = el('div', { style: { marginBottom: '8px' } });
-    const a = link(pkg, () => navigate('/realm/' + pkg.replace('gno.land/', '')));
-    if (pkg === root) a.style.fontWeight = 'bold';
-    item.appendChild(a);
-    if ((deps || []).length) {
+    item.appendChild(link(pkg, () => navigate('/realm/' + pkg.replace('gno.land/', ''))));
+
+    // What this one reaches in turn, minus the root: an edge back to the realm
+    // being viewed is the reverse relationship, not a new one.
+    const onward = ((graph || {})[pkg] || []).filter(d => d !== root);
+    if (onward.length) {
       const sub = el('div', { style: { paddingLeft: '16px', color: 'var(--fg2)', fontSize: '12px' } });
       sub.append('\u2192 ');
-      deps.forEach((d, i) => { if (i > 0) sub.append(', '); sub.appendChild(link(d.split('/').slice(-1)[0], () => navigate('/realm/' + d.replace('gno.land/', '')))); });
+      onward.forEach((d, i) => {
+        if (i > 0) sub.append(', ');
+        sub.appendChild(link(d.split('/').slice(-1)[0], () => navigate('/realm/' + d.replace('gno.land/', ''))));
+      });
       item.appendChild(sub);
     }
     div.appendChild(item);
@@ -3176,7 +3222,7 @@ async function loadAddressDetail(addr) {
       if (tx.network) txTd.appendChild(netBadgeEl(tx.network));
       tbody.appendChild(el('tr', {},
         txTd,
-        el('td', {}, typeBadge(msg?.value?.__typename)),
+        el('td', {}, typeBadge(msg?.value?.__typename, msg)),
         el('td', {}, txDetailEl(msg)),
         el('td', {}, statusBadge(tx.success)),
         el('td', { style: { color: 'var(--fg2)', fontSize: '12px' } }, when)
@@ -3293,8 +3339,8 @@ function argValueEl(val) {
 function renderMessageEl(msg, index, returnData, msgLog) {
   const v = msg.value;
   const div = el('div', { className: 'card' });
-  const typeLabel = { MsgCall: '/vm.m_call', MsgAddPackage: '/vm.m_addpkg', MsgRun: '/vm.m_run', BankMsgSend: '/bank.MsgSend' }[v.__typename] || msg.typeUrl || v.__typename;
-  const hdr = el('div', { style: { marginBottom: '8px' } }); hdr.appendChild(typeBadge(v.__typename)); hdr.append(' #' + index + '  '); hdr.appendChild(el('span', { style: { color: 'var(--fg2)', fontSize: '12px', fontFamily: 'var(--mono)' } }, typeLabel)); div.appendChild(hdr);
+  const typeLabel = { MsgCall: '/vm.m_call', MsgAddPackage: '/vm.m_addpkg', MsgRun: '/vm.m_run', BankMsgSend: '/bank.MsgSend' }[v.__typename] || msgKind(msg) || msg.typeUrl || v.__typename;
+  const hdr = el('div', { style: { marginBottom: '8px' } }); hdr.appendChild(typeBadge(v.__typename, msg)); hdr.append(' #' + index + '  '); hdr.appendChild(el('span', { style: { color: 'var(--fg2)', fontSize: '12px', fontFamily: 'var(--mono)' } }, typeLabel)); div.appendChild(hdr);
   const tbl = el('table', { style: { width: '100%' } });
   const addRow = (label, content) => {
     const td = el('td', { style: { wordBreak: 'break-word', maxWidth: '0', width: '100%' } });
@@ -3731,7 +3777,7 @@ function onLiveTx(tx) {
     const msg = tx.messages?.[0];
     const tr = el('tr', { className: 'live-new' },
       el('td', {}, blockLink(tx.block_height, tx.network)),
-      el('td', {}, typeBadge(msg?.value?.__typename)),
+      el('td', {}, typeBadge(msg?.value?.__typename, msg)),
       el('td', {}, txDetailEl(msg)),
       el('td', {}, statusBadge(tx.success)),
       el('td', { style: { color: 'var(--fg2)', fontSize: '12px' } }, timeEl(new Date().toISOString()))
@@ -3748,7 +3794,7 @@ function onLiveTx(tx) {
     const tr = el('tr', { className: 'live-new' },
       el('td', {}, txLink(tx.hash, tx.block_height, tx.network)),
       el('td', {}, blockLink(tx.block_height, tx.network)),
-      el('td', {}, typeBadge(msg?.value?.__typename)),
+      el('td', {}, typeBadge(msg?.value?.__typename, msg)),
       el('td', {}, txDetailEl(msg)),
       el('td', {}, statusBadge(tx.success))
     );


### PR DESCRIPTION
Fixes items 4 and 5 of #115, plus the unexplained arrow annotation in item 7.

## The self-referential dependency is real data, not rendering

#115 reasoned that because the `graph` tab omits the self-loop while the `deps` list shows it, this had to be a list rendering bug. I assumed the same and went looking in the frontend. Both of us were wrong — there are **41 self-edges in the production dependency table**:

```
before   self-edges: 41 of 2587 total
after    self-edges:  0 of 2500 total
```

`ExtractImports` skipped `_test.gno` but not `_filetest.gno`. That is gno's other test convention and does not end in `_test.gno`, so filetests were parsed as production source — and a filetest imports the package under test, which is exactly how a package ends up importing itself.

The same oversight pulled test-only packages into the graph: the 87-edge drop is 41 self-edges plus 46 imports that exist only in tests, like `p/nt/testutils/v0` appearing as a dependency of `r/gov/dao/v3/impl`.

`dependencyExtractorVersion` goes to 3, so every stored package is re-extracted once on the next start. A self-edge is now also refused outright, independent of which files are read.

## The list rendering was also wrong, separately

`buildDepTree` rendered every *node* of the returned graph, which includes the root. So even with clean data the realm appeared as an entry in its own imports and dependents lists.

It now lists the realm's **direct** edges — what the section title actually promises — with what each of those reaches in turn beneath it, and filters an edge pointing back at the root, since that is the reverse relationship rather than a new one.

The `→ x, y, z` annotation now carries a one-line legend ("what each of these imports in turn"), which #115 flagged as unexplained — readers could not tell whether it meant files, call sites or aliases.

## `UnexpectedMessage` was leaking from the indexer

Not a broken mapping — `UnexpectedMessage` is the tx-indexer's `__typename` for a message type its schema does not model. Found the live instance:

```
pearl  block 3986  route/typeUrl = auth/create_session  ->  __typename UnexpectedMessage
```

`route` and `typeUrl` are carried on every message regardless, and say what it actually is. The badge and label now read `auth/create_session`; the raw JSON pane still shows `"__typename": "UnexpectedMessage"`, which is correct — that is the payload. Verified in a browser against the live pearl indexer.

## A startup contention bug found while verifying

The first re-extraction run lost a package to `SQLITE_BUSY` and therefore failed the whole pass — the version marker is only written when every package succeeds, so it would have repeated all 805 on every start until it got a clean run.

The contention is the background `ANALYZE` started in `NewDB`, which holds the write lock for the better part of a second on a large database. The re-extraction now waits for startup work before writing, and only on the path where it actually has work to do. Second run: 805 packages, zero failures.

## Tests

`TestExtractImportsSkipsBothTestConventions` uses the real shape from `r/gov/dao/v3/impl` — a production file, a `_test.gno`, and a `_filetest.gno` that imports the package under test — and asserts no self-edge and no test-only import survives.

`TestExtractImportsNeverEmitsASelfEdge` covers the guard independently of file naming. `TestIsTestFile` includes the near-misses that must *not* match: `testutils.gno` and `latest.gno`.
