### PR TITLE
fix: window the address query so /api/address stops timing out

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -652,31 +652,49 @@ func (c *IndexerClient) GetTransactionByHash(ctx context.Context, hash string) (
 	return &result.GetTransactions[0], nil
 }
 
-// GetTransactionsByAddress fetches transactions involving an address.
+// addressTxLimit bounds an address page. The view shows recent activity, not an
+// account's whole history, and the indexer has no way to make the latter cheap.
+const addressTxLimit = 200
+
+// GetTransactionsByAddress fetches recent transactions involving an address.
+//
+// Windowed from the tip like every other "recent" query. Unbounded, this asked
+// the indexer to scan the whole chain for five address predicates at once: on
+// sapphire it took longer than the ten-second client deadline, so /api/address
+// answered 500 for the busiest accounts — and the timeout counted against the
+// per-network breaker, taking that chain out of every merged view for a minute.
+// One address page could degrade the whole site.
 func (c *IndexerClient) GetTransactionsByAddress(ctx context.Context, addr string) ([]Transaction, error) {
-	var result struct {
-		GetTransactions []Transaction `json:"getTransactions"`
-	}
-	q := fmt.Sprintf(`{
-		getTransactions(
-			where: {
-				_or: [
+	e := gqlEscape(addr)
+	involves := fmt.Sprintf(`_or: [
 					{ messages: { value: { MsgCall: { caller: { eq: "%s" } } } } }
 					{ messages: { value: { MsgAddPackage: { creator: { eq: "%s" } } } } }
 					{ messages: { value: { MsgRun: { caller: { eq: "%s" } } } } }
 					{ messages: { value: { BankMsgSend: { from_address: { eq: "%s" } } } } }
 					{ messages: { value: { BankMsgSend: { to_address: { eq: "%s" } } } } }
-				]
+				]`, e, e, e, e, e)
+
+	txs, err := c.recentTransactionsWindowed(ctx, addressTxLimit, involves,
+		func() ([]Transaction, error) {
+			var result struct {
+				GetTransactions []Transaction `json:"getTransactions"`
 			}
+			q := fmt.Sprintf(`{
+		getTransactions(
+			where: { %s }
 			order: { heightAndIndex: DESC }
 		) { %s }
-	}`, gqlEscape(addr), gqlEscape(addr), gqlEscape(addr), gqlEscape(addr), gqlEscape(addr), txFieldsLight)
-	err := c.query(ctx, q, nil, &result)
-	// Cap at 200 most recent to avoid huge responses
-	if len(result.GetTransactions) > 200 {
-		return result.GetTransactions[:200], err
+	}`, involves, txFieldsLight)
+			err := c.query(ctx, q, nil, &result)
+			return result.GetTransactions, err
+		})
+	if err != nil {
+		return nil, err
 	}
-	return result.GetTransactions, err
+	if len(txs) > addressTxLimit {
+		return txs[:addressTxLimit], nil
+	}
+	return txs, nil
 }
 
 // GetMsgRunTransactions fetches a page of MsgRun transactions above lastHeight.

--- a/indexer_queries_test.go
+++ b/indexer_queries_test.go
@@ -339,3 +339,60 @@ func TestBreakerResetsOnSuccess(t *testing.T) {
 		t.Error("the breaker opened after one failure; the success in between should have reset the count")
 	}
 }
+
+// An address page must be windowed like every other "recent" view.
+//
+// Unbounded, this asked the indexer to scan the whole chain for five address
+// predicates at once. On sapphire that exceeded the ten-second client deadline,
+// so /api/address answered 500 for the busiest accounts — and because a deadline
+// legitimately counts against the per-network breaker, viewing one address took
+// that chain out of every merged view for a minute.
+func TestAddressQueryIsWindowedFromTheTip(t *testing.T) {
+	f, c := newFakeIndexer(t)
+	f.seedChain(1, 5000)
+
+	// The address appears only near the tip, so a window that starts small and
+	// widens still finds it — and the query must be bounded either way.
+	f.add(fakeCall(4999, "2026-08-01T00:00:00Z", "g1needle", "gno.land/r/demo/boards", "Post"))
+
+	txs, err := c.GetTransactionsByAddress(context.Background(), "g1needle")
+	if err != nil {
+		t.Fatalf("GetTransactionsByAddress: %v", err)
+	}
+	if len(txs) == 0 {
+		t.Fatal("the address's own transaction was not found")
+	}
+
+	// Every query must carry a height bound in its *where* clause.
+	//
+	// Checking the whole query text passes for the wrong reason: txFieldsLight
+	// selects `block_height` as a field, so the string appears in every query
+	// regardless of what was filtered. Only the argument says what was asked.
+	for _, q := range f.askedQueries() {
+		if !strings.Contains(q, "getTransactions") {
+			continue
+		}
+		if !strings.Contains(whereClause(q), "block_height") {
+			t.Errorf("an unbounded transaction query went out, where clause: %s", whereClause(q))
+		}
+	}
+}
+
+// The page is capped, so an address with more history than fits still answers.
+func TestAddressQueryIsCapped(t *testing.T) {
+	f, c := newFakeIndexer(t)
+
+	when := "2026-08-01T00:00:00Z"
+	f.seedChain(1, 10)
+	for i := 0; i < addressTxLimit+50; i++ {
+		f.add(fakeCall(1000+i, when, "g1busy", "gno.land/r/demo/boards", "Post"))
+	}
+
+	txs, err := c.GetTransactionsByAddress(context.Background(), "g1busy")
+	if err != nil {
+		t.Fatalf("GetTransactionsByAddress: %v", err)
+	}
+	if len(txs) > addressTxLimit {
+		t.Errorf("returned %d transactions, want at most %d", len(txs), addressTxLimit)
+	}
+}


### PR DESCRIPTION
`/api/address/{addr}?network=sapphire` answered **500 after ten seconds** for the busiest accounts — and viewing one took sapphire out of every merged view for a minute.

Found while checking whether #10's "account balance is broken" finding still reproduced.

```
old   g1ve35g5rhcn9mlm…   http=500  10.00s   context deadline exceeded
old   g1g7dna0gp4nec5r…   http=500   0.00s   indexer unavailable, not retried yet

new   g1ve35g5rhcn9mlm…   http=200   5.63s   txs=200  balance=4895146813671ugnot
new   g1g7dna0gp4nec5r…   http=200   9.00s   txs=200  balance=8644659628ugnot
```

The second `500` is the interesting one: it is instant, because the first request's timeout had already opened the per-network breaker. Unlike the not-found case fixed earlier, a deadline *should* count against the breaker — it genuinely means the indexer was too slow. So one address page degraded the whole site for 60 seconds, correctly.

## Cause

`GetTransactionsByAddress` asked the indexer to scan the entire chain for five address predicates at once, with no height bound. Every other "recent" view had been windowed from the tip; this one was missed.

It now uses the same `recentTransactionsWindowed` helper — start narrow, widen until there are enough rows — which already existed and already handles the element cap correctly for a DESC-from-tip query.

## This also answers #10's balance finding

`balance` populates fine: `4895146813671ugnot` for the first address. It never appeared because the endpoint that carries it was failing outright. I cannot reproduce the exact symptom #10 reported (`"balance":""` *with* a 200), since that was measured against topaz, which no longer exists.

## A test that first passed for the wrong reason

`TestAddressQueryIsWindowedFromTheTip` asserts every transaction query carries a height bound. My first version checked `strings.Contains(query, "block_height")` and passed against the *unwindowed* code — because `txFieldsLight` selects `block_height` as a field, so the string is in every query regardless of what was filtered.

This is the second time that exact trap has caught me on this codebase: matching against the whole GraphQL query when only the `where:` argument says what was asked for. The assertion now goes through `whereClause()`, and I verified it fails against the unbounded version before shipping.

## Still slow

9 seconds for a heavily-active address is under the deadline but not good. That is the same underlying cost as #110 — the indexer has no index for these predicates, so it scans. Worth its own pass; this PR is about it answering at all.
