### PR TITLE
feat: watchlist with an activity digest, and keyboard navigation

### DIFF
--- a/api.go
+++ b/api.go
@@ -1091,6 +1091,57 @@ func (a *API) HandleLabels(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, labels)
 }
 
+// maxWatchItems bounds a watchlist request. Each item is a handful of indexed
+// counts, so the cost is linear — but the parameters come from a URL and this is
+// the one endpoint whose size a caller controls directly.
+const maxWatchItems = 100
+
+// HandleWatch summarises activity for the realms and addresses a caller watches.
+//
+// Items arrive as repeated `realm=` and `address=` parameters, each optionally
+// carrying the height the caller last saw as `path@height`. That height is what
+// turns a list into a digest: it is what "12 new calls since you last looked"
+// counts against.
+//
+// Height rather than a timestamp because it is exact and monotonic per chain,
+// where comparing wall-clock time against block time drifts.
+func (a *API) HandleWatch(w http.ResponseWriter, r *http.Request) {
+	network := a.networkParam(r)
+	q := r.URL.Query()
+
+	parse := func(values []string) []WatchRequest {
+		out := make([]WatchRequest, 0, len(values))
+		for _, v := range values {
+			if len(out) >= maxWatchItems {
+				break
+			}
+			id, since := v, 0
+			if at := strings.LastIndex(v, "@"); at > 0 {
+				if n, err := strconv.Atoi(v[at+1:]); err == nil {
+					id, since = v[:at], n
+				}
+			}
+			if id == "" {
+				continue
+			}
+			out = append(out, WatchRequest{ID: id, Since: since})
+		}
+		return out
+	}
+
+	realms, err := a.db.WatchRealms(network, parse(q["realm"]))
+	if err != nil {
+		jsonError(w, err.Error(), 500)
+		return
+	}
+	addresses, err := a.db.WatchAddresses(network, parse(q["address"]))
+	if err != nil {
+		jsonError(w, err.Error(), 500)
+		return
+	}
+	jsonResponse(w, map[string]any{"realms": realms, "addresses": addresses})
+}
+
 func (a *API) HandleAccounts(w http.ResponseWriter, r *http.Request) {
 	network := a.networkParam(r)
 
@@ -1624,5 +1675,6 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/tokens", a.HandleTokens)
 	mux.HandleFunc("GET /api/accounts", a.HandleAccounts)
 	mux.HandleFunc("GET /api/labels", a.HandleLabels)
+	mux.HandleFunc("GET /api/watch", a.HandleWatch)
 	mux.HandleFunc("GET /api/govdao", a.HandleGovDAO)
 }

--- a/db.go
+++ b/db.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	_ "modernc.org/sqlite"
@@ -2958,4 +2959,144 @@ func (d *DB) DerivedAddressLabels(network string) (map[string]AddressLabel, erro
 		}
 	}
 	return labels, nil
+}
+
+// --- Watchlist ------------------------------------------------------------
+
+// WatchedRealm is one realm's activity summary, for a watchlist digest.
+type WatchedRealm struct {
+	Network    string `json:"network"`
+	Path       string `json:"path"`
+	Exists     bool   `json:"exists"`
+	Calls      int    `json:"calls"`
+	Calls24h   int    `json:"calls_24h"`
+	Importers  int    `json:"importers"`
+	LastHeight int    `json:"last_height"`
+	LastTime   string `json:"last_time,omitempty"`
+	// NewSince counts activity above the height the caller last saw. Height
+	// rather than a timestamp because it is exact and monotonic per chain,
+	// where a wall-clock comparison drifts against block time.
+	//
+	// Zero when the caller supplied no baseline. Reporting the entire history as
+	// "new" in that case would be technically defensible and useless.
+	NewSince int `json:"new_since"`
+}
+
+// WatchedAddress is one address's activity summary.
+type WatchedAddress struct {
+	Network    string `json:"network"`
+	Address    string `json:"address"`
+	Calls      int    `json:"calls"`
+	Deploys    int    `json:"deploys"`
+	Sends      int    `json:"sends"`
+	Received   int    `json:"received"`
+	Calls24h   int    `json:"calls_24h"`
+	LastHeight int    `json:"last_height"`
+	LastTime   string `json:"last_time,omitempty"`
+	NewSince   int    `json:"new_since"`
+}
+
+// WatchRequest is one item a caller is watching, with the height it last saw.
+type WatchRequest struct {
+	ID    string
+	Since int
+}
+
+// WatchRealms summarises activity for a set of watched realms.
+//
+// Answered entirely from stored rows: a watchlist is checked often and by
+// definition covers things the caller already cares about, so it must not cost
+// an indexer round-trip per item.
+func (d *DB) WatchRealms(network string, items []WatchRequest) ([]WatchedRealm, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if len(items) == 0 {
+		return []WatchedRealm{}, nil
+	}
+	since24h := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
+	netFilter := d.networkFilter("network", network)
+
+	out := make([]WatchedRealm, 0, len(items))
+	for _, item := range items {
+		w := WatchedRealm{Path: item.ID}
+
+		// The realm itself. A watched path can exist on several chains; report
+		// the one the current view is scoped to, or the newest deploy otherwise.
+		err := d.db.QueryRow(`SELECT network FROM packages WHERE path = ? AND `+netFilter+
+			` ORDER BY block_height DESC LIMIT 1`, item.ID).Scan(&w.Network)
+		if err == nil {
+			w.Exists = true
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+
+		d.db.QueryRow(`SELECT COUNT(*) FROM calls WHERE pkg_path = ? AND `+netFilter,
+			item.ID).Scan(&w.Calls)
+		d.db.QueryRow(`SELECT COUNT(*) FROM calls WHERE pkg_path = ? AND block_time >= ? AND `+netFilter,
+			item.ID, since24h).Scan(&w.Calls24h)
+		d.db.QueryRow(`SELECT COUNT(*) FROM dependencies WHERE import_path = ? AND `+netFilter,
+			item.ID).Scan(&w.Importers)
+
+		var height sql.NullInt64
+		var when sql.NullString
+		d.db.QueryRow(`SELECT block_height, block_time FROM calls WHERE pkg_path = ? AND `+netFilter+
+			` ORDER BY block_height DESC LIMIT 1`, item.ID).Scan(&height, &when)
+		w.LastHeight, w.LastTime = int(height.Int64), when.String
+
+		if item.Since > 0 {
+			d.db.QueryRow(`SELECT COUNT(*) FROM calls WHERE pkg_path = ? AND block_height > ? AND `+netFilter,
+				item.ID, item.Since).Scan(&w.NewSince)
+		}
+		out = append(out, w)
+	}
+	return out, nil
+}
+
+// WatchAddresses summarises activity for a set of watched addresses.
+func (d *DB) WatchAddresses(network string, items []WatchRequest) ([]WatchedAddress, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if len(items) == 0 {
+		return []WatchedAddress{}, nil
+	}
+	since24h := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
+	nf := d.networkFilter("network", network)
+
+	out := make([]WatchedAddress, 0, len(items))
+	for _, item := range items {
+		w := WatchedAddress{Address: item.ID}
+
+		d.db.QueryRow(`SELECT COUNT(*) FROM calls WHERE caller = ? AND `+nf, item.ID).Scan(&w.Calls)
+		d.db.QueryRow(`SELECT COUNT(*) FROM packages WHERE creator = ? AND `+nf, item.ID).Scan(&w.Deploys)
+		d.db.QueryRow(`SELECT COUNT(*) FROM bank_sends WHERE from_address = ? AND `+nf, item.ID).Scan(&w.Sends)
+		d.db.QueryRow(`SELECT COUNT(*) FROM bank_sends WHERE to_address = ? AND `+nf, item.ID).Scan(&w.Received)
+		d.db.QueryRow(`SELECT COUNT(*) FROM calls WHERE caller = ? AND block_time >= ? AND `+nf,
+			item.ID, since24h).Scan(&w.Calls24h)
+
+		// Newest activity across every table the address can appear in, so a
+		// deploy-only or send-only account still reports a last-seen height.
+		var height sql.NullInt64
+		var when sql.NullString
+		d.db.QueryRow(`SELECT block_height, block_time, network FROM (
+			SELECT block_height, block_time, network FROM calls WHERE caller = ? AND `+nf+`
+			UNION ALL SELECT block_height, block_time, network FROM packages WHERE creator = ? AND `+nf+`
+			UNION ALL SELECT block_height, block_time, network FROM bank_sends WHERE from_address = ? AND `+nf+`
+			UNION ALL SELECT block_height, block_time, network FROM bank_sends WHERE to_address = ? AND `+nf+`
+		) ORDER BY block_height DESC LIMIT 1`,
+			item.ID, item.ID, item.ID, item.ID).Scan(&height, &when, &w.Network)
+		w.LastHeight, w.LastTime = int(height.Int64), when.String
+
+		if item.Since > 0 {
+			d.db.QueryRow(`SELECT COUNT(*) FROM (
+				SELECT block_height FROM calls WHERE caller = ? AND block_height > ? AND `+nf+`
+				UNION ALL SELECT block_height FROM packages WHERE creator = ? AND block_height > ? AND `+nf+`
+				UNION ALL SELECT block_height FROM bank_sends WHERE from_address = ? AND block_height > ? AND `+nf+`
+				UNION ALL SELECT block_height FROM bank_sends WHERE to_address = ? AND block_height > ? AND `+nf+`
+			)`, item.ID, item.Since, item.ID, item.Since, item.ID, item.Since, item.ID, item.Since).Scan(&w.NewSince)
+		}
+		out = append(out, w)
+	}
+	return out, nil
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -69,6 +69,7 @@ the whole window. `/api/live` and `/api/version` bypass the cache entirely.
 |---|---|
 | `GET /api/version` | build info: `git_hash`, `build_time` |
 | `GET /api/networks` | configured network IDs — the fastest way to confirm which chains an instance is actually serving |
+| `GET /api/watch` | activity digest for a watchlist. Repeated `realm=` and `address=` parameters, each optionally `id@height` — that height is the baseline `new_since` counts against. Answered from stored rows only, so a watchlist costs no indexer round-trips. Capped at 100 items |
 | `GET /api/labels` | display names for addresses, derived from on-chain data: `{address: {label, kind, why}}`. Currently one rule — the sole deployer of a named namespace is that namespace. `why` states the evidence so any label can be checked |
 
 **Address labels are global, not per network.** An address is the same key on

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -96,6 +96,19 @@ tr.total-row td { font-weight: bold; color: var(--accent); }
 .table-filter-note { color: var(--fg2); font-size: 11px; margin: 4px 0 8px; }
 .table-filter-note a { color: var(--accent); }
 .addr-inferred { color: var(--fg2); font-size: 10px; vertical-align: super; cursor: help; margin-left: 1px; }
+.watch-btn { background: var(--bg2); border: 1px solid var(--border); color: var(--fg2); border-radius: 4px;
+  padding: 3px 9px; font-family: inherit; font-size: 12px; cursor: pointer; }
+.watch-btn:hover { border-color: var(--accent); color: var(--accent); }
+.watch-btn.on { color: var(--accent); border-color: var(--accent); }
+.watch-new { color: var(--accent); font-weight: bold; }
+.shortcut-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex;
+  align-items: center; justify-content: center; z-index: 1000; }
+.shortcut-card { background: var(--bg2); border: 1px solid var(--border); border-radius: 6px;
+  padding: 20px 24px; min-width: 340px; max-width: 90vw; }
+.shortcut-row { display: flex; gap: 16px; align-items: baseline; margin: 6px 0; font-size: 13px; }
+.shortcut-row kbd { font-family: var(--mono); background: var(--bg3); border: 1px solid var(--border);
+  border-radius: 3px; padding: 1px 6px; font-size: 11px; white-space: nowrap; }
+.shortcut-row span { color: var(--fg2); }
 .search-direct { padding: 8px 12px; cursor: pointer; border-bottom: 1px solid var(--border);
   border-left: 2px solid var(--accent); font-family: var(--mono); word-break: break-all; }
 /* Load failures: shown where a skeleton would otherwise shimmer forever. */
@@ -172,6 +185,7 @@ footer a:hover { color: var(--accent); }
     <span class="logo" onclick="navigate('/')">mygnoscan</span>
     <nav>
       <a onclick="navigate('/')" id="nav-home" class="active">home</a>
+      <a onclick="navigate('/watch')" id="nav-watch">watch</a>
       <a onclick="navigate('/realms')" id="nav-realms">realms</a>
       <a onclick="navigate('/packages')" id="nav-packages">packages</a>
       <a onclick="navigate('/txs')" id="nav-txs">txs</a>
@@ -224,6 +238,7 @@ footer a:hover { color: var(--accent); }
         <table><thead><tr><th>path</th><th>used by</th><th>imports</th><th>calls</th><th>creator</th><th>block</th></tr></thead><tbody id="latest-realms"></tbody></table></div>
     </main>
   </div>
+  <div class="view" id="view-watch"><main><div id="watch-content"></div></main></div>
   <div class="view" id="view-realms"><main><div id="realms-stats" class="stats-bar" style="display:none"></div><div class="section"><div class="section-title">all realms</div>
     <table><thead><tr><th>path</th><th>creator</th>
       <th class="rs" data-sort="calls">calls</th>
@@ -1040,6 +1055,205 @@ function usageLink(realm, kind) {
   return a;
 }
 
+
+// --- Watchlist -------------------------------------------------------------
+//
+// The thing an explorer lacks for daily use is anything to come back *to*. You
+// look something up, you leave. A watchlist plus a count of what has happened
+// since you last looked turns that into a page worth opening in the morning.
+//
+// Kept in localStorage rather than behind an account: there is no user system
+// and adding one to store a dozen strings would be the wrong trade. It also
+// means the list is per-browser, which is worth saying out loud on the page.
+//
+// Watched items are stored without a network. An address is the same key on
+// every chain and a realm path can exist on several, so the watchlist follows
+// whatever network is selected — watch gno.land/r/demo/boards once and see it on
+// whichever chain you are looking at.
+const WATCH_KEY = 'mygnoscan-watch';
+
+// What the page currently being viewed would watch, for the `w` shortcut.
+let _watchTarget = null;
+
+function loadWatch() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(WATCH_KEY) || '{}');
+    return { realms: raw.realms || {}, addresses: raw.addresses || {} };
+  } catch (_) {
+    return { realms: {}, addresses: {} };
+  }
+}
+function saveWatch(w) {
+  try { localStorage.setItem(WATCH_KEY, JSON.stringify(w)); } catch (_) {}
+}
+function isWatched(kind, id) { return loadWatch()[kind][id] !== undefined; }
+function watchCount() {
+  const w = loadWatch();
+  return Object.keys(w.realms).length + Object.keys(w.addresses).length;
+}
+// seen is the block height the reader has acknowledged, recorded when the item
+// is first watched so there is always a baseline. Zero means no baseline — the
+// server then reports nothing as new, because "everything that ever happened"
+// is not a useful answer to "what changed since I last looked".
+function toggleWatch(kind, id, seen) {
+  const w = loadWatch();
+  if (w[kind][id] !== undefined) delete w[kind][id];
+  else w[kind][id] = { seen: seen || 0 };
+  saveWatch(w);
+  renderWatchBadge();
+  return w[kind][id] !== undefined;
+}
+function markWatchSeen(kind, id, height) {
+  const w = loadWatch();
+  if (w[kind][id] === undefined) return;
+  w[kind][id].seen = height || 0;
+  saveWatch(w);
+  renderWatchBadge();
+}
+
+// watchButton is the star. Deliberately a button rather than an icon-only
+// affordance: this is the only piece of state the app keeps for you, so it
+// should be obvious what it does.
+function watchButton(kind, id, currentHeight) {
+  const btn = el('button', { className: 'watch-btn' });
+  const paint = () => {
+    const on = isWatched(kind, id);
+    btn.textContent = on ? '\u2605 watching' : '\u2606 watch';
+    btn.classList.toggle('on', on);
+    btn.title = on ? 'stop watching' : 'add to your watchlist';
+  };
+  btn.addEventListener('click', ev => {
+    ev.stopPropagation();
+    toggleWatch(kind, id, currentHeight);
+    paint();
+  });
+  paint();
+  return btn;
+}
+
+function renderWatchBadge() {
+  const link = document.getElementById('nav-watch');
+  if (!link) return;
+  const n = watchCount();
+  link.textContent = n ? 'watch (' + n + ')' : 'watch';
+}
+
+async function loadWatchlist() {
+  const container = clear('watch-content');
+  const w = loadWatch();
+  const realms = Object.entries(w.realms);
+  const addresses = Object.entries(w.addresses);
+
+  if (!realms.length && !addresses.length) {
+    container.appendChild(el('div', { className: 'section-title' }, 'watchlist'));
+    container.appendChild(el('div', { className: 'section-sub' },
+      'Nothing watched yet. Open any realm or address and press \u2606 watch, or press w while viewing one. ' +
+      'Your list is stored in this browser only \u2014 there is no account and nothing is sent anywhere.'));
+    return;
+  }
+
+  skeletonBlock(container);
+  const params = [
+    ...realms.map(([id, v]) => 'realm=' + encodeURIComponent(id + '@' + (v.seen || 0))),
+    ...addresses.map(([id, v]) => 'address=' + encodeURIComponent(id + '@' + (v.seen || 0))),
+  ];
+
+  try {
+    const data = await api('watch?' + params.join('&'));
+    container.textContent = '';
+
+    const totalNew = [...(data.realms || []), ...(data.addresses || [])]
+      .reduce((n, r) => n + (r.new_since || 0), 0);
+
+    const head = el('div', { className: 'section-title' }, 'watchlist');
+    container.appendChild(head);
+    container.appendChild(el('div', { className: 'section-sub' },
+      totalNew
+        ? totalNew + ' new event' + (totalNew === 1 ? '' : 's') + ' since you last reviewed these.'
+        : 'Nothing new since you last reviewed these.'));
+
+    if ((data.realms || []).length) {
+      container.appendChild(el('div', { className: 'section-title' }, 'realms'));
+      const tbl = el('table');
+      tbl.appendChild(el('thead', {}, el('tr', {},
+        el('th', {}, 'realm'), el('th', {}, 'new'), el('th', {}, 'calls 24h'),
+        el('th', {}, 'calls'), el('th', {}, 'used by'), el('th', {}, 'last'), el('th', {}, ''))));
+      const body = el('tbody');
+      for (const r of data.realms) {
+        body.appendChild(watchRow('realms', r.path, r, [
+          el('td', {}, r.exists ? realmPathEl(r.path, r.network) : notOnChain(r.path)),
+          el('td', {}, newBadge(r.new_since)),
+          el('td', {}, fmtNum(r.calls_24h)),
+          el('td', {}, fmtNum(r.calls)),
+          el('td', {}, fmtNum(r.importers)),
+          el('td', {}, r.last_time ? timeEl(r.last_time) : '-'),
+        ]));
+      }
+      tbl.appendChild(body);
+      container.appendChild(tbl);
+    }
+
+    if ((data.addresses || []).length) {
+      container.appendChild(el('div', { className: 'section-title' }, 'addresses'));
+      const tbl = el('table');
+      tbl.appendChild(el('thead', {}, el('tr', {},
+        el('th', {}, 'address'), el('th', {}, 'new'), el('th', {}, 'calls 24h'),
+        el('th', {}, 'calls'), el('th', {}, 'deploys'), el('th', {}, 'sends'),
+        el('th', {}, 'last'), el('th', {}, ''))));
+      const body = el('tbody');
+      for (const a of data.addresses) {
+        body.appendChild(watchRow('addresses', a.address, a, [
+          el('td', {}, addrLink(a.address, a.network)),
+          el('td', {}, newBadge(a.new_since)),
+          el('td', {}, fmtNum(a.calls_24h)),
+          el('td', {}, fmtNum(a.calls)),
+          el('td', {}, fmtNum(a.deploys)),
+          el('td', {}, fmtNum(a.sends)),
+          el('td', {}, a.last_time ? timeEl(a.last_time) : '-'),
+        ]));
+      }
+      tbl.appendChild(body);
+      container.appendChild(tbl);
+    }
+
+    if (totalNew) {
+      const done = el('button', { className: 'watch-btn on', style: { marginTop: '14px' } }, 'mark all reviewed');
+      done.addEventListener('click', () => {
+        for (const r of (data.realms || [])) markWatchSeen('realms', r.path, r.last_height);
+        for (const a of (data.addresses || [])) markWatchSeen('addresses', a.address, a.last_height);
+        loadWatchlist();
+      });
+      container.appendChild(done);
+    }
+  } catch (err) {
+    failBlock(container, err, loadWatchlist);
+  }
+}
+
+// notOnChain renders a watched path that the selected network has never seen.
+// Silently showing zeros would read as "this realm is idle" rather than "this
+// realm does not exist here".
+function notOnChain(path) {
+  const span = el('span');
+  span.append(path.replace('gno.land/', ''));
+  span.appendChild(el('span', { className: 'block-ctx' }, ' not on this network'));
+  return span;
+}
+
+function newBadge(n) {
+  if (!n) return el('span', { style: { color: 'var(--fg2)' } }, '-');
+  return el('span', { className: 'watch-new' }, '+' + fmtNum(n));
+}
+
+function watchRow(kind, id, item, cells) {
+  const stop = el('td');
+  const btn = el('button', { className: 'watch-btn' }, '\u2715');
+  btn.title = 'remove from watchlist';
+  btn.addEventListener('click', () => { toggleWatch(kind, id); loadWatchlist(); });
+  stop.appendChild(btn);
+  return el('tr', {}, ...cells, stop);
+}
+
 // --- Load failures -------------------------------------------------------
 //
 // A failed load used to log to the console and leave the skeleton shimmering
@@ -1117,6 +1331,10 @@ function navigate(path, replace) {
 }
 
 function route() {
+  _watchTarget = null;
+  // The badge counts localStorage, which another tab can change under us.
+  // Repainting per navigation keeps it honest without polling.
+  renderWatchBadge();
   const path = window.location.pathname;
   document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
   document.querySelectorAll('nav a').forEach(a => a.classList.remove('active'));
@@ -1141,6 +1359,7 @@ function route() {
   else if (path === '/gas') { view = 'gas'; }
   else if (path === '/analytics') { view = 'analytics'; }
   else if (path === '/sanity') { view = 'sanity'; }
+  else if (path === '/watch') { view = 'watch'; }
   else if (path.startsWith('/block/')) { view = 'block-detail'; data = parseInt(path.slice(7)); }
   else if (path.startsWith('/realm/')) { view = 'realm-detail'; data = 'gno.land/' + path.slice(7); }
   else if (path.startsWith('/tx/')) { view = 'tx-detail'; data = decodeURIComponent(path.slice(4)); }
@@ -1164,6 +1383,7 @@ function route() {
 
   switch (view) {
     case 'home': loadHome(); break;
+    case 'watch': loadWatchlist(); break;
     case 'realms': loadRealms(); break;
     case 'packages': loadPackages(); break;
     case 'txs': loadTxs(); break;
@@ -2982,7 +3202,13 @@ async function loadRealmDetail(path, initialTab) {
     meta.append(' deployed by ');
     meta.appendChild(addrLink(detail.creator));
     meta.append(' at ' + blockLabel(detail.block_height) + ' \u00b7 ' + detail.num_files + ' files \u00b7 ' + detail.call_count + ' calls');
+    meta.append(' ');
+    // Baseline is the realm's most recent call, not its deploy height. Watching
+    // a busy realm should not immediately report its entire history as new.
+    const latestCall = (detail.recent_calls || [])[0]?.block_height || detail.block_height;
+    meta.appendChild(watchButton('realms', detail.path, latestCall));
     header.appendChild(meta);
+    _watchTarget = { kind: 'realms', id: detail.path, height: latestCall };
     const tabs = clear('realm-tabs');
     const tabNames = ['info', 'source', 'calls', 'events', 'storage', 'deps', 'graph'];
     const activeTab = initialTab && tabNames.includes(initialTab) ? initialTab : 'info';
@@ -3411,9 +3637,19 @@ async function loadAddressDetail(addr) {
     container.textContent = '';
     // Header
     container.appendChild(el('h2', { style: { margin: '16px 0 8px' } }, 'Address'));
-    const label = KNOWN_ADDRS[addr];
-    if (label) container.appendChild(el('div', { style: { color: 'var(--accent)', marginBottom: '4px', fontSize: '16px' } }, label));
-    container.appendChild(el('div', { style: { color: 'var(--fg2)', marginBottom: '16px', wordBreak: 'break-all' } }, addr));
+    const info = addrInfo(addr);
+    if (info) {
+      const labelRow = el('div', { style: { color: 'var(--accent)', marginBottom: '4px', fontSize: '16px' } }, info.label);
+      if (info.why) { labelRow.title = info.why; }
+      if (info.inferred) labelRow.append(' (inferred)');
+      container.appendChild(labelRow);
+    }
+    const addrRow = el('div', { style: { color: 'var(--fg2)', marginBottom: '16px', wordBreak: 'break-all' } });
+    addrRow.append(addr + ' ');
+    const lastHeight = (data.transactions || [])[0]?.block_height || 0;
+    addrRow.appendChild(watchButton('addresses', addr, lastHeight));
+    container.appendChild(addrRow);
+    _watchTarget = { kind: 'addresses', id: addr, height: lastHeight };
     // Stats bar
     const txs = data.transactions || [];
     const pkgs = data.packages || [];
@@ -4008,6 +4244,115 @@ document.getElementById('search-input').addEventListener('input', function() {
 });
 document.addEventListener('click', (e) => { if (!e.target.closest('.search-box')) document.getElementById('search-results').classList.remove('open'); });
 
+
+// --- Keyboard ---------------------------------------------------------------
+//
+// This is a terminal-shaped tool used by people who live in terminals, and the
+// difference between "I look things up here" and "I keep this open" is largely
+// how fast it is to move around without reaching for the mouse.
+//
+// Deliberately conventional: `/` focuses search, `g` then a letter goes
+// somewhere, `?` lists them, `w` watches whatever is on screen. Nothing fires
+// while typing in a field, and nothing shadows a browser shortcut.
+const KEY_ROUTES = {
+  h: ['/', 'home'],
+  w: ['/watch', 'watchlist'],
+  r: ['/realms', 'realms'],
+  p: ['/packages', 'packages'],
+  t: ['/txs', 'transactions'],
+  b: ['/blocks', 'blocks'],
+  a: ['/accounts', 'accounts'],
+  e: ['/events', 'events'],
+  g: ['/gas', 'gas'],
+  n: ['/analytics', 'analytics'],
+  s: ['/sanity', 'sanity'],
+};
+
+let _awaitingGoto = false;
+let _gotoTimer = null;
+
+function isTyping(target) {
+  const tag = (target?.tagName || '').toLowerCase();
+  return tag === 'input' || tag === 'textarea' || tag === 'select' || target?.isContentEditable;
+}
+
+function showShortcuts() {
+  const existing = document.getElementById('shortcut-overlay');
+  if (existing) { existing.remove(); return; }
+
+  const overlay = el('div', { id: 'shortcut-overlay', className: 'shortcut-overlay' });
+  const card = el('div', { className: 'shortcut-card' });
+  card.appendChild(el('div', { className: 'section-title' }, 'keyboard'));
+
+  const rows = [
+    ['/', 'focus search'],
+    ['g then h/r/p/t/b/a/e/g/n/s', 'go to a page'],
+    ['g then w', 'go to your watchlist'],
+    ['w', 'watch or unwatch what you are viewing'],
+    ['?', 'this list'],
+    ['esc', 'close this / leave the search box'],
+  ];
+  for (const [keys, what] of rows) {
+    const row = el('div', { className: 'shortcut-row' });
+    row.appendChild(el('kbd', {}, keys));
+    row.appendChild(el('span', {}, what));
+    card.appendChild(row);
+  }
+  overlay.appendChild(card);
+  overlay.addEventListener('click', ev => { if (ev.target === overlay) overlay.remove(); });
+  document.body.appendChild(overlay);
+}
+
+document.addEventListener('keydown', ev => {
+  if (ev.metaKey || ev.ctrlKey || ev.altKey) return;
+
+  if (ev.key === 'Escape') {
+    document.getElementById('shortcut-overlay')?.remove();
+    document.getElementById('search-results')?.classList.remove('open');
+    if (isTyping(ev.target)) ev.target.blur();
+    return;
+  }
+  if (isTyping(ev.target)) return;
+
+  if (_awaitingGoto) {
+    _awaitingGoto = false;
+    clearTimeout(_gotoTimer);
+    const dest = KEY_ROUTES[ev.key];
+    if (dest) { ev.preventDefault(); navigate(dest[0] + netSuffix(getNetwork())); }
+    return;
+  }
+
+  switch (ev.key) {
+    case '/':
+      ev.preventDefault();
+      document.getElementById('search-input')?.focus();
+      break;
+    case '?':
+      ev.preventDefault();
+      showShortcuts();
+      break;
+    case 'g':
+      // Wait for the second key, but not forever: a stray g should not swallow
+      // the next thing typed minutes later.
+      _awaitingGoto = true;
+      _gotoTimer = setTimeout(() => { _awaitingGoto = false; }, 1500);
+      break;
+    case 'w':
+      if (!_watchTarget) return;
+      ev.preventDefault();
+      toggleWatch(_watchTarget.kind, _watchTarget.id, _watchTarget.height);
+      // Repaint whatever star is on screen rather than reloading the view.
+      document.querySelectorAll('.watch-btn').forEach(b => {
+        if (b.textContent.includes('watch')) {
+          const on = isWatched(_watchTarget.kind, _watchTarget.id);
+          b.textContent = on ? '\u2605 watching' : '\u2606 watch';
+          b.classList.toggle('on', on);
+        }
+      });
+      break;
+  }
+});
+
 // --- Highlight on hover (addresses, tx hashes, event types, etc) ---
 document.addEventListener('mouseover', (e) => {
   const val = e.target.closest('[data-hl]')?.getAttribute('data-hl');
@@ -4032,6 +4377,7 @@ document.querySelectorAll('.stat-link').forEach(tile => {
 // Labels first: they change how every address renders, and arriving after the
 // first paint would show raw addresses that then silently rewrite themselves.
 loadAddrLabels().then(() => { initNetworkSelector(); });
+renderWatchBadge();
 
 // --- Footer version ---
 api('version').then(v => {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -619,3 +619,98 @@ func TestAccountsPagingAndSort(t *testing.T) {
 		}
 	})
 }
+
+// The watchlist digest: counts for the things a reader follows, plus how much
+// has happened since they last reviewed each one.
+//
+// Answered entirely from stored rows. A watchlist is checked often and covers
+// things the reader already cares about, so it must not cost an indexer
+// round-trip per item.
+func TestWatchEndpoint(t *testing.T) {
+	api, db := newTestAPI(t)
+
+	const when = "2026-08-01T00:00:00Z"
+	const realm = "gno.land/r/demo/boards"
+	if err := db.UpsertPackage("alpha", realm, "boards", "g1creator", "deploy", 100, when, true, 1); err != nil {
+		t.Fatalf("UpsertPackage: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if err := db.InsertCall("alpha", fmt.Sprintf("c%d", i), 200+i, when, "g1watched", realm, "Post", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+
+	get := func(t *testing.T, target string) map[string]any {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest("GET", target, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		var out map[string]any
+		mustJSON(t, rec.Body.Bytes(), &out)
+		return out
+	}
+
+	t.Run("a realm reports its activity", func(t *testing.T) {
+		out := get(t, "/api/watch?realm="+realm)
+		realms, _ := out["realms"].([]any)
+		if len(realms) != 1 {
+			t.Fatalf("got %d realms, want 1", len(realms))
+		}
+		r := realms[0].(map[string]any)
+		if r["calls"].(float64) != 10 {
+			t.Errorf("calls = %v, want 10", r["calls"])
+		}
+		if r["exists"] != true {
+			t.Error("a deployed realm reported as not existing")
+		}
+	})
+
+	t.Run("new_since counts only activity above the acknowledged height", func(t *testing.T) {
+		out := get(t, "/api/watch?realm="+realm+"@205")
+		r := out["realms"].([]any)[0].(map[string]any)
+		// Calls sit at heights 200..209, so four are above 205.
+		if r["new_since"].(float64) != 4 {
+			t.Errorf("new_since = %v, want 4", r["new_since"])
+		}
+	})
+
+	t.Run("an acknowledged height at the tip reports nothing new", func(t *testing.T) {
+		out := get(t, "/api/watch?realm="+realm+"@209")
+		r := out["realms"].([]any)[0].(map[string]any)
+		if r["new_since"].(float64) != 0 {
+			t.Errorf("new_since = %v, want 0", r["new_since"])
+		}
+	})
+
+	t.Run("a watched path absent from this chain is reported, not hidden", func(t *testing.T) {
+		// Showing zeros silently would read as "idle" rather than "not here".
+		out := get(t, "/api/watch?realm=gno.land/r/demo/nothing")
+		r := out["realms"].([]any)[0].(map[string]any)
+		if r["exists"] != false {
+			t.Error("an unknown realm reported as existing")
+		}
+	})
+
+	t.Run("an address reports across every table it appears in", func(t *testing.T) {
+		out := get(t, "/api/watch?address=g1watched")
+		addrs, _ := out["addresses"].([]any)
+		if len(addrs) != 1 {
+			t.Fatalf("got %d addresses, want 1", len(addrs))
+		}
+		if addrs[0].(map[string]any)["calls"].(float64) != 10 {
+			t.Errorf("calls = %v, want 10", addrs[0].(map[string]any)["calls"])
+		}
+	})
+
+	t.Run("an empty watchlist is an empty digest, not an error", func(t *testing.T) {
+		out := get(t, "/api/watch")
+		if out["realms"] == nil || out["addresses"] == nil {
+			t.Errorf("missing keys on an empty watchlist: %v", out)
+		}
+	})
+}


### PR DESCRIPTION
Two features aimed at the same gap: **this tool has nothing to come back to.**

Before this, the only state it kept for you was which network you picked. You look something up, you leave. That is a reference, not something you open in the morning.

## Watchlist with a digest

Star any realm or address, then `/watch` answers *what happened since I last looked*:

```
342 new events since you last reviewed these.

REALMS
/r/gnoswap/router          +335   28 576 calls 24h   153 938 calls   25 used by   2h ago
r/demo/nothing-here                not on this network

ADDRESSES
@test_token_faucet?  g1ve35g5…   +7   15 966 calls 24h   497 762 calls   2h ago
```

**"New" is counted against a block height, not a timestamp.** Height is exact and monotonic per chain; comparing wall-clock against block time drifts. The baseline is recorded when you first watch something, so a busy realm does not immediately report its entire history as new — and "mark all reviewed" advances every baseline to what you just saw.

A watched path that does not exist on the selected network says so. Showing zeros would read as "this realm is idle" rather than "this realm is not here" — the same class of quietly-wrong display this project has spent a while removing.

Stored in `localStorage`, not behind an account. There is no user system and adding one to hold a dozen strings would be the wrong trade. The empty state says so plainly: stored in this browser, nothing sent anywhere.

Items are stored **without a network**, so the list follows whichever chain you are viewing — watch `gno.land/r/demo/boards` once and see it wherever it exists.

`GET /api/watch` answers entirely from stored rows. A watchlist is checked often and by definition covers things you already care about, so it must not cost an indexer round-trip per item.

## Keyboard navigation

This is a terminal-shaped tool for people who live in terminals, and the gap between "I look things up here" and "I keep this open" is largely how fast it is without a mouse.

```
/                      focus search
g then h/r/p/t/b/…     go to a page
w                      watch or unwatch what you are viewing
?                      this list
esc                    close / leave the search box
```

Nothing fires while typing in a field, nothing shadows a browser shortcut, and a stray `g` times out after 1.5s rather than swallowing the next keystroke. Verified: `w` inside the search box does nothing.

## Three bugs caught while verifying

**The nav link never appeared.** My insertion assumed `href`/`data-view`; the nav actually uses `onclick` + `id="nav-<view>"`. The replacement silently matched nothing — I had asserted on my other edits but not that one. Both the nav edit and the watch-target edit now assert.

**The realm baseline used the deploy height**, so watching `r/gnoswap/router` would have reported 153,938 events as "new". It now uses the realm's most recent call.

**The nav badge only repainted on toggle**, so it read `watch (1)` with three items watched. It repaints per navigation, which also keeps it right when another tab changes the list.

## Also

`new_since` is 0 when no baseline was supplied. Reporting an entire history as "new" is technically defensible and useless. My first version of the frontend comment claimed the opposite of what the server did; they agree now.
