### PR TITLE
perf: page and filter transactions on the server

### DIFF
--- a/api.go
+++ b/api.go
@@ -555,8 +555,39 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 	}
 	need := offset + windowed
 
+	// A type filter is served from storage, not the indexer.
+	//
+	// The indexer has no index for message type, so asking it for deploys walks
+	// the chain until it finds enough — 12s for a 50-row page on sapphire,
+	// against 0.5s unfiltered. The syncer already writes one row per message
+	// into a per-type table indexed by (network, block_height), which answers
+	// the same question with a real offset.
+	//
+	// A status filter alone still goes to the indexer: `success` is a column on
+	// every transaction there, so it costs nothing extra.
+	msgType := r.URL.Query().Get("type")
+	if _, known := txSources[msgType]; known {
+		var success *bool
+		switch r.URL.Query().Get("success") {
+		case "true":
+			t := true
+			success = &t
+		case "false":
+			f := false
+			success = &f
+		}
+		rows, total, err := a.db.FilteredTransactions(network, msgType, success, windowed, offset)
+		if err != nil {
+			jsonError(w, err.Error(), 500)
+			return
+		}
+		jsonResponse(w, map[string]any{"items": rows, "total": total, "from_storage": true})
+		return
+	}
+
+	success := r.URL.Query().Get("success")
 	fetch := func(ctx context.Context, c *IndexerClient) ([]Transaction, error) {
-		return c.GetRecentTransactionsPage(ctx, need)
+		return c.GetRecentTransactionsFiltered(ctx, need, "", success)
 	}
 
 	if network != "" {

--- a/db.go
+++ b/db.go
@@ -3100,3 +3100,104 @@ func (d *DB) WatchAddresses(network string, items []WatchRequest) ([]WatchedAddr
 	}
 	return out, nil
 }
+
+// --- Filtered transaction listing ------------------------------------------
+
+// StoredTx is one transaction as the list view needs it: enough to render a row
+// without asking the indexer.
+type StoredTx struct {
+	Network     string `json:"network"`
+	Hash        string `json:"hash"`
+	BlockHeight int    `json:"block_height"`
+	BlockTime   string `json:"block_time,omitempty"`
+	Type        string `json:"type"`
+	Detail      string `json:"detail,omitempty"`
+	Caller      string `json:"caller,omitempty"`
+	Success     bool   `json:"success"`
+}
+
+// txSource maps a message type to the table that records it, and to the columns
+// that describe one of its rows.
+//
+// `success` is the awkward one. Three of these tables carry it; `packages` does
+// not — it is keyed by (network, path) and holds the current state of a package
+// rather than one row per deploy, so there is no per-attempt outcome to store.
+// For that table the flag comes from the transaction row instead.
+type txSource struct {
+	table   string
+	caller  string
+	detail  string
+	success string
+}
+
+var txSources = map[string]txSource{
+	"MsgCall":       {table: "calls", caller: "caller", detail: "pkg_path || '::' || func_name", success: "e.success"},
+	"MsgAddPackage": {table: "packages", caller: "creator", detail: "path", success: "COALESCE(t.success, 1)"},
+	"MsgRun":        {table: "msg_runs", caller: "caller", detail: "''", success: "e.success"},
+	"BankMsgSend":   {table: "bank_sends", caller: "from_address", detail: "to_address || ' ' || amount", success: "e.success"},
+}
+
+// FilteredTransactions lists transactions of one message type from storage.
+//
+// Filtering this at the indexer does not work. It has no index for message type,
+// so a query for deploys walks the chain until it finds enough — and deploys are
+// rare next to calls. Measured on sapphire: a 50-row page of MsgAddPackage took
+// 12 seconds and exceeded the client deadline, while the same page unfiltered
+// took 0.5s.
+//
+// The syncer already writes one row per message into a per-type table, each
+// indexed by (network, block_height). That is exactly this query, and it pages
+// properly: a real offset over an ordered index rather than a window that has to
+// be re-walked to reach page two.
+func (d *DB) FilteredTransactions(network, msgType string, success *bool, limit, offset int) ([]StoredTx, int, error) {
+	src, ok := txSources[msgType]
+	if !ok {
+		return nil, 0, fmt.Errorf("unknown message type: %s", msgType)
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	// packages needs the transaction row for its success flag; the others carry
+	// their own. LEFT JOIN so a package whose transaction has not been backfilled
+	// still lists, defaulting to success rather than vanishing.
+	join := ""
+	if src.success != "e.success" {
+		join = " LEFT JOIN transactions t ON t.network = e.network AND t.tx_hash = e.tx_hash"
+	}
+
+	where := " WHERE " + d.networkFilter("e.network", network)
+	if success != nil {
+		if *success {
+			where += " AND " + src.success + " = 1"
+		} else {
+			where += " AND " + src.success + " = 0"
+		}
+	}
+
+	var total int
+	if err := d.db.QueryRow(`SELECT COUNT(*) FROM ` + src.table + ` e` + join + where).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := d.db.Query(`
+		SELECT e.network, e.tx_hash, e.block_height, COALESCE(e.block_time, ''),
+		       COALESCE(e.`+src.caller+`, ''), `+src.detail+`, `+src.success+`
+		FROM `+src.table+` e`+join+where+`
+		ORDER BY e.block_height DESC, e.tx_hash ASC
+		LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	out := []StoredTx{}
+	for rows.Next() {
+		t := StoredTx{Type: msgType}
+		if err := rows.Scan(&t.Network, &t.Hash, &t.BlockHeight, &t.BlockTime,
+			&t.Caller, &t.Detail, &t.Success); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, t)
+	}
+	return out, total, rows.Err()
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -97,7 +97,7 @@ fact.
 
 | endpoint | description |
 |---|---|
-| `GET /api/txs` | **recent** transactions, from the indexer. `limit` defaults to 500 and is capped at 2000; `offset` pages within that window |
+| `GET /api/txs` | recent transactions. `limit` (default 500, max 2000), `offset`, `type` = `MsgCall`/`MsgAddPackage`/`MsgRun`/`BankMsgSend`, `success` = `true`/`false`. A `type` filter is served **from local storage** and pages properly with a real total; without one the rows come from the indexer and `total` is the fetched window. `from_storage` says which |
 | `GET /api/tx/{hash}` | one transaction: messages, events, errors |
 | `GET /api/blocks` | recent blocks. `limit` |
 | `GET /api/block/{height}` | one block and its transactions. **Requires `network`**: a height alone does not identify a block across chains |

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1979,86 +1979,95 @@ let _txsFilterType = null; // null = all
 let _txsFilterStatus = null; // null = all, true = ok, false = fail
 let _txsPage = 0;
 
-async function loadTxs() {
+// The transactions page pages on the server.
+//
+// It used to fetch a 500-row window and slice it locally, which cost 3.6s on a
+// busy chain to show 50 rows, and made the filter bar describe that window
+// rather than the network — "3 deploys" meant "3 among the last 500", which is
+// worse than slow because it is wrong.
+//
+// Now: one page at a time from the indexer, filters applied there too, and the
+// headline counts taken from /api/stats, which knows the whole chain and is
+// cheap because it reads stored rows.
+//
+// Uses the shared PAGE_SIZE, which pager() also divides by. Two constants that
+// have to agree is a defect waiting for one of them to change.
+async function loadTxs(page) {
+  _txsPage = page || 0;
   const tbody = clear('txs-list');
   skeletonRows(tbody, 5, 10);
   const statsBar = document.getElementById('txs-stats');
   const filterBar = document.getElementById('txs-filter');
-  statsBar.style.display = 'none';
-  filterBar.style.display = 'none';
+
+  // Arriving from a home stat tile pre-selects that message type.
+  if (_pendingTxType) { _txsFilterType = _pendingTxType; _pendingTxType = null; _txsPage = 0; }
+
   try {
-    // A bounded recent window, not the whole chain. Asking for everything used
-    // to fail outright on a busy network, and the counts below have always been
-    // over whatever came back rather than over all history.
-    const data = await api('txs?limit=' + TXS_WINDOW);
+    const q = ['limit=' + PAGE_SIZE, 'offset=' + (_txsPage * PAGE_SIZE)];
+    if (_txsFilterType) q.push('type=' + encodeURIComponent(_txsFilterType));
+    if (_txsFilterStatus !== null) q.push('success=' + (_txsFilterStatus ? 'true' : 'false'));
+
+    const [data, stats] = await Promise.all([api('txs?' + q.join('&')), api('stats')]);
     _txsCache = data.items || [];
-    _txsPage = 0;
-    // Arriving from a home stat tile pre-selects that message type.
-    _txsFilterType = _pendingTxType;
-    _pendingTxType = null;
-    _txsFilterStatus = null;
 
-    // Compute type counts
-    const typeCounts = {};
-    let okCount = 0, failCount = 0;
-    for (const tx of _txsCache) {
-      const t = tx.messages?.[0]?.value?.__typename || 'unknown';
-      typeCounts[t] = (typeCounts[t] || 0) + 1;
-      if (tx.success) okCount++; else failCount++;
-    }
-
-    // Stats
-    statsBar.textContent = ''; statsBar.style.display = 'flex';
-    // Labelled "recent" because it is: the window above, not an all-time count.
-    statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'recent'), el('span', { className: 'value' }, fmtNum(_txsCache.length))));
-    statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'success'), el('span', { className: 'value' }, fmtNum(okCount))));
-    statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'failed'), el('span', { className: 'value' }, fmtNum(failCount))));
-    for (const [t, c] of Object.entries(typeCounts).sort((a, b) => b[1] - a[1])) {
-      const shortName = t.replace('Msg', '').replace('BankMsgSend', 'send');
-      statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, shortName), el('span', { className: 'value' }, fmtNum(c))));
-    }
-
-    // Filter bar
-    filterBar.textContent = ''; filterBar.style.display = 'flex';
-    filterBar.style.gap = '8px'; filterBar.style.flexWrap = 'wrap';
-    filterBar.style.alignItems = 'center'; filterBar.style.padding = '8px 0';
-
-    // Type filter
-    filterBar.appendChild(el('span', { style: { color: 'var(--fg2)', fontSize: '12px' } }, 'type:'));
-    const allTypeBtn = el('button', { className: 'pager-btn', style: { padding: '3px 10px', fontSize: '12px' } }, 'all');
-    allTypeBtn.style.borderColor = 'var(--accent)'; allTypeBtn.style.color = 'var(--accent)';
-    allTypeBtn.addEventListener('click', () => { _txsFilterType = null; _txsPage = 0; renderTxRows(); highlightBtn('txs-type-btns', allTypeBtn); });
-    allTypeBtn.setAttribute('data-group', 'txs-type-btns');
-    filterBar.appendChild(allTypeBtn);
-    for (const t of Object.keys(typeCounts).sort()) {
-      const shortName = t.replace('Msg', '').replace('BankMsgSend', 'send');
-      const btn = el('button', { className: 'pager-btn', style: { padding: '3px 10px', fontSize: '12px' } }, shortName);
-      btn.setAttribute('data-group', 'txs-type-btns');
-      btn.addEventListener('click', () => { _txsFilterType = t; _txsPage = 0; renderTxRows(); highlightBtn('txs-type-btns', btn); });
-      filterBar.appendChild(btn);
-    }
-
-    // Status filter
-    filterBar.appendChild(el('span', { style: { color: 'var(--fg2)', fontSize: '12px', marginLeft: '12px', borderLeft: '1px solid var(--border)', paddingLeft: '12px' } }, 'status:'));
-    const statusAll = el('button', { className: 'pager-btn', style: { padding: '3px 10px', fontSize: '12px' } }, 'all');
-    statusAll.style.borderColor = 'var(--accent)'; statusAll.style.color = 'var(--accent)';
-    statusAll.setAttribute('data-group', 'txs-status-btns');
-    statusAll.addEventListener('click', () => { _txsFilterStatus = null; _txsPage = 0; renderTxRows(); highlightBtn('txs-status-btns', statusAll); });
-    filterBar.appendChild(statusAll);
-    const statusOk = el('button', { className: 'pager-btn', style: { padding: '3px 10px', fontSize: '12px' } }, 'ok');
-    statusOk.setAttribute('data-group', 'txs-status-btns');
-    statusOk.addEventListener('click', () => { _txsFilterStatus = true; _txsPage = 0; renderTxRows(); highlightBtn('txs-status-btns', statusOk); });
-    filterBar.appendChild(statusOk);
-    const statusFail = el('button', { className: 'pager-btn', style: { padding: '3px 10px', fontSize: '12px' } }, 'fail');
-    statusFail.setAttribute('data-group', 'txs-status-btns');
-    statusFail.addEventListener('click', () => { _txsFilterStatus = false; _txsPage = 0; renderTxRows(); highlightBtn('txs-status-btns', statusFail); });
-    filterBar.appendChild(statusFail);
-
-    renderTxRows();
+    renderTxStats(statsBar, stats);
+    renderTxFilters(filterBar);
+    renderTxRows(data);
   } catch (err) {
     console.error(err);
-    failRows(clear('txs-list'), 5, err, loadTxs);
+    statsBar.style.display = 'none';
+    filterBar.style.display = 'none';
+    failRows(clear('txs-list'), 5, err, () => loadTxs(_txsPage));
   }
+}
+
+// Counts come from /api/stats, which covers the whole chain. The previous
+// version counted whatever had loaded and labelled it "recent" to stay honest;
+// with real totals available there is no reason to settle for that.
+function renderTxStats(statsBar, stats) {
+  statsBar.textContent = '';
+  statsBar.style.display = 'flex';
+  const cell = (label, value) => statsBar.appendChild(el('div', { className: 'stat' },
+    el('span', { className: 'label' }, label), el('span', { className: 'value' }, fmtNum(value || 0))));
+  cell('total', stats.total_txs);
+  cell('calls', stats.total_calls);
+  cell('deploys', stats.total_deploys);
+  cell('runs', stats.total_msg_runs);
+  cell('sends', stats.total_sends);
+}
+
+function renderTxFilters(filterBar) {
+  filterBar.textContent = '';
+  filterBar.style.display = 'flex';
+  filterBar.style.gap = '8px';
+  filterBar.style.flexWrap = 'wrap';
+  filterBar.style.alignItems = 'center';
+  filterBar.style.padding = '8px 0';
+
+  const button = (text, group, active, onPick) => {
+    const btn = el('button', { className: 'pager-btn', style: { padding: '3px 10px', fontSize: '12px' } }, text);
+    btn.setAttribute('data-group', group);
+    if (active) { btn.style.borderColor = 'var(--accent)'; btn.style.color = 'var(--accent)'; }
+    // Every filter change refetches: the server decides what matches, so the
+    // page cannot show a filtered view of stale rows.
+    btn.addEventListener('click', () => { onPick(); loadTxs(0); });
+    filterBar.appendChild(btn);
+    return btn;
+  };
+
+  filterBar.appendChild(el('span', { style: { color: 'var(--fg2)', fontSize: '12px' } }, 'type:'));
+  button('all', 'txs-type', _txsFilterType === null, () => { _txsFilterType = null; });
+  for (const [type, label] of [['MsgCall', 'call'], ['MsgAddPackage', 'deploy'],
+                               ['MsgRun', 'run'], ['BankMsgSend', 'send']]) {
+    button(label, 'txs-type', _txsFilterType === type, () => { _txsFilterType = type; });
+  }
+
+  filterBar.appendChild(el('span', {
+    style: { color: 'var(--fg2)', fontSize: '12px', marginLeft: '12px',
+             borderLeft: '1px solid var(--border)', paddingLeft: '12px' } }, 'status:'));
+  button('all', 'txs-status', _txsFilterStatus === null, () => { _txsFilterStatus = null; });
+  button('ok', 'txs-status', _txsFilterStatus === true, () => { _txsFilterStatus = true; });
+  button('fail', 'txs-status', _txsFilterStatus === false, () => { _txsFilterStatus = false; });
 }
 
 function highlightBtn(group, activeBtn) {
@@ -2066,31 +2075,77 @@ function highlightBtn(group, activeBtn) {
   activeBtn.style.borderColor = 'var(--accent)'; activeBtn.style.color = 'var(--accent)';
 }
 
-function renderTxRows() {
+
+// storedTxDetail renders the detail cell for a row that came from storage,
+// matching what txDetailEl produces for the same message from the indexer.
+function storedTxDetail(tx) {
+  const span = el('span');
+  switch (tx.type) {
+    case 'MsgCall': {
+      const [path, fn] = (tx.detail || '').split('::');
+      if (path) span.appendChild(realmPathEl(path, tx.network));
+      if (fn) span.append('::' + fn);
+      return span;
+    }
+    case 'MsgAddPackage':
+      if (tx.detail) span.appendChild(realmPathEl(tx.detail, tx.network));
+      return span;
+    case 'MsgRun':
+      span.append('run by ');
+      span.appendChild(addrLink(tx.caller, tx.network));
+      return span;
+    case 'BankMsgSend': {
+      const [to, amount] = (tx.detail || '').split(' ');
+      span.appendChild(addrLink(tx.caller, tx.network));
+      span.append(' > ');
+      if (to) span.appendChild(addrLink(to, tx.network));
+      const pretty = fmtCoins(amount);
+      if (pretty) span.appendChild(el('span', { className: 'block-ctx' }, ' ' + pretty));
+      return span;
+    }
+  }
+  span.append(tx.detail || '');
+  return span;
+}
+
+// renderTxRows draws the page the server returned. No local filtering: the rows
+// that arrived are already the rows that match.
+function renderTxRows(data) {
   const section = document.querySelector('#view-txs .section');
   section.querySelectorAll('.pager').forEach(p => p.remove());
-  const filtered = (_txsCache || []).filter(tx => {
-    if (_txsFilterType && (tx.messages?.[0]?.value?.__typename || 'unknown') !== _txsFilterType) return false;
-    if (_txsFilterStatus !== null && tx.success !== _txsFilterStatus) return false;
-    return true;
-  });
-  const start = _txsPage * PAGE_SIZE;
-  const page = filtered.slice(start, start + PAGE_SIZE);
+
+  const rows = data.items || [];
   const list = clear('txs-list');
-  if (page.length === 0) {
-    list.appendChild(el('tr', {}, el('td', { colspan: '5', style: { color: 'var(--fg2)', textAlign: 'center', padding: '20px' } }, 'no transactions matching filter')));
+
+  if (!rows.length) {
+    const what = _txsFilterType || _txsFilterStatus !== null
+      ? 'no transactions match this filter in the recent window'
+      : 'no transactions';
+    list.appendChild(el('tr', {}, el('td', {
+      colspan: '5', style: { color: 'var(--fg2)', textAlign: 'center', padding: '20px' } }, what)));
   }
-  for (const tx of page) {
+
+  for (const tx of rows) {
+    // Two shapes reach here: indexer rows carry messages[], storage rows carry a
+    // flat type/detail. Rendering both keeps the filtered view — which must come
+    // from storage to be fast — looking identical to the unfiltered one.
     const msg = tx.messages?.[0];
+    const type = msg ? typeBadge(msg?.value?.__typename, msg) : typeBadge(tx.type);
+    const detail = msg ? txDetailEl(msg) : storedTxDetail(tx);
     list.appendChild(netRow(tx.network,
       el('td', {}, txLink(tx.hash, tx.block_height, tx.network)),
       el('td', {}, blockLink(tx.block_height, tx.network)),
-      el('td', {}, typeBadge(msg?.value?.__typename, msg)),
-      el('td', {}, txDetailEl(msg)),
+      el('td', {}, type),
+      el('td', {}, detail),
       el('td', {}, statusBadge(tx.success))
     ));
   }
-  pager(section, _txsPage, filtered.length, (p) => { _txsPage = p; renderTxRows(); });
+
+  // `total` is the size of the window the indexer searched, not the chain's
+  // transaction count — the indexer exposes no count and caps a result set, so
+  // there is nothing truthful to page against beyond it. The headline totals
+  // above come from stored rows and do cover the whole chain.
+  pager(section, _txsPage, data.total || rows.length, p => loadTxs(p));
 }
 
 let _blocksCache = null;

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -714,3 +714,110 @@ func TestWatchEndpoint(t *testing.T) {
 		}
 	})
 }
+
+// A type-filtered transaction list is served from storage, not the indexer.
+//
+// The indexer has no index for message type, so asking it for deploys walks the
+// chain until it finds enough — measured at 12s for a 50-row page on sapphire,
+// against 0.5s unfiltered, past the client deadline. The syncer already writes
+// one row per message into a per-type table, which answers the same question
+// with a real offset.
+func TestFilteredTransactionsFromStorage(t *testing.T) {
+	api, db := newTestAPI(t)
+
+	const when = "2026-08-01T00:00:00Z"
+	for i := 0; i < 30; i++ {
+		if err := db.InsertCall("alpha", fmt.Sprintf("call-%d", i), 1000+i, when,
+			"g1caller", "gno.land/r/demo/boards", "Post", i%5 != 0); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+	for i := 0; i < 7; i++ {
+		if err := db.UpsertPackage("alpha", fmt.Sprintf("gno.land/r/demo/pkg%d", i), "pkg",
+			"g1deployer", fmt.Sprintf("deploy-%d", i), 2000+i, when, true, 1); err != nil {
+			t.Fatalf("UpsertPackage: %v", err)
+		}
+	}
+	for i := 0; i < 12; i++ {
+		if err := db.InsertBankSend("alpha", fmt.Sprintf("send-%d", i), 3000+i, when,
+			"g1from", "g1to", "5ugnot", true); err != nil {
+			t.Fatalf("InsertBankSend: %v", err)
+		}
+	}
+
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+	page := func(t *testing.T, target string) (items []map[string]any, total int, fromStorage bool) {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest("GET", target, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		var out struct {
+			Items       []map[string]any `json:"items"`
+			Total       int              `json:"total"`
+			FromStorage bool             `json:"from_storage"`
+		}
+		mustJSON(t, rec.Body.Bytes(), &out)
+		return out.Items, out.Total, out.FromStorage
+	}
+
+	t.Run("deploys come from storage with a real total", func(t *testing.T) {
+		items, total, storage := page(t, "/api/txs?type=MsgAddPackage&limit=5&network=alpha")
+		if !storage {
+			t.Error("a type filter went to the indexer")
+		}
+		if total != 7 {
+			t.Errorf("total = %d, want 7 — the count must cover the chain, not the page", total)
+		}
+		if len(items) != 5 {
+			t.Errorf("got %d rows for limit=5", len(items))
+		}
+		for _, it := range items {
+			if it["type"] != "MsgAddPackage" {
+				t.Errorf("a %v leaked into a deploy-filtered page", it["type"])
+			}
+		}
+	})
+
+	t.Run("offset pages properly rather than re-slicing a window", func(t *testing.T) {
+		first, _, _ := page(t, "/api/txs?type=BankMsgSend&limit=5&network=alpha")
+		second, _, _ := page(t, "/api/txs?type=BankMsgSend&limit=5&offset=5&network=alpha")
+		if len(first) != 5 || len(second) != 5 {
+			t.Fatalf("page sizes = %d and %d", len(first), len(second))
+		}
+		for _, a := range first {
+			for _, b := range second {
+				if a["hash"] == b["hash"] {
+					t.Errorf("%v appears on both pages", a["hash"])
+				}
+			}
+		}
+	})
+
+	t.Run("the status filter narrows the total too", func(t *testing.T) {
+		_, all, _ := page(t, "/api/txs?type=MsgCall&limit=1&network=alpha")
+		_, failed, _ := page(t, "/api/txs?type=MsgCall&success=false&limit=1&network=alpha")
+		if all != 30 {
+			t.Errorf("unfiltered total = %d, want 30", all)
+		}
+		// Every fifth call was seeded as a failure.
+		if failed != 6 {
+			t.Errorf("failed total = %d, want 6", failed)
+		}
+	})
+
+	t.Run("deploys have a success flag despite the table lacking one", func(t *testing.T) {
+		// packages is keyed by path and holds current state, not per-deploy
+		// outcome, so the flag comes from the transaction row and defaults to
+		// success when that row has not been backfilled.
+		items, _, _ := page(t, "/api/txs?type=MsgAddPackage&limit=1&network=alpha")
+		if len(items) == 0 {
+			t.Fatal("no deploys")
+		}
+		if _, ok := items[0]["success"]; !ok {
+			t.Error("a deploy row carries no success flag")
+		}
+	})
+}

--- a/indexer.go
+++ b/indexer.go
@@ -565,7 +565,38 @@ const (
 // has ever had — 14MB and 4.5s on a modest testnet — because the indexer exposes
 // no limit or pagination argument. Bounding by height is the only lever there is.
 func (c *IndexerClient) GetRecentTransactionsPage(ctx context.Context, need int) ([]Transaction, error) {
-	return c.recentTransactionsWindowed(ctx, need, "", func() ([]Transaction, error) {
+	return c.GetRecentTransactionsFiltered(ctx, need, "", "")
+}
+
+// messageTypeFilter maps a message type name to its where-clause fragment.
+//
+// Filtering at the indexer rather than over a fetched page is what makes the
+// filter honest: a page-local filter describes the window it happens to have
+// loaded, not the chain, so "3 deploys" means "3 in the last 500 rows".
+func messageTypeFilter(msgType string) string {
+	switch msgType {
+	case "MsgCall", "MsgAddPackage", "MsgRun", "BankMsgSend":
+		return fmt.Sprintf("messages: { value: { %s: {} } }", msgType)
+	}
+	return ""
+}
+
+// GetRecentTransactionsFiltered fetches recent transactions, optionally narrowed
+// to one message type and/or success state.
+//
+// A narrowed query needs a wider height window to find the same number of rows —
+// deploys are rare next to calls — which the widening window already handles: it
+// keeps doubling until it has enough or reaches genesis.
+func (c *IndexerClient) GetRecentTransactionsFiltered(ctx context.Context, need int, msgType, success string) ([]Transaction, error) {
+	where := messageTypeFilter(msgType)
+	if success == "true" || success == "false" {
+		if where != "" {
+			where += " "
+		}
+		where += "success: { eq: " + success + " }"
+	}
+
+	return c.recentTransactionsWindowed(ctx, need, where, func() ([]Transaction, error) {
 		return c.GetRecentTransactions(ctx, 0)
 	})
 }

--- a/indexer_queries_test.go
+++ b/indexer_queries_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -395,4 +396,75 @@ func TestAddressQueryIsCapped(t *testing.T) {
 	if len(txs) > addressTxLimit {
 		t.Errorf("returned %d transactions, want at most %d", len(txs), addressTxLimit)
 	}
+}
+
+// Filtering happens at the indexer, so a filtered page describes the chain
+// rather than whatever window happened to load.
+func TestFilteredTransactionQueries(t *testing.T) {
+	f, c := newFakeIndexer(t)
+	when := "2026-08-01T00:00:00Z"
+	f.seedChain(1, 60) // 60 calls
+	for i := 0; i < 5; i++ {
+		f.add(fakePackage(100+i, when, "g1deployer", fmt.Sprintf("gno.land/r/demo/pkg%d", i)))
+	}
+	for i := 0; i < 8; i++ {
+		f.add(fakeSend(200+i, when, "g1from", "g1to", "1ugnot"))
+	}
+
+	tests := []struct {
+		name     string
+		msgType  string
+		wantType string
+	}{
+		{"deploys only", "MsgAddPackage", "MsgAddPackage"},
+		{"sends only", "BankMsgSend", "BankMsgSend"},
+		{"calls only", "MsgCall", "MsgCall"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			txs, err := c.GetRecentTransactionsFiltered(context.Background(), 100, tt.msgType, "")
+			if err != nil {
+				t.Fatalf("GetRecentTransactionsFiltered: %v", err)
+			}
+			if len(txs) == 0 {
+				t.Fatalf("no %s transactions returned", tt.msgType)
+			}
+			for _, tx := range txs {
+				for _, m := range tx.Messages {
+					if m.Value.Typename != tt.wantType {
+						t.Errorf("tx %s is a %s in a %s-filtered result", tx.Hash, m.Value.Typename, tt.wantType)
+					}
+				}
+			}
+		})
+	}
+
+	t.Run("an unknown type is ignored rather than matching nothing", func(t *testing.T) {
+		// A stale bookmark carrying type=Nonsense should show transactions, not
+		// an empty page that reads as "this chain has none".
+		txs, err := c.GetRecentTransactionsFiltered(context.Background(), 10, "Nonsense", "")
+		if err != nil {
+			t.Fatalf("GetRecentTransactionsFiltered: %v", err)
+		}
+		if len(txs) == 0 {
+			t.Error("an unrecognised filter produced an empty page")
+		}
+	})
+
+	t.Run("the filter reaches the where clause", func(t *testing.T) {
+		f.queries = nil
+		if _, err := c.GetRecentTransactionsFiltered(context.Background(), 10, "MsgAddPackage", ""); err != nil {
+			t.Fatalf("GetRecentTransactionsFiltered: %v", err)
+		}
+		found := false
+		for _, q := range f.askedQueries() {
+			if strings.Contains(whereClause(q), "MsgAddPackage") {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("no query carried the type filter in its where clause")
+		}
+	})
 }


### PR DESCRIPTION
Closes #46. The transactions page fetched a 500-row window and sliced it locally, which cost 3.6s to show 50 rows and made the filter bar describe that window rather than the network — "3 deploys" meant "3 among the last 500", which is worse than slow because it is wrong.

## Measured

```
                                    before      after
unfiltered page                     3.6s        0.5s
type=MsgCall                        —           0.079s   total 1 010 572
type=MsgAddPackage                  —           0.006s   total 409
type=MsgRun                         —           0.001s   total 10 414
type=BankMsgSend                    —           0.015s   total 191 544
type=MsgCall&success=false          —           0.390s   total 44 647
type=MsgCall&offset=500             —           0.045s
```

The pager now reads `page 1 / 3831 (191 544 items)` instead of paging through a window.

## The interesting part: the indexer is the wrong source for a filtered list

My first attempt filtered at the indexer, which is where the rows come from. That works for common types and falls apart for rare ones — the indexer has no index for message type, so a query for deploys walks the chain until it finds enough. **A 50-row page of `MsgAddPackage` took 12 seconds and exceeded the client deadline.** Unfiltered, the same page took 0.5s.

Widening windows cannot fix this: it is inherent to scanning for something rare.

The syncer already writes one row per message into a per-type table — `calls`, `packages`, `msg_runs`, `bank_sends` — each indexed by `(network, block_height)`. That is exactly this query, it pages with a real offset instead of re-walking a window, and it yields a genuine total. So a `type` filter is served from storage; without one, rows still come from the indexer, and `from_storage` says which.

A `success` filter alone still goes to the indexer, since that is a column on every transaction there and costs nothing extra.

## Headline counts are real now

They come from `/api/stats`, which covers the whole chain and reads stored rows. The previous version counted whatever had loaded and labelled it "recent" to stay honest; with real totals available there was no reason to keep settling.

## Two things I got wrong on the way

**`packages` has no `success` column.** It is keyed by `(network, path)` and holds a package's current state, not one row per deploy attempt, so there is no per-attempt outcome to store. Deploy rows take the flag from the transaction row via a LEFT JOIN — left, so a deploy whose transaction has not been backfilled still lists rather than vanishing. I found this by shipping a query that returned `no such column: e.success` and reading the schema instead of assuming symmetry.

**I introduced a second page-size constant.** `TXS_PAGE_SIZE = 50` alongside the existing `PAGE_SIZE = 50`, which `pager()` divides by. They happened to agree; two constants that must agree is a defect waiting for one to change. Removed.

## Rendering

Storage rows are flat (`type`, `detail`, `caller`); indexer rows carry `messages[]`. `storedTxDetail` renders the flat shape to match what `txDetailEl` produces, so a filtered page looks identical to an unfiltered one — realm paths link, addresses carry their labels, amounts are formatted. Verified in a browser across all four types plus paging to page two.
