### PR TITLE
fix: serve governance calls from storage instead of scanning the chain

### DIFF
--- a/api.go
+++ b/api.go
@@ -1206,49 +1206,25 @@ func (a *API) HandleBankStats(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, stats)
 }
 
+// HandleGovDAO lists governance calls, from storage.
+//
+// This used to ask the indexer, which cannot answer it: the filter is a
+// substring match over a field it has no index for, so on a chain with no
+// governance activity it widened its window until the deadline and returned a
+// 500 — 12 seconds on sapphire. On pearl it returned a row that was not a
+// governance call at all, because the predicate matched a message carrying no
+// pkg_path.
+//
+// The syncer already records every MsgCall with its path, indexed by
+// (network, pkg_path), so this is a prefix scan that answers instantly and
+// cannot match a non-call.
 func (a *API) HandleGovDAO(w http.ResponseWriter, r *http.Request) {
-	network := a.networkParam(r)
-	limit := eventTxLimit(r)
-
-	// Previously this called clientFor("") for all networks, which returns an
-	// arbitrary client — and in practice returned a null body.
-	if network == "" {
-		// Non-nil so an empty result serialises as [] rather than null; the
-		// frontend iterates this and null is what it used to receive.
-		merged := []Transaction{}
-		for _, txs := range fanOut(r.Context(), a.networks, a.clients, a.health,
-			func(ctx context.Context, nc NetworkConfig, c *IndexerClient) ([]Transaction, error) {
-				txs, err := c.GetGovDAOTransactions(ctx, limit)
-				if err != nil {
-					return nil, err
-				}
-				a.stampBlockTimes(ctx, nc.ID, c, txs)
-				for i := range txs {
-					txs[i].Network = nc.ID
-				}
-				return txs, nil
-			}) {
-			merged = append(merged, txs...)
-		}
-		sortTransactionsByTime(merged)
-		if len(merged) > limit {
-			merged = merged[:limit]
-		}
-		jsonResponse(w, merged)
-		return
-	}
-
-	client := a.clientFor(network)
-	if client == nil {
-		jsonError(w, "network not found", 404)
-		return
-	}
-	txs, err := client.GetGovDAOTransactions(r.Context(), limit)
+	calls, err := a.db.GovDAOCalls(a.networkParam(r), eventTxLimit(r))
 	if err != nil {
 		jsonError(w, err.Error(), 500)
 		return
 	}
-	jsonResponse(w, txs)
+	jsonResponse(w, calls)
 }
 
 func (a *API) HandleDeps(w http.ResponseWriter, r *http.Request) {

--- a/db.go
+++ b/db.go
@@ -3201,3 +3201,51 @@ func (d *DB) FilteredTransactions(network, msgType string, success *bool, limit,
 	}
 	return out, total, rows.Err()
 }
+
+// govDAOPathPrefix is the realm the governance view is about.
+//
+// A prefix, not a substring: paths are `gno.land/r/gov/dao` and its versioned
+// subpackages, and an anchored pattern can walk the (network, pkg_path) index
+// instead of scanning. It also cannot pick up gnoswap's `gov/staker` and
+// `gov/governance`, which a bare "gov" would.
+const govDAOPathPrefix = "gno.land/r/gov/dao"
+
+// GovDAOCalls lists governance calls from storage.
+//
+// Asking the indexer for these does not work on a chain that has none. The
+// filter is a substring match over a field it has no index for, so it widens its
+// window until the deadline and then fails — measured at 12s and a 500 on
+// sapphire, which has no governance activity at all.
+//
+// Worse, it returned a *wrong* row on pearl: the predicate
+// `MsgCall: { pkg_path: { like: ... } }` matched a message that is not a MsgCall
+// and carries no pkg_path, so the governance view listed an `auth/create_session`
+// transaction. Reading the calls table cannot do that — a row is there only
+// because the syncer decoded a MsgCall with that path.
+func (d *DB) GovDAOCalls(network string, limit int) ([]StoredTx, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	rows, err := d.db.Query(`
+		SELECT network, tx_hash, block_height, COALESCE(block_time, ''),
+		       caller, pkg_path || '::' || func_name, success
+		FROM calls
+		WHERE pkg_path LIKE ? AND `+d.networkFilter("network", network)+`
+		ORDER BY block_height DESC, tx_hash ASC
+		LIMIT ?`, govDAOPathPrefix+"%", limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []StoredTx{}
+	for rows.Next() {
+		t := StoredTx{Type: "MsgCall"}
+		if err := rows.Scan(&t.Network, &t.Hash, &t.BlockHeight, &t.BlockTime,
+			&t.Caller, &t.Detail, &t.Success); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -125,7 +125,7 @@ labels this figure "recent" for the same reason.
 | `GET /api/bankstats` | transfer volume statistics. Carries `by_network` in all-networks mode, because volume cannot be summed across chains. Every ranking row is keyed by `(address, network)` and carries its `network` |
 | `GET /api/tokens` | detected token packages. Rows carry their `network` |
 | `GET /api/validators` | valoper registrations, **served from storage** rather than the indexer. Flat rows with `address`, `moniker`, `func` and `success` — `address` is the validator the call is about, which is not always the caller |
-| `GET /api/govdao` | GovDAO activity. Queries every configured network in all-networks mode |
+| `GET /api/govdao` | governance calls, **served from local storage** as a prefix match on `gno.land/r/gov/dao`. The indexer cannot answer this: its filter is a substring match over an unindexed field, so it scans until the deadline on a chain with no governance activity, and its predicate can match a message carrying no `pkg_path` at all |
 | `GET /api/sanity/overview` | consistency counters and liveness. In all-networks mode liveness moves to `by_network`, one entry per chain, each with `reachable` |
 
 ## Time series

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3220,12 +3220,10 @@ async function loadGovDAO() {
       for (const item of events) {
         // Find the originating message
         let origin = '';
+        // Governance calls come from storage now, so a matched row carries a
+        // flat `detail` (path::func) rather than a messages[] to dig through.
         const tx = calls?.find(t => t.hash === item.tx_hash);
-        if (tx) {
-          const msg = tx.messages?.[0]?.value;
-          if (msg?.__typename === 'MsgCall') origin = msg.pkg_path + '::' + msg.func;
-          else if (msg?.__typename === 'MsgRun') origin = 'MsgRun by ' + shortAddr(msg.caller);
-        }
+        if (tx) origin = tx.detail || '';
         for (const ev of item.events) {
           const attrStr = (ev.attrs || []).map(a => a.key + '=' + a.value).join(', ');
           list.appendChild(el('tr', {},

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -821,3 +821,68 @@ func TestFilteredTransactionsFromStorage(t *testing.T) {
 		}
 	})
 }
+
+// Governance calls come from storage, which cannot produce a row that is not a
+// governance call.
+//
+// The indexer version could: its predicate `MsgCall: { pkg_path: { like: ... } }`
+// matched a message that was not a MsgCall and carried no pkg_path, so the
+// governance view listed an auth/create_session transaction on pearl. It also
+// took 12s and returned a 500 on sapphire, which has no governance activity —
+// the filter is a substring match over an unindexed field, so it widened its
+// window until the deadline.
+func TestGovDAOFromStorage(t *testing.T) {
+	api, db := newTestAPI(t)
+
+	const when = "2026-08-01T00:00:00Z"
+	// Governance calls, including a versioned subpackage.
+	if err := db.InsertCall("alpha", "gov-1", 100, when, "g1voter", "gno.land/r/gov/dao", "Propose", true); err != nil {
+		t.Fatalf("InsertCall: %v", err)
+	}
+	if err := db.InsertCall("alpha", "gov-2", 101, when, "g1voter", "gno.land/r/gov/dao/v3/impl", "Vote", true); err != nil {
+		t.Fatalf("InsertCall: %v", err)
+	}
+	// Near-misses that must not be picked up: gnoswap ships these, and a bare
+	// "gov" match would take them.
+	for _, path := range []string{"gno.land/r/gnoswap/gov/staker", "gno.land/r/gnoswap/gov/governance"} {
+		if err := db.InsertCall("alpha", "swap-"+path, 102, when, "g1trader", path, "Stake", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest("GET", "/api/govdao?network=alpha", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var calls []StoredTx
+	mustJSON(t, rec.Body.Bytes(), &calls)
+
+	if len(calls) != 2 {
+		t.Fatalf("got %d governance calls, want 2: %+v", len(calls), calls)
+	}
+	for _, c := range calls {
+		if !strings.HasPrefix(c.Detail, "gno.land/r/gov/dao") {
+			t.Errorf("%s is not a governance call", c.Detail)
+		}
+		if c.Type != "MsgCall" {
+			t.Errorf("a %s reached the governance view", c.Type)
+		}
+	}
+
+	t.Run("a chain with no governance activity answers empty, not slowly", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest("GET", "/api/govdao?network=beta", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		var none []StoredTx
+		mustJSON(t, rec.Body.Bytes(), &none)
+		if len(none) != 0 {
+			t.Errorf("got %d rows on a chain with no governance activity", len(none))
+		}
+	})
+}


### PR DESCRIPTION
Two bugs in the governance view, found while auditing every page after today's feature work.

```
              before                     after
sapphire      http=500  12.36s           http=200  1.06s   rows=0
pearl         http=200   0.76s  rows=1   http=200  0.006s  rows=0
gnoland1      http=200   0.48s  rows=0   http=200  0.001s  rows=0
all networks  http=200   8.00s  rows=1   http=200  0.61s   rows=0
```

## It timed out on a chain with nothing to find

The filter is a substring match over a field the indexer has no index for. On sapphire, which has no governance activity at all, it widened its window until the client deadline and returned a 500 — **12 seconds to discover an empty result.** The same class of problem as the `MsgAddPackage` filter in #126 and `/api/address` in #121: asking the indexer to find something rare means asking it to scan.

## And it returned a row that was not a governance call

Pearl's single result was the `auth/create_session` transaction — an `UnexpectedMessage` carrying **no `pkg_path` at all**. The predicate `MsgCall: { pkg_path: { like: "gov/dao" } }` matched a message that is not a `MsgCall`, so the filter was vacuously true for it.

Worth flagging upstream separately; from here the fix is to stop asking a question that can be answered wrongly.

## Served from storage

The syncer already records every `MsgCall` with its path, indexed by `(network, pkg_path)`. A row is in `calls` only because a `MsgCall` was decoded with that path, so a non-call cannot appear.

The match is a **prefix**, `gno.land/r/gov/dao%`, not a substring. Anchored, it can walk the index instead of scanning, and it cannot pick up gnoswap's `gov/staker` and `gov/governance` — which a bare `gov` would, and which the test asserts against explicitly.

## Note on the empty results

Every network genuinely has zero governance calls in storage right now, so "rows=0" everywhere is correct rather than a regression. The one row that disappeared is the phantom one. Confirmed directly against the production database: `SELECT ... FROM calls WHERE pkg_path LIKE '%gov/dao%'` returns nothing on any chain.

That also means this page will look empty until governance activity happens — which it now does instantly and honestly, rather than after twelve seconds and a 500.
