### PR TITLE
feat: name known addresses globally, deriving what can be proved

### DIFF
--- a/analytics_test.go
+++ b/analytics_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 )
@@ -368,5 +369,76 @@ func TestBankStatsScopedToOneNetwork(t *testing.T) {
 	}
 	if s.ByNetwork != nil {
 		t.Errorf("by_network was sent for a single network: %+v", s.ByNetwork)
+	}
+}
+
+// Namespace ownership is the one address name that can be proved from the data:
+// the sole deployer of gno.land/r/gnoswap/* is gnoswap.
+//
+// The rule has to refuse more than it accepts. Seven namespaces on the live
+// chains have several deployers, and picking one of them would present a guess
+// as a fact — which is precisely the class of thing that costs an explorer its
+// credibility.
+func TestDerivedAddressLabels(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "live"}, {ID: "retired"}})
+
+	const when = "2026-08-01T00:00:00Z"
+	deploy := func(net, path, creator string) {
+		t.Helper()
+		if err := db.UpsertPackage(net, path, "pkg", creator, net+path, 100, when, true, 1); err != nil {
+			t.Fatalf("UpsertPackage: %v", err)
+		}
+	}
+
+	// Sole deployer of a namespace, well past the minimum.
+	for i := 0; i < 5; i++ {
+		deploy("live", fmt.Sprintf("gno.land/r/gnoswap/pkg%d", i), "g1gnoswap")
+	}
+	// Two deployers under one namespace: nobody gets named.
+	for i := 0; i < 4; i++ {
+		deploy("live", fmt.Sprintf("gno.land/r/shared/a%d", i), "g1first")
+		deploy("live", fmt.Sprintf("gno.land/r/shared/b%d", i), "g1second")
+	}
+	// Only two packages: below the minimum evidence.
+	deploy("live", "gno.land/r/tiny/one", "g1tiny")
+	deploy("live", "gno.land/r/tiny/two", "g1tiny")
+	// A namespace that is itself an address carries no name.
+	for i := 0; i < 4; i++ {
+		deploy("live", fmt.Sprintf("gno.land/r/g1selfns/pkg%d", i), "g1selfns")
+	}
+	// Publishes widely, so no single namespace identifies it.
+	for i := 0; i < 4; i++ {
+		deploy("live", fmt.Sprintf("gno.land/r/spread%d/pkg", i), "g1spread")
+	}
+	// A retired chain must not contribute a name.
+	for i := 0; i < 5; i++ {
+		deploy("retired", fmt.Sprintf("gno.land/r/ghost/pkg%d", i), "g1ghost")
+	}
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "live"}})
+
+	labels, err := db.DerivedAddressLabels("")
+	if err != nil {
+		t.Fatalf("DerivedAddressLabels: %v", err)
+	}
+
+	if got := labels["g1gnoswap"].Label; got != "@gnoswap" {
+		t.Errorf("sole deployer label = %q, want @gnoswap", got)
+	}
+	if labels["g1gnoswap"].Why == "" {
+		t.Error("a label with no stated evidence cannot be checked by a reader")
+	}
+
+	for addr, reason := range map[string]string{
+		"g1first":  "shares its namespace with another deployer",
+		"g1second": "shares its namespace with another deployer",
+		"g1tiny":   "has too few packages to establish ownership",
+		"g1selfns": "its namespace is an address, which carries no name",
+		"g1spread": "publishes across namespaces, so none identifies it",
+		"g1ghost":  "deployed only on a retired network",
+	} {
+		if l, ok := labels[addr]; ok {
+			t.Errorf("%s was labelled %q but %s", addr, l.Label, reason)
+		}
 	}
 }

--- a/api.go
+++ b/api.go
@@ -1077,6 +1077,20 @@ const (
 	maxAccounts     = 500
 )
 
+// HandleLabels serves display names for addresses, derived from on-chain data.
+//
+// Kept separate from the rows that mention an address so it can be fetched once
+// and applied everywhere, rather than repeating a label on every transaction in
+// a list.
+func (a *API) HandleLabels(w http.ResponseWriter, r *http.Request) {
+	labels, err := a.db.DerivedAddressLabels(a.networkParam(r))
+	if err != nil {
+		jsonError(w, err.Error(), 500)
+		return
+	}
+	jsonResponse(w, labels)
+}
+
 func (a *API) HandleAccounts(w http.ResponseWriter, r *http.Request) {
 	network := a.networkParam(r)
 
@@ -1609,5 +1623,6 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/validators", a.HandleValidators)
 	mux.HandleFunc("GET /api/tokens", a.HandleTokens)
 	mux.HandleFunc("GET /api/accounts", a.HandleAccounts)
+	mux.HandleFunc("GET /api/labels", a.HandleLabels)
 	mux.HandleFunc("GET /api/govdao", a.HandleGovDAO)
 }

--- a/db.go
+++ b/db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	_ "modernc.org/sqlite"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -2858,4 +2859,103 @@ func (d *DB) GetActiveAddressTimeSeries(network, granularity string, days int) (
 		}
 	}
 	return out, nil
+}
+
+// AddressLabel is a display name for an address, derived from on-chain data.
+type AddressLabel struct {
+	Label string `json:"label"`
+	Kind  string `json:"kind"`
+	Why   string `json:"why"`
+}
+
+// namespaceLabelMinPackages is how many packages a deployer must have published
+// under a namespace before that namespace names it. Below this the evidence is
+// one or two deploys, which is as easily a guest as an owner.
+const namespaceLabelMinPackages = 3
+
+// namespaceLabelDominance is the share of a deployer's own packages that must sit
+// under the namespace. Someone who publishes widely and happens to have three
+// packages under a prefix is not that prefix's owner.
+const namespaceLabelDominance = 0.6
+
+var namespacePath = regexp.MustCompile(`^gno\.land/[rp]/([^/]+)/`)
+
+// DerivedAddressLabels names addresses from what they have deployed.
+//
+// The signal is namespace ownership: an address that is the sole deployer of
+// gno.land/r/gnoswap/* is gnoswap. Derived rather than hand-maintained, so it
+// stays correct as namespaces appear, and it independently reproduces the
+// hand-written entries that already existed — which is the check that the rule
+// is the right one.
+//
+// Two guards keep it from naming the wrong address:
+//
+//   - A namespace with more than one deployer names nobody. Seven of them exist
+//     on the live chains (onbloc has three), and picking one would be a guess
+//     presented as a fact.
+//   - A namespace that is itself an address (gno.land/r/g1abc.../foo) is skipped.
+//     The prefix is the deployer, so it carries no name.
+func (d *DB) DerivedAddressLabels(network string) (map[string]AddressLabel, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`SELECT path, creator FROM packages WHERE ` +
+		d.networkFilter("network", network))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	perCreator := map[string]map[string]int{} // creator -> namespace -> packages
+	total := map[string]int{}                 // creator -> packages with any namespace
+	deployers := map[string]map[string]bool{} // namespace -> creators
+
+	for rows.Next() {
+		var path, creator string
+		if err := rows.Scan(&path, &creator); err != nil {
+			return nil, err
+		}
+		m := namespacePath.FindStringSubmatch(path)
+		if m == nil || strings.HasPrefix(m[1], "g1") {
+			continue
+		}
+		ns := m[1]
+		if perCreator[creator] == nil {
+			perCreator[creator] = map[string]int{}
+		}
+		perCreator[creator][ns]++
+		total[creator]++
+		if deployers[ns] == nil {
+			deployers[ns] = map[string]bool{}
+		}
+		deployers[ns][creator] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	labels := map[string]AddressLabel{}
+	for creator, counts := range perCreator {
+		best, n := "", 0
+		for ns, c := range counts {
+			if c > n {
+				best, n = ns, c
+			}
+		}
+		if best == "" || n < namespaceLabelMinPackages {
+			continue
+		}
+		if len(deployers[best]) != 1 {
+			continue
+		}
+		if float64(n)/float64(total[creator]) < namespaceLabelDominance {
+			continue
+		}
+		labels[creator] = AddressLabel{
+			Label: "@" + best,
+			Kind:  "namespace",
+			Why:   fmt.Sprintf("sole deployer of gno.land/*/%s/* (%d packages)", best, n),
+		}
+	}
+	return labels, nil
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -69,6 +69,17 @@ the whole window. `/api/live` and `/api/version` bypass the cache entirely.
 |---|---|
 | `GET /api/version` | build info: `git_hash`, `build_time` |
 | `GET /api/networks` | configured network IDs — the fastest way to confirm which chains an instance is actually serving |
+| `GET /api/labels` | display names for addresses, derived from on-chain data: `{address: {label, kind, why}}`. Currently one rule — the sole deployer of a named namespace is that namespace. `why` states the evidence so any label can be checked |
+
+**Address labels are global, not per network.** An address is the same key on
+every chain, so a name earned on one applies everywhere. `/api/labels` derives
+what it can prove; the UI adds a small curated map for names that cannot be
+derived — faucets and infrastructure keys — and marks any label inferred from
+behaviour rather than proved, with the reasoning in its tooltip.
+
+Nothing is derived from a namespace with more than one deployer. Seven exist on
+the live chains, and naming one of their deployers would present a guess as a
+fact.
 
 ## Packages and realms
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -95,6 +95,7 @@ tr.total-row td { font-weight: bold; color: var(--accent); }
 .section-sub { color: var(--fg2); font-size: 12px; margin: -4px 0 10px; max-width: 70ch; }
 .table-filter-note { color: var(--fg2); font-size: 11px; margin: 4px 0 8px; }
 .table-filter-note a { color: var(--accent); }
+.addr-inferred { color: var(--fg2); font-size: 10px; vertical-align: super; cursor: help; margin-left: 1px; }
 .search-direct { padding: 8px 12px; cursor: pointer; border-bottom: 1px solid var(--border);
   border-left: 2px solid var(--accent); font-family: var(--mono); word-break: break-all; }
 /* Load failures: shown where a skeleton would otherwise shimmer forever. */
@@ -311,12 +312,81 @@ function badge(type, text) {
   return b;
 }
 function link(text, onclick) { const a = el('a', { href: '#' }, text); a.addEventListener('click', (e) => { e.preventDefault(); onclick(); }); return a; }
+// Curated address labels, global rather than per network: an address is the same
+// key everywhere, and a faucet on one testnet is the same operator on the next.
+//
+// Only for names that cannot be derived. Anything provable from on-chain data —
+// namespace ownership in particular — comes from /api/labels instead, so it
+// stays right as the chains change instead of rotting here.
+//
+// A plain string is a name we can stand behind. An object with `why` is an
+// *inference* from behaviour: it renders with a marker and the reasoning in its
+// tooltip, so a reader can tell "this address deployed gno.land/r/gnoswap/*"
+// from "this address looks like a faucet". Guessing silently is how an explorer
+// loses the trust that makes it worth using.
 const KNOWN_ADDRS = {
   'g1edq4dugw0sgat4zxcw9xardvuydqf6cgleuc8p': '@genesis_deployer',
   'g1manfred47kzduec920z88wfr64ylksmdcedlf5': '@moul',
   'g1m0rgan0rla00ygmdmp55f5m0unvsvknluyg2a4': '@morgan',
   'g148583t5x66zs6p90ehad6l4qefeyaf54s69wql': '@faucet',
+
+  // Inferred from activity shape. Measured 2026-08-28 against the live chains.
+  'g18qhq2fl54lszhmxeyqlvxnwjzc3xpu4nnakclp': {
+    label: '@faucet',
+    why: 'inferred: 3 683 sends to 953 addresses across three networks, never calls a realm, receives nothing',
+  },
+  'g1ve35g5rhcn9mlmqcp9pr085hsqe5x4dm8f23j7': {
+    label: '@test_token_faucet',
+    why: 'inferred: 464 582 calls, almost all Transfer on gnoswap test tokens (test_atom, test_btc, …)',
+  },
+  'g1v73cacldctfky0thu5xuuhmy5zs0mnd8vxyl2w': {
+    label: '@gnoswap_bot',
+    why: 'inferred: 7 189 uniform 500 000 ugnot sends plus router::ExactInSwapRoute — distributes and trades',
+  },
+  'g1vmmklhc7eyxgr3x8ll0yr5wupv8lkxv4xhd8l0': {
+    label: '@gnoswap_bot',
+    why: 'inferred: 6 410 sends to 6 123 addresses plus 6 135 router::ExactInSwapRoute calls',
+  },
+  'g1cywjkx44a92c2j0fgfjxa64pg9qjf0vn6p8qsm': {
+    label: '@gnoswap_bot',
+    why: 'inferred: 5 262 sends to 4 924 addresses plus 4 930 router::ExactInSwapRoute calls',
+  },
+  'g1uhsq7qat4l345hkw9f2g5wpm6pnncmrju9p5mu': {
+    label: '@gnoswap_bot',
+    why: 'inferred: 1 637 uniform 500 000 ugnot sends plus router::ExactInSwapRoute calls',
+  },
 };
+
+// Labels derived on the server from namespace ownership, fetched once per load.
+let _derivedAddrLabels = {};
+async function loadAddrLabels() {
+  try {
+    _derivedAddrLabels = await api('labels') || {};
+  } catch (_) {
+    _derivedAddrLabels = {};
+  }
+}
+
+// addrInfo resolves an address to {label, why, inferred}.
+//
+// `why` is the evidence and is shown for every label that has any. `inferred` is
+// narrower: it means the label was worked out from behaviour rather than proved.
+// The two are not the same, and conflating them would put a doubt marker on
+// @gnoswap — an address that demonstrably deployed gno.land/r/gnoswap/*.
+//
+// Curated entries win over derived ones: a hand-written name is a deliberate
+// override of whatever the data implies.
+function addrInfo(addr) {
+  const curated = KNOWN_ADDRS[addr];
+  if (typeof curated === 'string') return { label: curated, why: '', inferred: false };
+  // Every curated object entry is a behavioural inference; that is what the
+  // object form is for.
+  if (curated) return { label: curated.label, why: curated.why || '', inferred: true };
+
+  const derived = _derivedAddrLabels[addr];
+  if (derived) return { label: derived.label, why: derived.why || '', inferred: false };
+  return null;
+}
 // proposerEl renders a block proposer.
 //
 // It used to look the address up in a moniker map built from /api/validators, so
@@ -341,7 +411,7 @@ function proposerEl(addr) {
   span.appendChild(addrLink(addr));
   return span;
 }
-function addrLabel(addr) { return KNOWN_ADDRS[addr] || ''; }
+function addrLabel(addr) { return (addrInfo(addr) || {}).label || ''; }
 // Single source of truth for abbreviating an address: keep the g1 prefix and the
 // tail, so two addresses sharing a prefix stay distinguishable. Every call site
 // that shortens an address goes through this.
@@ -358,17 +428,26 @@ function shortAddr(addr) {
 // address row from a merged view navigated to the current selection, which in
 // all-networks mode meant no network at all.
 function addrLink(addr, network) {
-  const label = KNOWN_ADDRS[addr];
+  const info = addrInfo(addr);
   const span = el('span');
   span.setAttribute('data-hl', addr);
   // Show the abbreviated form; a full 40-character address in every table cell
   // crowds out the content beside it. The full value stays in the tooltip, and
   // the link target is unchanged.
-  const a = link(label || truncAddr(addr), () => navigate('/address/' + addr + netSuffix(network)));
+  const a = link(info ? info.label : truncAddr(addr), () => navigate('/address/' + addr + netSuffix(network)));
   a.setAttribute('data-hl', addr);
   a.title = addr;
   span.appendChild(a);
-  if (label) {
+  if (info) {
+    // The evidence goes in the link's tooltip whatever its source, so any label
+    // can be checked. Only an inferred one is marked, because only that one
+    // asks the reader to take something on trust.
+    if (info.why) a.title = addr + '\n' + info.why;
+    if (info.inferred) {
+      const mark = el('span', { className: 'addr-inferred' }, '?');
+      mark.title = info.why || 'inferred from activity';
+      span.appendChild(mark);
+    }
     span.appendChild(el('span', { className: 'block-ctx' }, ' ' + truncAddr(addr)));
   }
   return span;
@@ -3950,7 +4029,9 @@ document.querySelectorAll('.stat-link').forEach(tile => {
 });
 
 // --- Init ---
-initNetworkSelector();
+// Labels first: they change how every address renders, and arriving after the
+// first paint would show raw addresses that then silently rewrite themselves.
+loadAddrLabels().then(() => { initNetworkSelector(); });
 
 // --- Footer version ---
 api('version').then(v => {


### PR DESCRIPTION
Address labels, global rather than per network — an address is the same key on every chain, so a name earned on one applies everywhere. The existing `KNOWN_ADDRS` was already a flat global map; this expands what feeds it.

Two sources, deliberately kept apart.

## Derived: namespace ownership (`GET /api/labels`)

The sole deployer of `gno.land/r/gnoswap/*` **is** gnoswap. That is provable from data already stored, so it is computed rather than hand-maintained and stays right as namespaces appear.

On production it yields 8 labels:

```
g1manfred47kzduec920z88wfr64ylksmdcedlf5   @moul       sole deployer of gno.land/*/moul/* (150 packages)
g1q5tjjv3kkslzwf2na9y9wk7e5a8ugph8xfsk04   @gnoswap    sole deployer of gno.land/*/gnoswap/* (51 packages)
g12j6x2cnpkvz83l6a5lhfw22703kwwpknpfnt70   @aib        sole deployer of gno.land/*/aib/* (31 packages)
g125em6arxsnj49vx35f0n0z34putv5ty3376fg5   @leon       sole deployer of gno.land/*/leon/* (6 packages)
```

Plus four `@nym-*` namespace registrations, which are real self-registered namespaces even if the names are throwaway. Filtering them would mean hardcoding a rule about which names look serious, which is exactly the kind of guess this is trying to avoid.

`@moul` was already hardcoded, and the rule rediscovers it independently — the check that the rule is the right one.

The rule refuses more than it accepts:

- a namespace with **more than one deployer** names nobody (seven exist on the live chains; `onbloc` has three)
- a namespace that is itself an address carries no name
- fewer than three packages is not enough evidence
- a deployer must be predominantly under one namespace, so someone publishing widely is not named after a prefix they happen to have three packages under

## Curated: names that cannot be derived

Faucets and infrastructure keys, hand-maintained. Per your call, the behavioural guesses are included — `@faucet`, `@test_token_faucet`, four `@gnoswap_bot`s — but they are **marked**, with the measurement in the tooltip:

```
@gnoswap  g1q5tjjv…sk04      tooltip: sole deployer of gno.land/*/gnoswap/* (51 packages)
@faucet?  g18qhq2f…kclp      tooltip: inferred: 3 683 sends to 953 addresses across three
                                      networks, never calls a realm, receives nothing
```

A reader can tell a name we can prove from one worked out from behaviour. Given how much of this project's recent work has been about not showing plausible-but-wrong numbers, silently guessing a name felt like the same mistake in a different place.

## One bug I caught while verifying

My first version marked **every** label carrying evidence, so `@gnoswap` rendered as `@gnoswap?` — a doubt marker on an address that demonstrably deployed that namespace. I had conflated *evidence* (worth showing for everything) with *inference* (only for guesses). They are now separate: `why` is the tooltip on any label, `inferred` drives the marker.

## Corrections to my own first pass

I initially read the four `@gnoswap_bot` addresses as faucets purely from fan-out — thousands of sends to nearly as many distinct recipients. Looking at what they actually call, they are mostly `router::ExactInSwapRoute` and receive more than they send, so "faucet" would have been wrong. Their labels say `bot` and their tooltips say what was measured.

## Not included

Validator monikers, per your call. Worth recording that they would work: 94 of 101 valoper operator addresses appear in the transaction data. That is the useful half of the lookup removed in #123 — the half that failed was proposers, which use consensus keys.
