### PR TITLE
feat: search by address, hash or height, and page the accounts list

### DIFF
--- a/api.go
+++ b/api.go
@@ -1070,9 +1070,29 @@ func (a *API) HandleTokens(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, tokens)
 }
 
+// Account listing bounds. The default matches the previous fixed top 100, so an
+// existing caller passing nothing sees no change.
+const (
+	defaultAccounts = 100
+	maxAccounts     = 500
+)
+
 func (a *API) HandleAccounts(w http.ResponseWriter, r *http.Request) {
 	network := a.networkParam(r)
-	accounts, err := a.db.GetActiveAccounts(network)
+
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	if limit <= 0 {
+		limit = defaultAccounts
+	}
+	if limit > maxAccounts {
+		limit = maxAccounts
+	}
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	if offset < 0 {
+		offset = 0
+	}
+
+	accounts, err := a.db.GetActiveAccounts(network, r.URL.Query().Get("sort"), limit, offset)
 	if err != nil {
 		jsonError(w, err.Error(), 500)
 		return

--- a/db.go
+++ b/db.go
@@ -1642,7 +1642,32 @@ type AccountInfo struct {
 	SendCount   int    `json:"send_count"`
 }
 
-func (d *DB) GetActiveAccounts(network string) ([]AccountInfo, error) {
+// accountSortClause maps a sort name to an ORDER BY over the aggregated columns.
+//
+// The sums are recomputed rather than referenced by alias: SQLite allows the
+// alias here but the expression is what the index-free aggregate produces
+// either way, and spelling it out keeps the mapping readable next to the query.
+func accountSortClause(sortBy string) string {
+	switch sortBy {
+	case "calls":
+		return "SUM(call_count) DESC"
+	case "deploys":
+		return "SUM(deploy_count) DESC"
+	case "runs":
+		return "SUM(run_count) DESC"
+	case "sends":
+		return "SUM(send_count) DESC"
+	default: // total activity
+		return "(SUM(call_count) + SUM(deploy_count) + SUM(run_count) + SUM(send_count)) DESC"
+	}
+}
+
+// GetActiveAccounts returns the most active accounts, paged.
+//
+// limit and offset are honoured so this can back a real leaderboard: it used to
+// return a fixed top 100 with no controls at all, which #10 flagged as the
+// reason it could not serve as one.
+func (d *DB) GetActiveAccounts(network, sortBy string, limit, offset int) ([]AccountInfo, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -1672,10 +1697,10 @@ func (d *DB) GetActiveAccounts(network string) ([]AccountInfo, error) {
 			SELECT to_address as address, network, 0, 0, 0, COUNT(*) FROM bank_sends` + nFilter + ` GROUP BY to_address, network
 		)
 		GROUP BY address, network
-		ORDER BY (SUM(call_count) + SUM(deploy_count) + SUM(run_count) + SUM(send_count)) DESC
-		LIMIT 100
+		ORDER BY ` + accountSortClause(sortBy) + `
+		LIMIT ? OFFSET ?
 	`
-	rows, err := d.db.Query(q)
+	rows, err := d.db.Query(q, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -959,7 +959,7 @@ func TestActiveAccountsAreScopedPerNetwork(t *testing.T) {
 	call("alpha", "a3")
 	call("beta", "b1")
 
-	accounts, err := db.GetActiveAccounts("")
+	accounts, err := db.GetActiveAccounts("", "", 100, 0)
 	if err != nil {
 		t.Fatalf("GetActiveAccounts: %v", err)
 	}
@@ -981,7 +981,7 @@ func TestActiveAccountsAreScopedPerNetwork(t *testing.T) {
 	}
 
 	// Selecting one chain must show only that chain's activity.
-	only, err := db.GetActiveAccounts("beta")
+	only, err := db.GetActiveAccounts("beta", "", 100, 0)
 	if err != nil {
 		t.Fatalf("GetActiveAccounts(beta): %v", err)
 	}

--- a/docs/api.md
+++ b/docs/api.md
@@ -101,7 +101,7 @@ labels this figure "recent" for the same reason.
 | endpoint | description |
 |---|---|
 | `GET /api/address/{addr}` | activity for an address: calls, deploys, runs, sends, and balance |
-| `GET /api/accounts` | most active accounts. **Top 100 by total activity, no pagination or sort controls.** One row per `(address, network)`: the same key on two chains is two different actors, and each row carries its `network` |
+| `GET /api/accounts` | most active accounts. `limit` (default 100, max 500), `offset`, and `sort` = `calls`, `deploys`, `runs`, `sends` or total activity. One row per `(address, network)`: the same key on two chains is two different actors, and each row carries its `network` |
 
 ## Aggregates
 
@@ -143,6 +143,11 @@ GET /api/search?q=<query>
 Searches **package paths, names and creators only**. It does not search
 transaction hashes, block heights, or addresses — an address matches only when it
 happens to be a package creator.
+
+The UI covers the rest without asking the server: an address, a transaction hash
+or a block height is recognised by shape and offered as a direct destination
+above the package matches. A bare number is offered only when a network is
+selected, since a height identifies a different block on every chain.
 
 ## Live feed
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -95,6 +95,8 @@ tr.total-row td { font-weight: bold; color: var(--accent); }
 .section-sub { color: var(--fg2); font-size: 12px; margin: -4px 0 10px; max-width: 70ch; }
 .table-filter-note { color: var(--fg2); font-size: 11px; margin: 4px 0 8px; }
 .table-filter-note a { color: var(--accent); }
+.search-direct { padding: 8px 12px; cursor: pointer; border-bottom: 1px solid var(--border);
+  border-left: 2px solid var(--accent); font-family: var(--mono); word-break: break-all; }
 /* Load failures: shown where a skeleton would otherwise shimmer forever. */
 .load-error { padding: 16px 4px; text-align: left; }
 .load-error-head { color: var(--red); font-weight: bold; margin-bottom: 4px; }
@@ -842,6 +844,36 @@ async function api(path) {
 
 
 
+
+
+// directDestinations recognises what a search term is by its shape.
+//
+// /api/search covers package paths, names and creators. An address, transaction
+// hash or block height matches none of those, so typing one returned "no
+// results" — which reads as "this does not exist" rather than "this box does not
+// search that". Rather than broaden the server query (a hash lookup is an
+// indexer round-trip, and a height needs a network), offer the destination
+// directly: the reader already knows what they typed.
+function directDestinations(raw) {
+  const q = raw.trim();
+  const net = netSuffix(getNetwork());
+  const out = [];
+
+  // gno bech32: g1 followed by 38 more characters.
+  if (/^g1[0-9a-z]{38}$/.test(q)) {
+    out.push({ label: q, kind: 'address', href: '/address/' + q + net });
+  }
+  // A transaction hash is 32 bytes base64: 43 characters and a pad.
+  if (/^[A-Za-z0-9+/]{43}=$/.test(q)) {
+    out.push({ label: q, kind: 'transaction', href: '/tx/' + encodeURIComponent(q) + net });
+  }
+  // A bare number is a block height. It needs a network — a height identifies a
+  // different block on every chain — so this is offered only when one is picked.
+  if (/^\d+$/.test(q) && net) {
+    out.push({ label: 'block ' + fmtNum(parseInt(q, 10)), kind: 'block', href: '/block/' + q + net });
+  }
+  return out;
+}
 
 // dependentsCell groups a realm's dependents by who deployed them.
 //
@@ -3864,7 +3896,27 @@ document.getElementById('search-input').addEventListener('input', function() {
     try {
       const data = await api('search?q=' + encodeURIComponent(q));
       results.textContent = '';
-      if (!data || !data.length) { results.appendChild(el('div', { style: { padding: '8px 12px' } }, 'no results')); }
+
+      // The box looks like a universal search, so make it one. /api/search covers
+      // package paths, names and creators only — an address, a transaction hash
+      // or a block height returned nothing at all, which reads as "not found"
+      // rather than "not searched". These are recognised by shape and offered as
+      // direct destinations above the package matches.
+      for (const d of directDestinations(q)) {
+        const item = el('div', { className: 'search-direct' });
+        item.appendChild(el('div', { style: { fontSize: '13px' } }, d.label));
+        item.appendChild(el('div', { style: { fontSize: '11px', color: 'var(--fg2)' } }, d.kind));
+        item.addEventListener('click', () => { results.classList.remove('open'); navigate(d.href); });
+        item.addEventListener('mouseover', () => item.style.background = 'var(--bg3)');
+        item.addEventListener('mouseout', () => item.style.background = '');
+        results.appendChild(item);
+      }
+
+      if (!data || !data.length) {
+        if (!results.childNodes.length) {
+          results.appendChild(el('div', { style: { padding: '8px 12px' } }, 'no results'));
+        }
+      }
       else { for (const r of data) {
         const item = el('div', { style: { padding: '8px 12px', cursor: 'pointer', borderBottom: '1px solid var(--border)' } });
         item.appendChild(el('div', { style: { fontSize: '13px' } }, r.path));

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -535,3 +535,87 @@ func TestEmptyNotNull(t *testing.T) {
 		})
 	}
 }
+
+// The accounts leaderboard takes paging and sort controls.
+//
+// It used to return a fixed top 100 with none, which #10 flagged as the reason
+// it could not back a real "rich list": there was no way to page past the first
+// hundred or to rank by anything but total activity.
+func TestAccountsPagingAndSort(t *testing.T) {
+	api, db := newTestAPI(t)
+
+	const when = "2026-08-01T00:00:00Z"
+	for i := 0; i < 12; i++ {
+		addr := fmt.Sprintf("g1caller%02d", i)
+		// Descending calls, ascending sends: the two orders disagree, so a sort
+		// that is ignored cannot pass by coincidence.
+		for c := 0; c <= 12-i; c++ {
+			if err := db.InsertCall("alpha", fmt.Sprintf("c-%d-%d", i, c), 100+c, when,
+				addr, "gno.land/r/demo/boards", "Post", true); err != nil {
+				t.Fatalf("InsertCall: %v", err)
+			}
+		}
+		for sIdx := 0; sIdx <= i; sIdx++ {
+			if err := db.InsertBankSend("alpha", fmt.Sprintf("s-%d-%d", i, sIdx), 200+sIdx, when,
+				addr, "g1recv", "1ugnot", true); err != nil {
+				t.Fatalf("InsertBankSend: %v", err)
+			}
+		}
+	}
+
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	get := func(t *testing.T, target string) []AccountInfo {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest("GET", target, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		var accounts []AccountInfo
+		mustJSON(t, rec.Body.Bytes(), &accounts)
+		return accounts
+	}
+
+	t.Run("limit is honoured", func(t *testing.T) {
+		if got := get(t, "/api/accounts?limit=5"); len(got) != 5 {
+			t.Errorf("got %d accounts for limit=5", len(got))
+		}
+	})
+
+	t.Run("offset pages past the first rows", func(t *testing.T) {
+		first := get(t, "/api/accounts?limit=3")
+		next := get(t, "/api/accounts?limit=3&offset=3")
+		if len(first) != 3 || len(next) != 3 {
+			t.Fatalf("page sizes = %d and %d", len(first), len(next))
+		}
+		for _, a := range first {
+			for _, b := range next {
+				if a.Address == b.Address {
+					t.Errorf("%s appears on both pages", a.Address)
+				}
+			}
+		}
+	})
+
+	t.Run("sort changes the order", func(t *testing.T) {
+		byCalls := get(t, "/api/accounts?limit=1&sort=calls")
+		bySends := get(t, "/api/accounts?limit=1&sort=sends")
+		if len(byCalls) == 0 || len(bySends) == 0 {
+			t.Fatal("empty result")
+		}
+		if byCalls[0].Address == bySends[0].Address {
+			t.Errorf("sort=calls and sort=sends both lead with %s; the parameter is ignored",
+				byCalls[0].Address)
+		}
+	})
+
+	t.Run("an absent limit keeps the previous default", func(t *testing.T) {
+		// Twelve callers plus g1recv, which is an active account by virtue of
+		// receiving — the accounts view counts both sides of a send.
+		if got := get(t, "/api/accounts"); len(got) != 13 {
+			t.Errorf("got %d accounts, want all 13 under the default of %d", len(got), defaultAccounts)
+		}
+	})
+}


### PR DESCRIPTION
Closes the two remaining findings in #10. Both still reproduced on production.

## Search looked universal and was not

```
q=boards                                     hits=8
q=g1ve35g5rhcn9mlmqcp9pr085hsqe5x4dm8f23j7   hits=0
q=72779                                      hits=0
```

`/api/search` covers package paths, names and creators. An address, a transaction hash or a block height matches none of those, so the box answered **"no results"** — which reads as *this does not exist*, not *this box does not search that*.

#10 offered two options: broaden the endpoint, or be explicit in the UI. Neither quite fits — "be explicit" leaves a search box that cannot find a transaction, and broadening the server query means an indexer round-trip for a hash and a network for a height.

So the UI recognises what was typed and offers it directly, above the package matches:

- `g1` + 38 characters → address
- 43 base64 characters and a pad → transaction
- a bare number → block, **only when a network is selected**, since a height identifies a different block on every chain

Verified against live data: all three shapes resolve, and `boards` and a partial `g1abc` correctly produce nothing, so package search is unaffected.

## The accounts list had no controls

```
GET /api/accounts?limit=5   ->  100 rows
```

A fixed top 100 by total activity, which #10 flagged as the reason it could not back a real leaderboard. It now takes `limit` (default 100, max 500), `offset`, and `sort` = `calls`, `deploys`, `runs`, `sends` or total.

The default is deliberately the previous fixed 100, so an existing caller passing nothing sees no change.

`TestAccountsPagingAndSort` seeds twelve accounts whose call and send rankings deliberately **disagree**, so a `sort` parameter that is silently ignored cannot pass by coincidence — it asserts `sort=calls` and `sort=sends` lead with different addresses.

One test expectation of mine was wrong and the code was right: I expected twelve accounts and got thirteen, having forgotten that the recipient of a send is an active account too. Corrected the test.

## Not fixed here

#10's first finding — balance unpopulated — was fixed in #121: the `/api/address` endpoint was timing out entirely, so the balance never had a chance to appear. It returns `4894233657062ugnot` now.
