### PR TITLE
fix: serve the address page from storage instead of scanning the chain

### DIFF
--- a/api.go
+++ b/api.go
@@ -667,73 +667,70 @@ func (a *API) HandleTxs(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, map[string]any{"items": merged[offset:end], "total": total})
 }
 
+// addressTxPage bounds an address page. Its history can be enormous — the
+// busiest account on sapphire has half a million calls — and the view shows
+// recent activity, not an archive.
+const addressTxPage = 200
+
+// HandleAddress serves an address's activity from storage.
+//
+// It used to ask the indexer, which cannot answer at chain scale: the query is
+// five address predicates over fields it has no index for, so it scans.
+// Windowing it from the tip (#121) bought time and the chain outgrew it — the
+// busiest account went back to a 500 at 13.9s.
+//
+// Every message the syncer decodes is already written to a per-type table keyed
+// by the address involved, all indexed. Balance still comes from RPC, which is
+// the only place it exists.
 func (a *API) HandleAddress(w http.ResponseWriter, r *http.Request) {
 	network := a.networkParam(r)
 	addr := r.PathValue("addr")
 
-	// Get transactions for this address (fan-out to all networks when unfiltered)
-	var txs []Transaction
-	if network == "" {
-		seen := make(map[string]bool)
-		for _, netTxs := range fanOut(r.Context(), a.networks, a.clients, a.health,
-			func(ctx context.Context, n NetworkConfig, c *IndexerClient) ([]Transaction, error) {
-				netTxs, err := c.GetTransactionsByAddress(ctx, addr)
-				if err != nil {
-					return nil, err
-				}
-				a.stampBlockTimes(ctx, n.ID, c, netTxs)
-				for i := range netTxs {
-					netTxs[i].Network = n.ID
-				}
-				return netTxs, nil
-			}) {
-			for i := range netTxs {
-				if !seen[netTxs[i].Hash] {
-					seen[netTxs[i].Hash] = true
-					txs = append(txs, netTxs[i])
-				}
-			}
-		}
-		sortTransactionsByTime(txs)
-	} else {
-		c := a.clientFor(network)
-		if c == nil {
-			jsonError(w, "network not found", 404)
-			return
-		}
-		var err error
-		txs, err = c.GetTransactionsByAddress(r.Context(), addr)
-		if err != nil {
-			jsonError(w, err.Error(), 500)
-			return
-		}
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	if limit <= 0 || limit > addressTxPage {
+		limit = addressTxPage
+	}
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	if offset < 0 {
+		offset = 0
 	}
 
-	// Get packages created by this address
+	txs, total, err := a.db.AddressTransactions(network, addr, limit, offset)
+	if err != nil {
+		jsonError(w, err.Error(), 500)
+		return
+	}
+
 	pkgs, err := a.db.Search(network, addr)
 	if err != nil {
 		jsonError(w, err.Error(), 500)
 		return
 	}
 
-	// First block seen
-	firstBlock := -1
+	// The oldest block on this page, not the address's first ever: paging back
+	// would otherwise make "first seen" wander. Named accordingly.
+	oldestOnPage := -1
 	for _, tx := range txs {
-		if firstBlock < 0 || tx.BlockHeight < firstBlock {
-			firstBlock = tx.BlockHeight
+		if oldestOnPage < 0 || tx.BlockHeight < oldestOnPage {
+			oldestOnPage = tx.BlockHeight
 		}
 	}
 
-	// Bank balance via RPC
-	rpcURL := a.rpcURLFor(network)
-	balance := fetchBalance(r.Context(), addr, rpcURL)
+	// Balance is per chain and lives only at the RPC, so it is reported only
+	// when one chain is selected. Summing balances across chains would repeat
+	// the category error of adding ugnot from different networks.
+	balance := ""
+	if network != "" {
+		balance = fetchBalance(r.Context(), addr, a.rpcURLFor(network))
+	}
 
 	jsonResponse(w, map[string]any{
-		"address":      addr,
-		"transactions": txs,
-		"packages":     pkgs,
-		"first_block":  firstBlock,
-		"balance":      balance,
+		"address":        addr,
+		"transactions":   txs,
+		"total":          total,
+		"packages":       pkgs,
+		"oldest_on_page": oldestOnPage,
+		"balance":        balance,
 	})
 }
 

--- a/db.go
+++ b/db.go
@@ -3114,6 +3114,10 @@ type StoredTx struct {
 	Detail      string `json:"detail,omitempty"`
 	Caller      string `json:"caller,omitempty"`
 	Success     bool   `json:"success"`
+	// Gas figures live only on the transaction row, so they are joined in where
+	// the view needs them and left zero where it does not.
+	GasUsed int `json:"gas_used,omitempty"`
+	GasFee  int `json:"gas_fee,omitempty"`
 }
 
 // txSource maps a message type to the table that records it, and to the columns
@@ -3248,4 +3252,98 @@ func (d *DB) GovDAOCalls(network string, limit int) ([]StoredTx, error) {
 		out = append(out, t)
 	}
 	return out, rows.Err()
+}
+
+// AddressTransactions lists an address's activity from storage.
+//
+// The indexer cannot serve this at chain scale. The query is five address
+// predicates over fields it has no index for, so it scans: windowing it from the
+// tip (#121) bought time and the chain outgrew it — the busiest account on
+// sapphire went back to a 500 at 13.9s as its history grew.
+//
+// Every message the syncer decodes is already written to a per-type table keyed
+// by the address involved, and those are indexed. This is the same question with
+// an index behind it, and it pages properly.
+func (d *DB) AddressTransactions(network, addr string, limit, offset int) ([]StoredTx, int, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	nf := d.networkFilter("network", network)
+
+	// Each branch is bounded before the union.
+	//
+	// Unbounded, the union has to be fully materialised and sorted before the
+	// outer LIMIT can pick anything — 580,000 rows for the busiest account on
+	// sapphire, measured at 3.5s. The global newest N must lie within each
+	// branch's own newest N, so taking that many per branch first is exact, not
+	// an approximation, and cuts it to 1.5s.
+	//
+	// SQLite requires each bounded branch to be wrapped in a subselect: ORDER BY
+	// is not allowed directly on a UNION ALL arm.
+	//
+	// Measured against adding (network, address, block_height) indexes to all
+	// four tables, which made it slightly *worse* — 1.70s — so they are not here.
+	take := limit + offset
+
+	branch := func(sel, table, cond string) string {
+		return fmt.Sprintf("SELECT * FROM (SELECT %s FROM %s WHERE %s AND %s"+
+			" ORDER BY block_height DESC LIMIT %d)", sel, table, cond, nf, take)
+	}
+
+	// One branch per way an address can appear. bank_sends matches both
+	// directions because being paid is activity too.
+	union := strings.Join([]string{
+		branch(`network, tx_hash, block_height, COALESCE(block_time,'') bt, 'MsgCall' typ,
+		        caller who, pkg_path || '::' || func_name detail, success`, "calls", "caller = ?"),
+		branch(`network, tx_hash, block_height, COALESCE(block_time,''), 'MsgAddPackage',
+		        creator, path, 1`, "packages", "creator = ?"),
+		branch(`network, tx_hash, block_height, COALESCE(block_time,''), 'MsgRun',
+		        caller, '', success`, "msg_runs", "caller = ?"),
+		branch(`network, tx_hash, block_height, COALESCE(block_time,''), 'BankMsgSend',
+		        from_address, to_address || ' ' || amount, success`, "bank_sends",
+			"(from_address = ? OR to_address = ?)"),
+	}, " UNION ALL ")
+
+	// The count is over unbounded branches — a total that stopped at the page
+	// size would not be a total. It is cheap: 0.155s for the same account,
+	// because counting needs no sort.
+	countUnion := strings.Join([]string{
+		"SELECT tx_hash FROM calls WHERE caller = ? AND " + nf,
+		"SELECT tx_hash FROM packages WHERE creator = ? AND " + nf,
+		"SELECT tx_hash FROM msg_runs WHERE caller = ? AND " + nf,
+		"SELECT tx_hash FROM bank_sends WHERE (from_address = ? OR to_address = ?) AND " + nf,
+	}, " UNION ALL ")
+
+	args := []any{addr, addr, addr, addr, addr}
+
+	var total int
+	if err := d.db.QueryRow(`SELECT COUNT(*) FROM (`+countUnion+`)`, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	// Gas comes from the transaction row. LEFT JOIN so an event whose
+	// transaction has not been backfilled still lists, with zero gas rather
+	// than disappearing.
+	rows, err := d.db.Query(`
+		SELECT e.network, e.tx_hash, e.block_height, e.bt, e.typ, e.who, e.detail, e.success,
+		       COALESCE(t.gas_used, 0), COALESCE(t.gas_fee, 0)
+		FROM (`+union+`) e
+		LEFT JOIN transactions t ON t.network = e.network AND t.tx_hash = e.tx_hash
+		ORDER BY e.block_height DESC, e.tx_hash ASC LIMIT ? OFFSET ?`,
+		append(args, limit, offset)...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	out := []StoredTx{}
+	for rows.Next() {
+		var t StoredTx
+		if err := rows.Scan(&t.Network, &t.Hash, &t.BlockHeight, &t.BlockTime,
+			&t.Type, &t.Caller, &t.Detail, &t.Success, &t.GasUsed, &t.GasFee); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, t)
+	}
+	return out, total, rows.Err()
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -112,7 +112,7 @@ labels this figure "recent" for the same reason.
 
 | endpoint | description |
 |---|---|
-| `GET /api/address/{addr}` | activity for an address: calls, deploys, runs, sends, and balance |
+| `GET /api/address/{addr}` | activity for an address, **from local storage**: calls, deploys, runs, sends (both directions), with `total` covering its whole history and `limit`/`offset` paging the rows. `balance` comes from RPC and is present only when a single network is selected. The indexer cannot serve this at chain scale — five address predicates over unindexed fields means a scan |
 | `GET /api/accounts` | most active accounts. `limit` (default 100, max 500), `offset`, and `sort` = `calls`, `deploys`, `runs`, `sends` or total activity. One row per `(address, network)`: the same key on two chains is two different actors, and each row carries its `network` |
 
 ## Aggregates

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3709,11 +3709,19 @@ async function loadAddressDetail(addr) {
     const txs = data.transactions || [];
     const pkgs = data.packages || [];
     const statsBar = el('div', { className: 'stats-bar' });
-    statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'transactions'), el('span', { className: 'value' }, fmtNum(txs.length))));
+    // The address's whole history, not this page: data.total counts every row
+    // storage holds for it, and paging must not make the headline wander.
+    statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'transactions'), el('span', { className: 'value' }, fmtNum(data.total ?? txs.length))));
     statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'deploys'), el('span', { className: 'value' }, fmtNum(pkgs.length))));
-    if (data.first_block >= 0) {
-      const fbEl = el('div', { className: 'stat' }, el('span', { className: 'label' }, 'first seen'));
-      const fbVal = el('span', { className: 'value' }); fbVal.appendChild(blockLink(data.first_block)); fbEl.appendChild(fbVal);
+    if (data.oldest_on_page >= 0) {
+      // "oldest here", not "first seen": this is the oldest block on the page
+      // being shown, and paging back would make a "first seen" figure wander.
+      // The address's true first block would need a separate query.
+      const label = (data.total > txs.length) ? 'oldest here' : 'first seen';
+      const fbEl = el('div', { className: 'stat' }, el('span', { className: 'label' }, label));
+      const fbVal = el('span', { className: 'value' });
+      fbVal.appendChild(blockLink(data.oldest_on_page, data.transactions?.[0]?.network));
+      fbEl.appendChild(fbVal);
       statsBar.appendChild(fbEl);
     }
     if (data.balance) {
@@ -3727,41 +3735,39 @@ async function loadAddressDetail(addr) {
       statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'balance'), el('span', { className: 'value' }, balDisplay)));
     }
     container.appendChild(statsBar);
-    // Analyze tx patterns
+    // Analyse the page's rows.
+    //
+    // These come from storage as flat {type, caller, detail} rather than from
+    // the indexer as nested messages, because the indexer cannot serve an
+    // address page at chain scale — eight of the nine busiest accounts on
+    // sapphire returned 500 after twelve seconds. Storage answers instantly and
+    // pages properly.
+    //
+    // The one thing lost with the message internals is the storage-deposit
+    // breakdown, which lives in transaction events and is not recorded per
+    // address. The transaction detail page still shows it in full.
     const sentTo = {}, recvFrom = {}, calledRealms = {};
     let totalSentAmount = 0, totalRecvAmount = 0, sendCount = 0, recvCount = 0;
-    let totalGasUsed = 0, totalGasFee = 0, totalStorageBytes = 0, totalStorageFee = 0;
+    let totalGasUsed = 0, totalGasFee = 0;
     for (const tx of txs) {
       totalGasUsed += tx.gas_used || 0;
-      if (tx.gas_fee) totalGasFee += tx.gas_fee.amount || 0;
-      // Storage events
-      for (const ev of (tx.response?.events || [])) {
-        if (ev.__typename === 'StorageDepositEvent') {
-          totalStorageBytes += ev.bytes_delta || 0;
-          if (ev.fee_delta) totalStorageFee += ev.fee_delta.amount || 0;
+      totalGasFee += tx.gas_fee || 0;
+      if (tx.type === 'BankMsgSend') {
+        // detail is "<to> <amount>", the shape FilteredTransactions builds.
+        const [to, amount] = (tx.detail || '').split(' ');
+        const value = parseInt((amount || '').match(/^(\d+)/)?.[1] || '0', 10);
+        if (tx.caller === addr) {
+          sentTo[to] = (sentTo[to] || 0) + 1;
+          sendCount++;
+          totalSentAmount += value;
         }
-      }
-      for (const m of tx.messages) {
-        const v = m.value;
-        if (v.__typename === 'BankMsgSend') {
-          if (v.from_address === addr) {
-            sentTo[v.to_address] = (sentTo[v.to_address] || 0) + 1;
-            sendCount++;
-            const am = (v.amount || '').match(/^(\d+)/);
-            if (am) totalSentAmount += parseInt(am[1]);
-          }
-          if (v.to_address === addr) {
-            recvFrom[v.from_address] = (recvFrom[v.from_address] || 0) + 1;
-            recvCount++;
-            const am = (v.amount || '').match(/^(\d+)/);
-            if (am) totalRecvAmount += parseInt(am[1]);
-          }
-        } else if (v.__typename === 'MsgCall') {
-          if (v.caller === addr) {
-            const key = v.pkg_path + '::' + v.func;
-            calledRealms[key] = (calledRealms[key] || 0) + 1;
-          }
+        if (to === addr) {
+          recvFrom[tx.caller] = (recvFrom[tx.caller] || 0) + 1;
+          recvCount++;
+          totalRecvAmount += value;
         }
+      } else if (tx.type === 'MsgCall' && tx.caller === addr) {
+        calledRealms[tx.detail] = (calledRealms[tx.detail] || 0) + 1;
       }
     }
     // Additional stats
@@ -3785,11 +3791,6 @@ async function loadAddressDetail(addr) {
       hasExtra = true;
       extraStats.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'gas used'), el('span', { className: 'value' }, fmtNum(totalGasUsed))));
       extraStats.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'gas fees'), el('span', { className: 'value' }, fmtNum(Math.floor(totalGasFee / 1000000 * 100) / 100) + ' GNOT')));
-    }
-    if (totalStorageBytes > 0) {
-      hasExtra = true;
-      extraStats.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'storage'), el('span', { className: 'value' }, fmtNum(totalStorageBytes) + ' bytes')));
-      extraStats.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'storage fee'), el('span', { className: 'value' }, fmtNum(Math.floor(totalStorageFee / 1000000 * 100) / 100) + ' GNOT')));
     }
     if (hasExtra) container.appendChild(extraStats);
     // Top receivers (if >1 with multiple txs)
@@ -3846,19 +3847,21 @@ async function loadAddressDetail(addr) {
       container.appendChild(ptbl);
     }
     // Transactions
-    container.appendChild(el('div', { className: 'section-title', style: { marginTop: '24px' } }, 'transactions (' + txs.length + ')'));
+    const shown = data.total > txs.length
+      ? 'transactions (' + fmtNum(txs.length) + ' of ' + fmtNum(data.total) + ' most recent)'
+      : 'transactions (' + fmtNum(txs.length) + ')';
+    container.appendChild(el('div', { className: 'section-title', style: { marginTop: '24px' } }, shown));
     const tbl = el('table');
     tbl.appendChild(el('thead', {}, el('tr', {}, el('th', {}, 'tx'), el('th', {}, 'type'), el('th', {}, 'detail'), el('th', {}, 'status'), el('th', {}, 'when'))));
     const tbody = el('tbody');
     for (const tx of txs) {
-      const msg = tx.messages?.[0];
       const when = tx.block_time ? timeEl(tx.block_time) : blockTime[tx.block_height] ? timeEl(blockTime[tx.block_height]) : (tx.block_height === 0 ? 'genesis' : '');
       const txTd = el('td', {}, txLink(tx.hash, tx.block_height, tx.network));
       if (tx.network) txTd.appendChild(netBadgeEl(tx.network));
       tbody.appendChild(el('tr', {},
         txTd,
-        el('td', {}, typeBadge(msg?.value?.__typename, msg)),
-        el('td', {}, txDetailEl(msg)),
+        el('td', {}, typeBadge(tx.type)),
+        el('td', {}, storedTxDetail(tx)),
         el('td', {}, statusBadge(tx.success)),
         el('td', { style: { color: 'var(--fg2)', fontSize: '12px' } }, when)
       ));

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -886,3 +886,100 @@ func TestGovDAOFromStorage(t *testing.T) {
 		}
 	})
 }
+
+// The address page is served from storage.
+//
+// The indexer cannot answer it at chain scale: five address predicates over
+// unindexed fields means a scan. Eight of the nine busiest accounts on sapphire
+// returned 500 after twelve seconds, including the top one at 15s.
+func TestAddressFromStorage(t *testing.T) {
+	api, db := newTestAPI(t)
+
+	const when = "2026-08-01T00:00:00Z"
+	const me = "g1me"
+	for i := 0; i < 25; i++ {
+		if err := db.InsertCall("alpha", fmt.Sprintf("call-%d", i), 100+i, when,
+			me, "gno.land/r/demo/boards", "Post", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+	if err := db.UpsertPackage("alpha", "gno.land/r/me/pkg", "pkg", me, "deploy", 300, when, true, 1); err != nil {
+		t.Fatalf("UpsertPackage: %v", err)
+	}
+	// Sent by me, and received by me: both are this address's activity.
+	if err := db.InsertBankSend("alpha", "sent", 400, when, me, "g1other", "5ugnot", true); err != nil {
+		t.Fatalf("InsertBankSend: %v", err)
+	}
+	if err := db.InsertBankSend("alpha", "recv", 401, when, "g1other", me, "9ugnot", true); err != nil {
+		t.Fatalf("InsertBankSend: %v", err)
+	}
+	// Someone else's activity must not appear.
+	if err := db.InsertCall("alpha", "theirs", 500, when, "g1other", "gno.land/r/demo/boards", "Post", true); err != nil {
+		t.Fatalf("InsertCall: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	api.RegisterRoutes(mux)
+	get := func(t *testing.T, target string) map[string]any {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest("GET", target, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+		var out map[string]any
+		mustJSON(t, rec.Body.Bytes(), &out)
+		return out
+	}
+
+	t.Run("every kind of activity appears, and only this address's", func(t *testing.T) {
+		out := get(t, "/api/address/"+me+"?network=alpha")
+		if out["total"].(float64) != 28 {
+			t.Errorf("total = %v, want 28: 25 calls, 1 deploy, 1 sent, 1 received", out["total"])
+		}
+		kinds := map[string]bool{}
+		for _, raw := range out["transactions"].([]any) {
+			tx := raw.(map[string]any)
+			kinds[tx["type"].(string)] = true
+			if tx["hash"] == "theirs" {
+				t.Error("another address's transaction appeared")
+			}
+		}
+		for _, want := range []string{"MsgCall", "MsgAddPackage", "BankMsgSend"} {
+			if !kinds[want] {
+				t.Errorf("no %s in the results", want)
+			}
+		}
+	})
+
+	t.Run("the total counts everything, the page is bounded", func(t *testing.T) {
+		out := get(t, "/api/address/"+me+"?network=alpha&limit=10")
+		if got := len(out["transactions"].([]any)); got != 10 {
+			t.Errorf("page has %d rows for limit=10", got)
+		}
+		// A total that stopped at the page size would not be a total.
+		if out["total"].(float64) != 28 {
+			t.Errorf("total = %v, want 28 regardless of page size", out["total"])
+		}
+	})
+
+	t.Run("bounding each branch still returns the globally newest rows", func(t *testing.T) {
+		// The union is bounded per branch before sorting, which is only exact if
+		// the global newest N lie within each branch's own newest N. The newest
+		// row overall is the received send at height 401.
+		out := get(t, "/api/address/"+me+"?network=alpha&limit=3")
+		first := out["transactions"].([]any)[0].(map[string]any)
+		if first["block_height"].(float64) != 401 {
+			t.Errorf("newest row is at height %v, want 401", first["block_height"])
+		}
+	})
+
+	t.Run("balance is reported only for a single network", func(t *testing.T) {
+		// It is per chain and lives only at the RPC; summing across chains would
+		// repeat the category error of adding ugnot from different networks.
+		out := get(t, "/api/address/"+me)
+		if out["balance"] != "" {
+			t.Errorf("balance %q reported in all-networks mode", out["balance"])
+		}
+	})
+}


### PR DESCRIPTION
The address page was returning **500 for eight of the nine busiest accounts on sapphire**. Found while auditing every page after today's feature work.

```
                                          before            after
g1ve35g5…  580 015 events   http=500 15.2s     http=200 5.5s
g1g7dna0…   83 446          http=500 13.5s     http=200 1.2s
g1a24jw4…   44 711          http=500 16.7s     http=200 1.0s
g1v73cac…   37 912          http=500 12.1s     http=200 0.6s
g1zzr0xs…   11 438          http=500 12.8s     http=200 0.5s
```

## Windowing only bought time

#121 windowed this query from the tip, which took the busiest account from a 500 to 5.6s. The chain grew and it crossed the deadline again — 13.9s and a 500 by the time I re-measured today.

That was the wrong fix for the right symptom. The query is five address predicates over fields the indexer has no index for, so it scans; a narrower window just delays when the scan gets too big. Same shape as `type=MsgAddPackage` in #126 and governance in #128.

The syncer already writes every decoded message to a per-type table keyed by the address involved, all indexed. That answers the same question with an index behind it, pages properly, and yields a real total — 580,015 rather than "however many we managed to fetch".

## Bounding each branch, and an index that did not help

The union alone was still 3.5s, because it has to be fully materialised and sorted before the outer LIMIT can pick anything.

Bounding each branch before the union cuts that to **1.5s**. This is exact rather than an approximation: the globally newest N must lie within each branch's own newest N.

I then tried adding `(network, address, block_height)` indexes to all four tables, expecting the per-branch ordering to become free. It measured **1.70s — slightly worse**. Not shipped. The comment in the code records the measurement so the next person does not repeat it.

The count runs over *unbounded* branches, because a total that stopped at the page size would not be a total. It costs 0.155s, since counting needs no sort.

## What is lost

The storage-deposit breakdown. It lives in transaction events, which are not recorded per address, so it cannot be reconstructed from stored rows. The transaction detail page still shows it in full.

Everything else survives, rebuilt from the flat shape: sent/received counts and amounts, unique counterparties, top called realms, gas totals.

## A misleading label I introduced and then fixed

My first version kept the existing `first_block` field, now computed from one page. Paging back would have made "FIRST SEEN" wander, and it would have been wrong on the first page too — the oldest row of the newest 200 is not the address's first block.

Renamed to `oldest_on_page`, and the label reads "oldest here" whenever the page is a subset. Getting the true first block needs its own query; claiming it without one is the same class of quietly-wrong display this project keeps removing.
