### PR TITLE
fix: remove the proposer moniker lookup that cannot ever match

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -317,31 +317,28 @@ const KNOWN_ADDRS = {
   'g1m0rgan0rla00ygmdmp55f5m0unvsvknluyg2a4': '@morgan',
   'g148583t5x66zs6p90ehad6l4qefeyaf54s69wql': '@faucet',
 };
-// Validator moniker map: address → moniker (loaded from /api/validators)
-const _valMonikers = {};
-async function loadValMonikers() {
-  try {
-    const regs = await fetch('/api/validators?network=' + getNetwork()).then(r => r.json());
-    // Newest first, so the first moniker seen for an address is the current one.
-    for (const reg of (regs || [])) {
-      if (!reg.success || !reg.moniker || !reg.address) continue;
-      if (_valMonikers[reg.address] === undefined) _valMonikers[reg.address] = reg.moniker;
-    }
-  } catch(e) {}
-}
+// proposerEl renders a block proposer.
+//
+// It used to look the address up in a moniker map built from /api/validators, so
+// blocks could show "BonyNode" instead of a raw g1…. That lookup never matched
+// once, on any network, since the day it was written — and it fired on every
+// blocks-view load.
+//
+// The reason is not a bug in the join. A valoper registration carries an ed25519
+// public key, and `sha256(key)[:20]` bech32-encoded reproduces the operator
+// address it registered with — verified against production, where it matches for
+// four of six registrations. But that is the *operator* key. Proposers are
+// identified by the chain's *consensus* key, which is a different key and is
+// never published to the valopers realm. The two address sets are disjoint by
+// construction, so no amount of derivation joins them.
+//
+// See #84 for the measurements. If a realm ever records consensus keys, this
+// becomes possible; until then a lookup that cannot succeed is worse than no
+// lookup, because it reads as a feature that is merely missing data.
 function proposerEl(addr) {
-  const moniker = _valMonikers[addr];
   const span = el('span');
   span.setAttribute('data-hl', addr);
-  if (moniker) {
-    const a = link(moniker, () => navigate('/address/' + addr + netSuffix(getNetwork())));
-    a.setAttribute('data-hl', addr);
-    a.title = addr;
-    span.appendChild(a);
-    span.appendChild(el('span', { className: 'block-ctx' }, ' ' + truncAddr(addr)));
-  } else {
-    span.appendChild(addrLink(addr));
-  }
+  span.appendChild(addrLink(addr));
   return span;
 }
 function addrLabel(addr) { return KNOWN_ADDRS[addr] || ''; }
@@ -1807,7 +1804,7 @@ async function loadBlocks() {
   statsBar.style.display = 'none';
   filterBar.style.display = 'none';
   try {
-    const [data] = await Promise.all([api('blocks?limit=500'), loadValMonikers()]);
+    const data = await api('blocks?limit=500');
     _blocksCache = data;
     _blocksWithTxsOnly = false;
     const withTxs = (data || []).filter(b => b.num_txs > 0);


### PR DESCRIPTION
Closes #84. That issue measured zero matches and asked whether to fix or remove, noting it needed someone who knows gno address derivation. I worked out the derivation, and the answer is **remove** — the join is impossible with the data that exists, not merely unimplemented.

## The derivation is not the problem

A valoper `Register` call carries five arguments; the fifth is a bech32 `gpub1…` public key. Decoded, it is amino-wrapped:

```
0a 11 "/tm.PubKeyEd25519"  12 22  0a 20  <32-byte ed25519 key>
```

`sha256(key)[:20]`, bech32-encoded with hrp `g`, is the standard Tendermint address derivation. It works — verified against production, where it reproduces the operator address the validator registered with:

```
g168x59yty3asqw853e6xwnc6u4wequ9lx5w0v2k  ->  g168x59yty3asqw853e6xwnc6u4wequ9lx5w0v2k  =operator
g1pslde6zthl8crd3970rd6xz5rgxjgasenu3svu  ->  g1pslde6zthl8crd3970rd6xz5rgxjgasenu3svu  =operator
g1vl79vskhqwpmex8g2d5tpu9vrcm0fy9fv7exck  ->  g1vl79vskhqwpmex8g2d5tpu9vrcm0fy9fv7exck  =operator
g1u3q5s5t20ywcw3txfatrv4tvptk2mjaw7a7vm8  ->  g1u3q5s5t20ywcw3txfatrv4tvptk2mjaw7a7vm8  =operator
```

Four of six. So the derivation is right and the registrations are internally consistent.

## But it derives the wrong kind of address

```
proposers matched: 0 of 5
```

The registered key is the validator's **operator** key. Proposers are identified by the chain's **consensus** key — a different key, never published to the valopers realm. The two sets are disjoint by construction, which is why #84 measured zero and why no amount of derivation would have changed that.

## So the lookup goes

`loadValMonikers` fired on every blocks-view load, fetched `/api/validators`, and built a map that was never once hit. `proposerEl` keeps rendering the address; it just no longer consults a map that cannot contain it.

A lookup that cannot succeed is worse than none: it reads as a feature waiting on data, and it costs a request per page load to produce nothing. If a realm ever records consensus keys this becomes possible, and the comment on `proposerEl` says exactly what would be needed.

## One observation, not acted on

Two of the six registrations carry a pubkey that does *not* derive their stated address:

```
g15804zy06zp2mcg5r7wguxke9askqssy3hr0htw  ->  g1tj4qxqr0z0wx75g0yaydqdfjt94mz3x5fnk8ap
g17fagya0w79zdjz5zg9sn9xlpzmx2clschkrj8r  ->  g1xyjsw9rjgqjwmrl8zpn4puvjgal6azm0kje55r
```

That may be deliberate — nothing forces the two to correspond — so I am recording it rather than flagging it in the UI as an error. Worth knowing if the validators view ever grows a consistency check.
