### PR TITLE
feat: block persistence and block charts

### DIFF
--- a/api.go
+++ b/api.go
@@ -1067,6 +1067,10 @@ func (a *API) HandleBlock(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, err.Error(), 404)
 		return
 	}
+	if block == nil {
+		jsonError(w, fmt.Sprintf("block not found: %d", height), 404)
+		return
+	}
 	// Also get transactions in this block
 	txs, _ := client.GetTransactionsByBlock(r.Context(), height)
 	jsonResponse(w, map[string]any{
@@ -1681,6 +1685,59 @@ func (a *API) HandleTimeSeriesActiveAddresses(w http.ResponseWriter, r *http.Req
 	jsonResponse(w, pts)
 }
 
+func (a *API) HandleTimeSeriesBlocks(w http.ResponseWriter, r *http.Request) {
+	network := a.networkParam(r)
+	days, granularity := parseTimeseriesParams(r)
+	pts, err := a.db.GetBlockTimeSeries(network, granularity, days)
+	if err != nil {
+		jsonError(w, err.Error(), 500)
+		return
+	}
+	if pts == nil {
+		pts = []BlockTimePoint{}
+	}
+	jsonResponse(w, pts)
+}
+
+func (a *API) HandleBlockTimeHistogram(w http.ResponseWriter, r *http.Request) {
+	network := a.networkParam(r)
+	days, _ := parseTimeseriesParams(r)
+	bins, err := a.db.GetBlockTimeHistogram(network, days)
+	if err != nil {
+		jsonError(w, err.Error(), 500)
+		return
+	}
+	if bins == nil {
+		bins = []BlockTimeBin{}
+	}
+	jsonResponse(w, bins)
+}
+
+func (a *API) HandleBlockProposers(w http.ResponseWriter, r *http.Request) {
+	network := a.networkParam(r)
+	days, _ := parseTimeseriesParams(r)
+	topN, _ := strconv.Atoi(r.URL.Query().Get("topN"))
+	props, err := a.db.GetBlockProposers(network, days, topN)
+	if err != nil {
+		jsonError(w, err.Error(), 500)
+		return
+	}
+	if props == nil {
+		props = []ProposerCount{}
+	}
+	jsonResponse(w, props)
+}
+
+func (a *API) HandleBlockCoverage(w http.ResponseWriter, r *http.Request) {
+	network := a.networkParam(r)
+	cov, err := a.db.GetBlockCoverage(network)
+	if err != nil {
+		jsonError(w, err.Error(), 500)
+		return
+	}
+	jsonResponse(w, cov)
+}
+
 // RegisterRoutes wires every API endpoint onto a mux.
 //
 // These lived inline in run(), which meant nothing could reach them: a test
@@ -1710,6 +1767,10 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/sanity/overview", a.HandleSanityOverview)
 	mux.HandleFunc("GET /api/timeseries/health", a.HandleTimeSeriesHealth)
 	mux.HandleFunc("GET /api/timeseries/active-addresses", a.HandleTimeSeriesActiveAddresses)
+	mux.HandleFunc("GET /api/timeseries/blocks", a.HandleTimeSeriesBlocks)
+	mux.HandleFunc("GET /api/blocks/time-histogram", a.HandleBlockTimeHistogram)
+	mux.HandleFunc("GET /api/blocks/proposers", a.HandleBlockProposers)
+	mux.HandleFunc("GET /api/blocks/coverage", a.HandleBlockCoverage)
 	mux.HandleFunc("GET /api/gas", a.HandleGas)
 	mux.HandleFunc("GET /api/bankstats", a.HandleBankStats)
 	mux.HandleFunc("GET /api/storage/{path...}", a.HandleStorage)

--- a/db.go
+++ b/db.go
@@ -459,6 +459,22 @@ func initSchema(db *sql.DB) error {
 			value TEXT NOT NULL
 		);
 
+		CREATE TABLE IF NOT EXISTS proposers (
+			id      INTEGER PRIMARY KEY,
+			network TEXT NOT NULL,
+			address TEXT NOT NULL,
+			UNIQUE (network, address)
+		);
+
+		CREATE TABLE IF NOT EXISTS blocks (
+			network     TEXT NOT NULL DEFAULT 'gnoland1',
+			height      INTEGER NOT NULL,
+			time        TEXT NOT NULL,
+			proposer_id INTEGER,
+			num_txs     INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (network, height)
+		) WITHOUT ROWID;
+
 		CREATE INDEX IF NOT EXISTS idx_txs_height ON transactions(network, block_height);
 		CREATE INDEX IF NOT EXISTS idx_calls_pkg ON calls(pkg_path);
 		CREATE INDEX IF NOT EXISTS idx_calls_caller ON calls(caller);
@@ -477,6 +493,7 @@ func initSchema(db *sql.DB) error {
 		CREATE INDEX IF NOT EXISTS idx_runs_block_time   ON msg_runs(network, block_time);
 		CREATE INDEX IF NOT EXISTS idx_sends_block_time  ON bank_sends(network, block_time);
 		CREATE INDEX IF NOT EXISTS idx_txs_block_time    ON transactions(network, block_time);
+		CREATE INDEX IF NOT EXISTS idx_blocks_time ON blocks(network, time);
 
 		-- The gas view's "most expensive transactions" sorts by gas_used within a
 		-- network and keeps 20 rows. Without this the sort cannot be served from
@@ -817,11 +834,19 @@ var networkScopedTables = []string{
 	"msg_runs",
 	"bank_sends",
 	"transactions",
+	"blocks",
+	"proposers",
 }
 
 // DeleteNetworkData removes every row belonging to a network, in one transaction.
 // Used when a chain reset makes the stored history refer to blocks that no longer
 // exist. Returns the number of rows removed.
+//
+// The blocks backfill flag in sync_state goes with them. Leaving it set would
+// mark an empty blocks table as fully backfilled, so the coverage endpoint would
+// report complete history for a network that has none — and the backfill would
+// never run again to fix it. It is bookkeeping rather than data, so it is not
+// counted in the returned row total.
 func (d *DB) DeleteNetworkData(network string) (int64, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -842,6 +867,11 @@ func (d *DB) DeleteNetworkData(network string) (int64, error) {
 		if n, err := res.RowsAffected(); err == nil {
 			total += n
 		}
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM sync_state WHERE key = ?`, blocksBackfillDoneKey(network),
+	); err != nil {
+		return 0, fmt.Errorf("clear blocks backfill flag: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, err
@@ -3684,4 +3714,304 @@ func (d *DB) gasRollupReady() (bool, string) {
 	var at string
 	d.db.QueryRow(`SELECT value FROM sync_state WHERE key = ?`, gasRollupKey).Scan(&at)
 	return true, at
+}
+
+// --- blocks ---
+
+// InternProposer maps a proposer address to a small integer id, creating the
+// row on first sight. Storing the id rather than the 40-byte address on every
+// block row saves roughly 119MB across a 3.3M-block chain.
+//
+// The unique key is (network, address), so the same validator address on two
+// chains gets two ids and an id can never span networks.
+func (d *DB) InternProposer(network, address string) (int64, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, err := d.db.Exec(
+		`INSERT INTO proposers (network, address) VALUES (?, ?) ON CONFLICT DO NOTHING`,
+		network, address,
+	); err != nil {
+		return 0, err
+	}
+	var id int64
+	err := d.db.QueryRow(
+		`SELECT id FROM proposers WHERE network = ? AND address = ?`, network, address,
+	).Scan(&id)
+	return id, err
+}
+
+type BlockRow struct {
+	Height     int
+	Time       string
+	ProposerID int64
+	NumTxs     int
+}
+
+// UpsertBlocks writes many blocks under a single lock and a single SQLite
+// transaction, mirroring UpsertTransactions.
+//
+// This is not an optimisation. The comment on UpsertTransactions records that
+// writing rows individually made read requests queue behind a backfill of a
+// hundred rows; a block page is 5,000 rows and the full backfill is 3.3M, so
+// per-row writes here would stall the API for the entire backfill.
+//
+// Idempotent on (network, height), so a re-synced page is a no-op.
+func (d *DB) UpsertBlocks(network string, rows []BlockRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	tx, err := d.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO blocks (network, height, time, proposer_id, num_txs)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (network, height) DO UPDATE SET
+			time = excluded.time,
+			proposer_id = excluded.proposer_id,
+			num_txs = excluded.num_txs`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, r := range rows {
+		if _, err := stmt.Exec(network, r.Height, r.Time, r.ProposerID, r.NumTxs); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// UpsertBlock stores a single block. Convenience wrapper over UpsertBlocks for
+// tests and one-off writes.
+func (d *DB) UpsertBlock(network string, height int, blockTime string, proposerID int64, numTxs int) error {
+	return d.UpsertBlocks(network, []BlockRow{{
+		Height: height, Time: blockTime, ProposerID: proposerID, NumTxs: numTxs,
+	}})
+}
+
+// BlockHeightBounds returns the lowest and highest stored height for a network.
+// The syncer derives both its cursors from these rather than from separate
+// state; ok is false when the network has no blocks yet.
+func (d *DB) BlockHeightBounds(network string) (minH, maxH int, ok bool, err error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var lo, hi sql.NullInt64
+	err = d.db.QueryRow(
+		`SELECT MIN(height), MAX(height) FROM blocks WHERE network = ?`, network,
+	).Scan(&lo, &hi)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	if !lo.Valid || !hi.Valid {
+		return 0, 0, false, nil
+	}
+	return int(lo.Int64), int(hi.Int64), true, nil
+}
+
+type BlockTimePoint struct {
+	Time   string `json:"time"`
+	Blocks int    `json:"blocks"`
+	Txs    int    `json:"txs"`
+}
+
+type BlockTimeBin struct {
+	Bin    string `json:"bin"`
+	Blocks int    `json:"blocks"`
+}
+
+type ProposerCount struct {
+	Address string `json:"address"`
+	Blocks  int    `json:"blocks"`
+}
+
+type BlockCoverage struct {
+	MinTime  string `json:"min_time"`
+	MaxTime  string `json:"max_time"`
+	Complete bool   `json:"complete"`
+}
+
+// blockTimeBinExpr bins a block-time delta (seconds) into the ranges below.
+// Edges come from measurement against gnoland1: median 4.34s, observed
+// 3.69-10.11s, so the resolution is concentrated where the mass actually is.
+// Lower edges are inclusive.
+const blockTimeBinExpr = `CASE
+	WHEN d <  4.0 THEN '<4.0'
+	WHEN d <  4.5 THEN '4.0-4.5'
+	WHEN d <  5.0 THEN '4.5-5.0'
+	WHEN d <  5.5 THEN '5.0-5.5'
+	WHEN d <  6.0 THEN '5.5-6.0'
+	WHEN d <  7.0 THEN '6.0-7.0'
+	WHEN d <  8.0 THEN '7.0-8.0'
+	WHEN d < 10.0 THEN '8.0-10.0'
+	ELSE '>=10.0'
+END`
+
+// BlockTimeBinOrder is the display order of the histogram's bins.
+var BlockTimeBinOrder = []string{
+	"<4.0", "4.0-4.5", "4.5-5.0", "5.0-5.5", "5.5-6.0", "6.0-7.0", "7.0-8.0", "8.0-10.0", ">=10.0",
+}
+
+// GetBlockTimeSeries returns blocks and transactions per bucket.
+func (d *DB) GetBlockTimeSeries(network, granularity string, days int) ([]BlockTimePoint, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	sqlFmt, step, truncFn := timeseriesFormat(granularity)
+	start := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
+
+	q := fmt.Sprintf(
+		`SELECT strftime('%s', time) AS bucket, COUNT(*), COALESCE(SUM(num_txs), 0)
+		 FROM blocks WHERE network = ? AND time >= ?
+		 GROUP BY bucket ORDER BY bucket ASC`, sqlFmt)
+
+	rows, err := d.db.Query(q, network, start)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	buckets := make(map[string]*BlockTimePoint)
+	for rows.Next() {
+		var p BlockTimePoint
+		if err := rows.Scan(&p.Time, &p.Blocks, &p.Txs); err != nil {
+			return nil, err
+		}
+		cp := p
+		buckets[p.Time] = &cp
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return fillBuckets(buckets, days, granularity, step, truncFn,
+		func(k string) BlockTimePoint { return BlockTimePoint{Time: k} },
+		func(p *BlockTimePoint) {}), nil
+}
+
+// GetBlockTimeHistogram bins the interval between consecutive blocks.
+//
+// Deltas are computed at query time with LAG rather than stored per block: it
+// needs no extra column and, crucially, no handling for the page boundaries the
+// syncer fetches across, where an ingest-time computation would have no
+// predecessor to subtract from. The window's first block has a NULL delta and
+// is excluded.
+func (d *DB) GetBlockTimeHistogram(network string, days int) ([]BlockTimeBin, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	start := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
+
+	// The delta is rounded to milliseconds: julianday's double-precision julian
+	// day number is large enough (~2.46M) that subtracting two close values
+	// loses a few microseconds to floating-point cancellation, which is enough
+	// to flip a delta landing exactly on a bin edge (e.g. 4.500000 computed as
+	// 4.499996). Real block-time gaps are never meaningfully precise below a
+	// millisecond, so rounding away that noise costs nothing.
+	q := fmt.Sprintf(`
+		WITH deltas AS (
+			SELECT ROUND((julianday(time) - julianday(LAG(time) OVER (ORDER BY height))) * 86400.0, 3) AS d
+			FROM blocks WHERE network = ? AND time >= ?
+		)
+		SELECT %s AS bin, COUNT(*) FROM deltas WHERE d IS NOT NULL GROUP BY bin`, blockTimeBinExpr)
+
+	rows, err := d.db.Query(q, network, start)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	counts := make(map[string]int)
+	for rows.Next() {
+		var bin string
+		var n int
+		if err := rows.Scan(&bin, &n); err != nil {
+			return nil, err
+		}
+		counts[bin] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]BlockTimeBin, 0, len(BlockTimeBinOrder))
+	for _, bin := range BlockTimeBinOrder {
+		out = append(out, BlockTimeBin{Bin: bin, Blocks: counts[bin]})
+	}
+	return out, nil
+}
+
+// GetBlockProposers counts blocks proposed per validator in the window.
+// Addresses only — moniker resolution lives in the frontend's _valMonikers.
+func (d *DB) GetBlockProposers(network string, days, topN int) ([]ProposerCount, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if topN <= 0 {
+		topN = 25
+	}
+	start := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
+
+	// p.network is filtered as well as b.network: proposer ids are already
+	// network-scoped by construction, but relying on that would make this join
+	// silently wrong if the intern key ever changed.
+	rows, err := d.db.Query(`
+		SELECT p.address, COUNT(*) AS n
+		FROM blocks b JOIN proposers p ON p.id = b.proposer_id
+		WHERE b.network = ? AND p.network = ? AND b.time >= ?
+		GROUP BY p.address ORDER BY n DESC LIMIT ?`,
+		network, network, start, topN)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []ProposerCount
+	for rows.Next() {
+		var c ProposerCount
+		if err := rows.Scan(&c.Address, &c.Blocks); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// GetBlockCoverage reports the stored block range and whether backfill finished.
+//
+// Complete comes from the syncer's flag, not from MIN(height) <= 1: an indexer
+// that prunes early history never yields height 1, and an inferred version would
+// report incomplete forever.
+func (d *DB) GetBlockCoverage(network string) (BlockCoverage, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var cov BlockCoverage
+	var lo, hi sql.NullString
+	err := d.db.QueryRow(
+		`SELECT MIN(time), MAX(time) FROM blocks WHERE network = ?`, network,
+	).Scan(&lo, &hi)
+	if err != nil {
+		return cov, err
+	}
+	cov.MinTime, cov.MaxTime = lo.String, hi.String
+
+	var done string
+	err = d.db.QueryRow(
+		`SELECT value FROM sync_state WHERE key = ?`, blocksBackfillDoneKey(network),
+	).Scan(&done)
+	if err != nil && err != sql.ErrNoRows {
+		return cov, err
+	}
+	cov.Complete = done == "1"
+	return cov, nil
 }

--- a/db_test.go
+++ b/db_test.go
@@ -1094,3 +1094,175 @@ func TestMonthlyStepAlwaysAdvances(t *testing.T) {
 		cur = next
 	}
 }
+
+func TestInternProposer(t *testing.T) {
+	db := newTestDB(t)
+
+	a1, err := db.InternProposer("gnoland1", "g1aaa")
+	if err != nil {
+		t.Fatalf("intern: %v", err)
+	}
+	a2, err := db.InternProposer("gnoland1", "g1aaa")
+	if err != nil {
+		t.Fatalf("intern repeat: %v", err)
+	}
+	if a1 != a2 {
+		t.Errorf("same address interned to different ids: %d vs %d", a1, a2)
+	}
+
+	// The same validator address on two chains must never share an id, or a
+	// per-network aggregate would silently mix chains.
+	b1, err := db.InternProposer("test12", "g1aaa")
+	if err != nil {
+		t.Fatalf("intern other network: %v", err)
+	}
+	if b1 == a1 {
+		t.Errorf("same address on two networks shares id %d", a1)
+	}
+}
+
+func TestUpsertBlockIsIdempotent(t *testing.T) {
+	db := newTestDB(t)
+	pid, _ := db.InternProposer("gnoland1", "g1aaa")
+
+	for i := 0; i < 3; i++ {
+		if err := db.UpsertBlock("gnoland1", 100, "2026-08-13T13:00:00Z", pid, 2); err != nil {
+			t.Fatalf("upsert %d: %v", i, err)
+		}
+	}
+
+	var n int
+	if err := db.db.QueryRow(`SELECT COUNT(*) FROM blocks WHERE network = ?`, "gnoland1").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("row count = %d, want 1 after repeated upsert", n)
+	}
+}
+
+func TestBlockHeightBounds(t *testing.T) {
+	db := newTestDB(t)
+	pid, _ := db.InternProposer("gnoland1", "g1aaa")
+
+	if _, _, ok, err := db.BlockHeightBounds("gnoland1"); err != nil || ok {
+		t.Fatalf("empty table: ok = %v, err = %v; want ok=false, err=nil", ok, err)
+	}
+
+	for _, h := range []int{50, 51, 52} {
+		if err := db.UpsertBlock("gnoland1", h, "2026-08-13T13:00:00Z", pid, 0); err != nil {
+			t.Fatalf("upsert %d: %v", h, err)
+		}
+	}
+	// A different network's rows must not move this network's cursors.
+	opid, _ := db.InternProposer("test12", "g1bbb")
+	if err := db.UpsertBlock("test12", 9999, "2026-08-13T13:00:00Z", opid, 0); err != nil {
+		t.Fatalf("upsert other network: %v", err)
+	}
+
+	minH, maxH, ok, err := db.BlockHeightBounds("gnoland1")
+	if err != nil || !ok {
+		t.Fatalf("ok = %v, err = %v; want ok=true, err=nil", ok, err)
+	}
+	if minH != 50 || maxH != 52 {
+		t.Errorf("bounds = (%d, %d), want (50, 52)", minH, maxH)
+	}
+}
+
+// seedBlocks stores blocks at fixed 1-second-multiples from a base time so
+// delta bins are exactly predictable.
+func seedBlocks(t *testing.T, db *DB, network string, proposer string, base time.Time, offsets []float64) {
+	t.Helper()
+	pid, err := db.InternProposer(network, proposer)
+	if err != nil {
+		t.Fatalf("intern: %v", err)
+	}
+	for i, off := range offsets {
+		ts := base.Add(time.Duration(off * float64(time.Second))).UTC().Format("2006-01-02T15:04:05.000000000Z")
+		if err := db.UpsertBlock(network, 1000+i, ts, pid, i); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+	}
+}
+
+func TestGetBlockTimeHistogram(t *testing.T) {
+	db := newTestDB(t)
+	base := time.Now().UTC().Add(-2 * time.Hour)
+	// Cumulative offsets producing deltas of exactly:
+	//   4.2 (bin 4.0-4.5), 4.5 (bin 4.5-5.0, lower edge is inclusive),
+	//   6.5 (bin 6.0-7.0), 12.0 (bin >=10.0)
+	seedBlocks(t, db, "gnoland1", "g1aaa", base, []float64{0, 4.2, 8.7, 15.2, 27.2})
+
+	bins, err := db.GetBlockTimeHistogram("gnoland1", 1)
+	if err != nil {
+		t.Fatalf("histogram: %v", err)
+	}
+
+	got := map[string]int{}
+	total := 0
+	for _, b := range bins {
+		got[b.Bin] = b.Blocks
+		total += b.Blocks
+	}
+	// 5 blocks produce 4 deltas; the first block has a NULL delta and must be
+	// excluded rather than counted as a zero-second interval.
+	if total != 4 {
+		t.Errorf("total binned = %d, want 4 (5 blocks - 1 with no predecessor)", total)
+	}
+	for bin, want := range map[string]int{"4.0-4.5": 1, "4.5-5.0": 1, "6.0-7.0": 1, ">=10.0": 1} {
+		if got[bin] != want {
+			t.Errorf("bin %q = %d, want %d (all bins: %v)", bin, got[bin], want, got)
+		}
+	}
+}
+
+func TestGetBlockProposersIsNetworkScoped(t *testing.T) {
+	// Two networks holding blocks at the SAME heights. AGENTS.md calls this the
+	// failure mode that goes wrong silently.
+	db := newTestDB(t)
+	base := time.Now().UTC().Add(-2 * time.Hour)
+	seedBlocks(t, db, "gnoland1", "g1aaa", base, []float64{0, 5, 10})
+	seedBlocks(t, db, "test12", "g1bbb", base, []float64{0, 5, 10})
+
+	got, err := db.GetBlockProposers("gnoland1", 1, 10)
+	if err != nil {
+		t.Fatalf("proposers: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d proposers, want 1 (only gnoland1's)", len(got))
+	}
+	if got[0].Address != "g1aaa" {
+		t.Errorf("address = %q, want g1aaa", got[0].Address)
+	}
+	if got[0].Blocks != 3 {
+		t.Errorf("blocks = %d, want 3 — other network's rows leaked in", got[0].Blocks)
+	}
+}
+
+func TestGetBlockCoverage(t *testing.T) {
+	db := newTestDB(t)
+
+	cov, err := db.GetBlockCoverage("gnoland1")
+	if err != nil {
+		t.Fatalf("empty coverage: %v", err)
+	}
+	if cov.Complete || cov.MinTime != "" {
+		t.Errorf("empty table: %+v, want zero value and Complete=false", cov)
+	}
+
+	base := time.Now().UTC().Add(-2 * time.Hour)
+	seedBlocks(t, db, "gnoland1", "g1aaa", base, []float64{0, 5})
+	if err := db.SetSyncState(blocksBackfillDoneKey("gnoland1"), "1"); err != nil {
+		t.Fatalf("set state: %v", err)
+	}
+
+	cov, err = db.GetBlockCoverage("gnoland1")
+	if err != nil {
+		t.Fatalf("coverage: %v", err)
+	}
+	if !cov.Complete {
+		t.Error("Complete = false after the done flag was set")
+	}
+	if cov.MinTime == "" || cov.MaxTime == "" {
+		t.Errorf("times not populated: %+v", cov)
+	}
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -156,9 +156,24 @@ All accept `days` and `granularity`.
 | `GET /api/timeseries/health` | chain health indicators |
 | `GET /api/timeseries/storage` | storage growth. `realm=<path>` scopes it to one realm |
 | `GET /api/timeseries/storage/realms` | realms that have storage data, for populating a selector |
+| `GET /api/timeseries/blocks` | blocks and transactions per bucket. **Single-network** |
 
 There is no per-realm **activity** time series; `storage` is the only endpoint that
 accepts a `realm` parameter.
+
+## Blocks analytics
+
+Read from the local `blocks` table, which the syncer keeps current and backfills
+backward. **All four are single-network**: pass `network=<id>`. With no filter
+they return empty or all-zero results rather than an aggregate — block-time
+deltas across two interleaved chains are meaningless, proposer identities do not
+merge across chains, and a union coverage range would hide a lagging network.
+
+| endpoint | description |
+|---|---|
+| `GET /api/blocks/time-histogram` | interval between consecutive blocks, binned. Accepts `days`/`window` |
+| `GET /api/blocks/proposers` | blocks proposed per validator address. Accepts `days`/`window` and `topN` (defaults to 25 when absent, unparseable or ≤ 0) |
+| `GET /api/blocks/coverage` | `min_time`, `max_time` of stored blocks and `complete`, which is true once the backward backfill has reached genesis or the indexer's pruned floor |
 
 ## Search
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,8 +43,18 @@ silent fallback, because an instance pointed at the wrong chain looks healthy.
 explorer needs lives here: transactions by various filters, blocks, latest height.
 
 **`syncer.go`** — the background loop, one per network, every 30s. Each pass
-checks chain identity, then syncs packages, calls/sends, and msg_runs. Cursors come
-from the highest stored height, so a pass only fetches what is new.
+checks chain identity, syncs blocks, then syncs packages, calls/sends, and
+msg_runs. Cursors come from the highest stored height, so a pass only fetches
+what is new.
+
+Block sync is the one part with two cursors, both derived from the `blocks` table
+itself: head sync walks forward from `MAX(height)` to the tip, and a backfill
+walks backward from `MIN(height)`, bounded per pass so a multi-million-block
+history spreads over many passes instead of stalling everything behind it.
+Backward rather than forward, so the dashboard's recent window populates first.
+The stored range stays contiguous, which is what lets both cursors be derived
+rather than stored. The backfill stops at genesis, or at a pruned floor once a
+single-block probe confirms the indexer really has nothing below it.
 
 **`analyzer.go`** — takes `MsgAddPackage` source and extracts
 `import "gno.land/..."` statements by regex, then writes package, file and
@@ -70,7 +80,9 @@ file, with D3 for the dependency graph. Routing is client-side; the server serve
    packages, files and dependency edges. `MsgCall`, `MsgRun` and `BankMsgSend`
    become `calls`, `msg_runs` and `bank_sends` rows. Every transaction also becomes
    a `transactions` row with its gas and success status.
-3. Block times are fetched per unique height and stamped onto the rows.
+3. Block times are fetched per unique height and stamped onto the rows. Blocks
+   themselves are stored separately by the block sync above, with the proposer
+   address interned into `proposers`, and back the block charts.
 4. Handlers read SQLite, and for a few endpoints query the indexer or RPC live.
 5. The frontend calls `/api/*` and renders.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,9 +70,10 @@ ID and nothing ties the two together.
 **Renaming an ID orphans the data stored under the old one.** Since sync cursors
 are derived from the highest stored height per network, a renamed network looks
 brand new and re-syncs from genesis. To relabel while keeping history, update the
-`network` column across all seven network-scoped tables (`packages`,
+`network` column across all nine network-scoped tables (`packages`,
 `package_files`, `dependencies`, `calls`, `msg_runs`, `bank_sends`,
-`transactions`) — that preserves the cursor too. Back up first.
+`transactions`, `blocks`, `proposers`) — that preserves the cursor too. Back up
+first.
 
 ## Reset-prone networks
 
@@ -131,6 +132,15 @@ the build carries no version information at all.
   a public endpoint.
 - **The database grows with source code**, since full `.gno` file bodies are stored.
   Expect tens of MB per busy network.
+- **Every block is stored**, at roughly 130 bytes each including its index — about
+  **430 MB per network** at mainnet's ~3.3M blocks, and the built-in defaults
+  configure two networks. This is on top of the source-code storage above, and it
+  is not optional in this release.
+- **The block backfill runs automatically** on startup, bounded per pass so it
+  cannot stall the rest of the sync. It walks backward from the tip and takes
+  roughly 16 minutes to cover a mainnet-sized chain. Until it finishes, block
+  charts cover only recent history and say so; `/api/blocks/coverage` reports the
+  stored range and whether it is complete.
 - **WAL mode is on**, so back up the `-wal` and `-shm` files alongside the database,
   or take the backup with the service stopped.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -33,6 +33,8 @@ path exists on multiple chains and means different things on each.
 | `msg_runs` | one `MsgRun` message | full source of the run |
 | `bank_sends` | one `BankMsgSend` message | from, to, amount |
 | `transactions` | one transaction | height, time, gas used/wanted/fee, success |
+| `blocks` | one block per network | height, time, `num_txs`, and the interned proposer. `WITHOUT ROWID` — the range is contiguous by construction |
+| `proposers` | one validator address per network | interned so a block row stores an id, not a 40-byte address |
 | `sync_state` | key/value | sync bookkeeping, keyed with the network in the key |
 
 Derived, not stored:

--- a/fakeindexer_test.go
+++ b/fakeindexer_test.go
@@ -45,6 +45,11 @@ type fakeIndexer struct {
 	capAt         int    // >0: truncate to this many rows and report the element cap
 	blocksFailing bool   // fail only getBlocks, leaving other queries healthy
 	delay         time.Duration
+
+	// emptyBlocksOnce makes the next getBlocks answer with no rows regardless of
+	// what is stored, which is how a lagging replica (or a load balancer fronting
+	// a partially-populated node) answers a range that genuinely has data.
+	emptyBlocksOnce bool
 }
 
 var (
@@ -127,6 +132,10 @@ func (f *fakeIndexer) resolve(q string) (map[string]any, int) {
 		return map[string]any{"latestBlockHeight": f.tip()}, 1
 
 	case strings.Contains(q, "getBlocks"):
+		if f.emptyBlocksOnce {
+			f.emptyBlocksOnce = false
+			return map[string]any{"getBlocks": []Block{}}, 0
+		}
 		blocks := filterBlocks(f.blocks, q)
 		return map[string]any{"getBlocks": blocks}, len(blocks)
 
@@ -377,6 +386,49 @@ func (f *fakeIndexer) seedChain(from, n int) {
 		f.txs = append(f.txs, fakeCall(h, when, fmt.Sprintf("g1caller%d", i%3),
 			"gno.land/r/demo/boards", "Post"))
 	}
+}
+
+// setBlockRange replaces the fake's blocks with the contiguous range [lo, hi]
+// and reports hi as the tip. Nothing exists below lo, which is what a pruned
+// indexer looks like from the outside.
+func (f *fakeIndexer) setBlockRange(lo, hi int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	f.blocks = f.blocks[:0]
+	for h := lo; h <= hi; h++ {
+		f.blocks = append(f.blocks, Block{
+			Hash: fmt.Sprintf("block-%d", h), Height: h, ChainID: f.chainID,
+			Time:               base.Add(time.Duration(h-lo) * time.Minute).Format(time.RFC3339),
+			NumTxs:             1,
+			TotalTxs:           h - lo + 1,
+			ProposerAddressRaw: "g1proposer",
+		})
+	}
+	f.latestHeight = hi
+}
+
+// forceEmptyRange makes the very next getBlocks return no rows, then clears
+// itself, so a test can inject one transient empty page.
+func (f *fakeIndexer) forceEmptyRange() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.emptyBlocksOnce = true
+}
+
+// blockQueryCount reports how many getBlocks queries have been asked, so a test
+// can assert that a terminated backfill stops re-querying.
+func (f *fakeIndexer) blockQueryCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, q := range f.queries {
+		if strings.Contains(q, "getBlocks") {
+			n++
+		}
+	}
+	return n
 }
 
 // redate stamps every block and transaction with the same timestamp, to make

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,9 +137,11 @@ tr.total-row td { font-weight: bold; color: var(--accent); }
 .dash-card { background: var(--bg2); border: 1px solid var(--border); border-radius: 4px; padding: 12px; }
 .dash-card.wide { grid-column: 1 / -1; }
 .dash-head { display: flex; align-items: center; gap: 6px; margin-bottom: 8px; }
+.dash-controls { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 8px; }
 .dash-title { font-size: 13px; color: var(--fg); }
 .dash-chart { width: 100%; height: 300px; }
 .dash-msg { color: var(--fg2); font-size: 12px; padding: 20px 0; }
+.dash-note { color: var(--fg2); font-size: 11px; margin-bottom: 10px; }
 .dash-bar { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; margin-bottom: 12px; }
 .dash-grp { display: inline-flex; align-items: center; gap: 6px; }
 .dash-bar .label { font-size: 11px; color: var(--fg2); text-transform: uppercase; letter-spacing: 1px; }
@@ -4799,6 +4801,13 @@ function dashAxisMerge(base, opt) {
 function dashCatAxis(times) {
   return dashAxisMerge(DASH_AXIS, { type: 'category', data: times, boundaryGap: false });
 }
+// dashCatAxisBars is dashCatAxis with boundaryGap on. Line charts want ticks
+// sitting on the grid edges (boundaryGap: false); bar charts center each bar
+// on its tick, so with boundaryGap: false the first and last bars are drawn
+// half outside the grid's clip rect and render clipped.
+function dashCatAxisBars(times) {
+  return dashAxisMerge(DASH_AXIS, { type: 'category', data: times, boundaryGap: true });
+}
 function dashValAxis(name) {
   return dashAxisMerge(DASH_AXIS, {
     type: 'value', name: name, nameTextStyle: { color: '#888' },
@@ -4847,8 +4856,8 @@ const DASHBOARDS = [
     charts: [
       {
         id: 'tx-by-type',
-        title: 'transactions per bucket, by message type',
-        why: 'Total on-chain activity and what it is made of. A shift in the mix between calls, sends, runs and deploys shows what the chain is actually being used for. Counts messages, not transactions: one transaction can carry several.',
+        title: 'messages per bucket, by type',
+        why: 'Total on-chain activity and what it is made of. A shift in the mix between calls, sends, runs and deploys shows what the chain is actually being used for. This counts messages, not transactions: one transaction carries one or more messages, so this number is always greater than or equal to the transaction count in the throughput chart below.',
         wide: true,
         fetch: w => dashApi('timeseries/transactions', w),
         opt: rows => dashBase({
@@ -4916,6 +4925,76 @@ const DASHBOARDS = [
           ],
         }),
       },
+      {
+        id: 'blocks-per-bucket',
+        title: 'blocks and transactions per bucket',
+        why: 'Throughput. Blocks per bucket tracks consensus liveness; transactions is the real on-chain transaction count, which is lower than the message count above because one transaction can carry several messages.',
+        networkScoped: true,
+        fetch: w => dashApi('timeseries/blocks', w),
+        opt: rows => dashBase({
+          tooltip: { trigger: 'axis' },
+          legend: dashLegend(['blocks', 'transactions']),
+          xAxis: dashCatAxisBars(rows.map(r => r.time)),
+          yAxis: [dashValAxis('blocks'), Object.assign(dashValAxis('txs'), { position: 'right' })],
+          series: [
+            { name: 'blocks', type: 'line', showSymbol: false, areaStyle: { opacity: 0.2 }, data: rows.map(r => r.blocks) },
+            { name: 'transactions', type: 'bar', yAxisIndex: 1, itemStyle: { color: DASH_PAL[3] }, data: rows.map(r => r.txs) },
+          ],
+        }),
+      },
+      {
+        id: 'block-time-histogram',
+        title: 'block-time distribution',
+        window: '7d',
+        why: 'Consensus health. A tight cluster around the target interval is healthy; a fat right tail means the chain is stalling under load. Pinned to 7 days because recent consensus behaviour is what matters here, so the window picker above does not change it.',
+        networkScoped: true,
+        fetch: w => dashApi('blocks/time-histogram', w),
+        opt: rows => dashBase({
+          tooltip: { trigger: 'axis' },
+          xAxis: dashCatAxisBars(rows.map(r => r.bin)),
+          yAxis: dashValAxis('blocks'),
+          series: [{ type: 'bar', data: rows.map(r => r.blocks), itemStyle: { color: DASH_PAL[5] } }],
+        }),
+      },
+      {
+        id: 'block-proposers',
+        title: 'block proposers',
+        wide: true,
+        state: { topN: 15 },
+        why: 'Decentralisation. Blocks proposed per validator over the window — a heavily skewed bar means a few validators dominate block production. Names come from the r/gnops/valopers registry; validators that never registered a moniker show as truncated addresses.',
+        networkScoped: true,
+        controls: (bar, rerender, state) => {
+          bar.appendChild(el('span', { className: 'label' }, 'top'));
+          const seg = el('div', { className: 'dash-seg' });
+          [10, 15, 25, 50].forEach(n => {
+            const b = el('button', { type: 'button', className: n === state.topN ? 'on' : '' }, String(n));
+            b.addEventListener('click', () => { state.topN = n; rerender(); });
+            seg.appendChild(b);
+          });
+          bar.appendChild(seg);
+        },
+        fetch: async function (w) {
+          // _valMonikers is only populated by the blocks view, so this chart
+          // loads it itself. loadValMonikers already swallows its own errors,
+          // so a registry failure degrades to truncated addresses rather than
+          // failing the card.
+          const [rows] = await Promise.all([
+            dashApi('blocks/proposers?topN=' + (this.state && this.state.topN ? this.state.topN : 15), w),
+            loadValMonikers(),
+          ]);
+          return rows;
+        },
+        opt: rows => {
+          const labels = rows.map(r => _valMonikers[r.address] || truncAddr(r.address));
+          return dashBase({
+            grid: { left: 130, right: 20, top: 10, bottom: 28 },
+            tooltip: { trigger: 'axis' },
+            xAxis: dashValAxis('blocks'),
+            yAxis: dashCatAxisBars(labels.slice().reverse()),
+            series: [{ type: 'bar', data: rows.map(r => r.blocks).reverse(), itemStyle: { color: DASH_PAL[0] } }],
+          });
+        },
+      },
     ],
   },
   {
@@ -4960,7 +5039,7 @@ const DASHBOARDS = [
         opt: rows => dashBase({
           tooltip: { trigger: 'axis' },
           legend: dashLegend(['fees', 'cumulative']),
-          xAxis: dashCatAxis(rows.map(r => r.time)),
+          xAxis: dashCatAxisBars(rows.map(r => r.time)),
           yAxis: [
             dashValAxis('ugnot'),
             Object.assign(dashValAxis('cumulative'), { position: 'right' }),
@@ -4984,13 +5063,42 @@ function infoTip(text) {
 function dashCard(chart) {
   const head = el('div', { className: 'dash-head' }, el('span', { className: 'dash-title' }, chart.title));
   if (chart.why) head.appendChild(infoTip(chart.why));
-  const host = el('div', { className: 'dash-chart', id: 'dash-chart-' + chart.id });
-  return el('div', { className: 'dash-card' + (chart.wide ? ' wide' : '') }, head, host);
+  const parts = [head];
+  if (chart.controls) parts.push(el('div', { className: 'dash-controls', id: 'dash-controls-' + chart.id }));
+  parts.push(el('div', { className: 'dash-chart', id: 'dash-chart-' + chart.id }));
+  const card = el('div', { className: 'dash-card' + (chart.wide ? ' wide' : '') });
+  parts.forEach(p => card.appendChild(p));
+  return card;
+}
+
+// dashGranularityOf infers the bucket size from the shape of the server's
+// `time` strings rather than re-deriving it from the window client-side, so
+// it cannot drift from the server's own window->bucket mapping.
+//   2026-08          -> monthly
+//   2026-W33         -> weekly
+//   2026-08-13       -> daily
+//   2026-08-13T13    -> hourly
+function dashGranularityOf(rows) {
+  const t = rows && rows.length ? String(rows[0].time || '') : '';
+  if (/^\d{4}-W\d{2}$/.test(t)) return 'weekly';
+  if (/^\d{4}-\d{2}$/.test(t)) return 'monthly';
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}$/.test(t)) return 'hourly';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(t)) return 'daily';
+  return 'unknown';
 }
 
 async function renderDashChart(chart, gen) {
   const host = document.getElementById('dash-chart-' + chart.id);
   if (!host) return;
+  if (chart.networkScoped && getNetwork() === 'all') {
+    // Three of the four block queries are not meaningfully aggregatable across
+    // chains (interleaved heights, merged proposer identities, a union
+    // coverage range), so a networkScoped chart must not fetch or draw at all
+    // in the all-networks state rather than rendering a misleading aggregate.
+    host.textContent = '';
+    host.appendChild(el('div', { className: 'dash-msg' }, 'select a specific network to see this chart'));
+    return;
+  }
   let rows;
   try {
     // chart.window pins a chart to its own range, ignoring the global picker.
@@ -5016,9 +5124,25 @@ async function renderDashChart(chart, gen) {
     return;
   }
   rows = trimLeadingEmptyRows(rows);
+  // If the error or empty-data path above already ran for this host, it
+  // cleared the host's contents with textContent = '' but left an ECharts
+  // instance registered against that node. echarts.init(host) would then
+  // return that same instance, whose canvas was just removed — dispose it
+  // first so init() creates a fresh one on the live DOM node.
+  const existing = echarts.getInstanceByDom(host);
+  if (existing) existing.dispose();
   const inst = echarts.init(host);
-  inst.setOption(chart.opt(rows), true);
+  const ctx = { window: chart.window || _dashWindow, granularity: dashGranularityOf(rows) };
+  inst.setOption(chart.opt(rows, ctx), true);
   _dashCharts[chart.id] = inst;
+  if (chart.controls) {
+    const bar = document.getElementById('dash-controls-' + chart.id);
+    if (bar) {
+      bar.textContent = '';
+      chart.state = chart.state || {};
+      chart.controls(bar, () => renderDashChart(chart, _dashGen), chart.state);
+    }
+  }
 }
 
 // trimLeadingEmptyRows drops leading all-zero rows (e.g. window=all's
@@ -5091,6 +5215,26 @@ function loadDashboards() {
   const grid = el('div', { className: 'dash-grid' });
   section.charts.forEach(c => grid.appendChild(dashCard(c)));
   root.appendChild(grid);
+  // A 90d window showing three days of blocks is indistinguishable from a
+  // chain that was down. Say which it is while the backfill is still running.
+  // Skipped in the all-networks state: the block charts themselves render
+  // "select a specific network" there and never fetch, so a coverage note
+  // would be commenting on charts that aren't even trying to show data.
+  if (section.charts.some(c => c.id.startsWith('block')) && getNetwork() !== 'all') {
+    api('blocks/coverage').then(cov => {
+      if (!cov || cov.complete || !cov.min_time) return;
+      const note = el('div', { className: 'dash-note' },
+        'history backfilling — block charts currently cover ' +
+        cov.min_time.slice(0, 10) + ' to ' + cov.max_time.slice(0, 10));
+      // insertBefore(note, grid) is safe even if grid were ever stale (e.g. a
+      // superseded render) only because insertBefore throws NotFoundError on
+      // a detached reference node, and that throw is swallowed by the
+      // .catch(() => {}) below. appendChild would not throw and would
+      // silently attach the note to a dead, unattached node instead — this
+      // relies on insertBefore's semantics, not on grid always being live.
+      root.insertBefore(note, grid);
+    }).catch(() => {});
+  }
   section.charts.forEach(c => renderDashChart(c, gen));
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4961,7 +4961,7 @@ const DASHBOARDS = [
         title: 'block proposers',
         wide: true,
         state: { topN: 15 },
-        why: 'Decentralisation. Blocks proposed per validator over the window — a heavily skewed bar means a few validators dominate block production. Names come from the r/gnops/valopers registry; validators that never registered a moniker show as truncated addresses.',
+        why: 'Decentralisation. Blocks proposed per validator over the window — a heavily skewed bar means a few validators dominate block production. Proposers are identified by their consensus key, which is never published to the valopers registry, so these are raw addresses rather than monikers (see #84).',
         networkScoped: true,
         controls: (bar, rerender, state) => {
           bar.appendChild(el('span', { className: 'label' }, 'top'));
@@ -4973,19 +4973,11 @@ const DASHBOARDS = [
           });
           bar.appendChild(seg);
         },
-        fetch: async function (w) {
-          // _valMonikers is only populated by the blocks view, so this chart
-          // loads it itself. loadValMonikers already swallows its own errors,
-          // so a registry failure degrades to truncated addresses rather than
-          // failing the card.
-          const [rows] = await Promise.all([
-            dashApi('blocks/proposers?topN=' + (this.state && this.state.topN ? this.state.topN : 15), w),
-            loadValMonikers(),
-          ]);
-          return rows;
+        fetch: function (w) {
+          return dashApi('blocks/proposers?topN=' + (this.state && this.state.topN ? this.state.topN : 15), w);
         },
         opt: rows => {
-          const labels = rows.map(r => _valMonikers[r.address] || truncAddr(r.address));
+          const labels = rows.map(r => truncAddr(r.address));
           return dashBase({
             grid: { left: 130, right: 20, top: 10, bottom: 28 },
             tooltip: { trigger: 'axis' },

--- a/indexer.go
+++ b/indexer.go
@@ -865,7 +865,12 @@ func (c *IndexerClient) GetBlocksByHeights(ctx context.Context, heights []int) (
 	return m, nil
 }
 
-// GetBlock fetches a single block by height.
+// GetBlock fetches a single block by height. A nil, nil return means the
+// query succeeded but the indexer has nothing at that height — genesis not
+// yet reached from the other side, or a pruned/nonexistent height. Callers
+// that need to tell "confirmed absent" apart from "could not ask" (network
+// error, indexer down) rely on this distinction; do not collapse it back into
+// a single error.
 func (c *IndexerClient) GetBlock(ctx context.Context, height int) (*Block, error) {
 	var result struct {
 		GetBlocks []Block `json:"getBlocks"`
@@ -880,7 +885,7 @@ func (c *IndexerClient) GetBlock(ctx context.Context, height int) (*Block, error
 		return nil, err
 	}
 	if len(result.GetBlocks) == 0 {
-		return nil, fmt.Errorf("block not found: %d", height)
+		return nil, nil
 	}
 	return &result.GetBlocks[0], nil
 }

--- a/syncer.go
+++ b/syncer.go
@@ -11,14 +11,25 @@ import (
 )
 
 type Syncer struct {
-	client    *IndexerClient
-	db        *DB
-	analyzer  *Analyzer
-	networkID string
+	client      *IndexerClient
+	db          *DB
+	analyzer    *Analyzer
+	networkID   string
+	proposerIDs map[string]int64 // address -> interned id, memoised across passes
+
+	// Block paging budget. Fields rather than constants so a test can bound a
+	// pass to a handful of blocks: the paging behaviour under test is about the
+	// budget being respected, not about its production size, and seeding 100k
+	// real blocks to observe it is not a unit test.
+	blockPageSize     int
+	blockPagesPerPass int
 }
 
 func NewSyncer(client *IndexerClient, db *DB, analyzer *Analyzer, networkID string) *Syncer {
-	return &Syncer{client: client, db: db, analyzer: analyzer, networkID: networkID}
+	return &Syncer{
+		client: client, db: db, analyzer: analyzer, networkID: networkID,
+		blockPageSize: defaultBlockPageSize, blockPagesPerPass: defaultBlockPagesPerPass,
+	}
 }
 
 // fingerprintKeyPrefix namespaces the stored chain fingerprint per network.
@@ -30,6 +41,7 @@ func (s *Syncer) SyncAll(ctx context.Context) error {
 		return fmt.Errorf("check chain reset: %w", err)
 	}
 	s.warnOnHeightRegression(ctx)
+	s.syncBlocks(ctx)
 	s.backfillBlockTimes(ctx)
 	s.backfillTransactions(ctx)
 	s.backfillValopers(ctx)
@@ -283,6 +295,9 @@ func (s *Syncer) chainFingerprint(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if block == nil {
+		return "", errors.New("block 1 not found")
+	}
 	if block.Hash == "" {
 		return "", errors.New("block 1 has no hash")
 	}
@@ -333,6 +348,10 @@ func (s *Syncer) checkChainReset(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("discard data after chain reset: %w", err)
 	}
+	// The proposer memo now points at deleted rows. Keeping it would write every
+	// subsequent block with a dangling proposer_id, and GetBlockProposers joins
+	// on that id, so those blocks would silently vanish from the aggregate.
+	s.proposerIDs = nil
 	log.Printf("[%s] removed %d rows, re-syncing from the new genesis", s.networkID, deleted)
 
 	return s.db.SetSyncState(key, current)
@@ -354,6 +373,192 @@ func (s *Syncer) warnOnHeightRegression(ctx context.Context) {
 		log.Printf("[%s] indexer tip %d is below stored height %d on the same chain; sync will not advance until the indexer catches up",
 			s.networkID, remote, stored)
 	}
+}
+
+// Page size measured against the live indexer: 5,000 blocks in ~500ms / 684KB.
+// The per-pass budget bounds one SyncAll pass to ~100k blocks (~10s) so a full
+// 3.3M-block backfill spreads over ~33 passes instead of stalling package,
+// call and msg-run syncing behind a single 5-6 minute run.
+const (
+	defaultBlockPageSize     = 5000
+	defaultBlockPagesPerPass = 20
+)
+
+func blocksBackfillDoneKey(network string) string {
+	return "blocks_backfill_done:" + network
+}
+
+// syncBlocks keeps the blocks table current and backfills history.
+//
+// Two cursors, both derived from the table itself: head sync walks forward from
+// MAX(height) to the tip, backfill walks backward from MIN(height). Because the
+// table always holds a contiguous height range, neither cursor can be fooled by
+// a gap — nothing may insert blocks outside that range.
+//
+// Backward rather than forward: filling oldest-first would leave the dashboard's
+// default 90d window empty until the backfill nearly finished.
+func (s *Syncer) syncBlocks(ctx context.Context) {
+	tip, err := s.client.LatestBlockHeight(ctx)
+	if err != nil {
+		log.Printf("[%s] syncBlocks: tip: %v", s.networkID, err)
+		return
+	}
+
+	minH, maxH, ok, err := s.db.BlockHeightBounds(s.networkID)
+	if err != nil {
+		log.Printf("[%s] syncBlocks: bounds: %v", s.networkID, err)
+		return
+	}
+
+	// One budget shared across seeding, head sync, and backfill: the point of
+	// bounding a pass is a cap on total blocks fetched, not just on the
+	// backfill loop, so every phase below draws from the same pagesLeft.
+	pagesLeft := s.blockPagesPerPass
+
+	if !ok {
+		// Seed at the tip so recent windows populate immediately.
+		from := tip - s.blockPageSize + 1
+		if from < 1 {
+			from = 1
+		}
+		if !s.fetchBlockPage(ctx, from, tip) {
+			return
+		}
+		pagesLeft--
+		minH, maxH, ok, err = s.db.BlockHeightBounds(s.networkID)
+		if err != nil || !ok {
+			return
+		}
+	}
+
+	// Head sync: catch up to the tip.
+	if maxH < tip && pagesLeft > 0 {
+		to := maxH + s.blockPageSize
+		if to > tip {
+			to = tip
+		}
+		s.fetchBlockPage(ctx, maxH+1, to)
+		pagesLeft--
+	}
+
+	// Backfill: walk down until genesis or an empty page, bounded per pass.
+	if done, _ := s.db.GetSyncState(blocksBackfillDoneKey(s.networkID)); done == "1" {
+		return
+	}
+	reachedFloor := false
+	for i := 0; i < pagesLeft && minH > 1; i++ {
+		to := minH - 1
+		from := to - s.blockPageSize + 1
+		if from < 1 {
+			from = 1
+		}
+		if !s.fetchBlockPage(ctx, from, to) {
+			return
+		}
+		newMin, _, ok, err := s.db.BlockHeightBounds(s.networkID)
+		if err != nil || !ok {
+			return
+		}
+		if newMin >= minH {
+			// The page returned nothing new. That alone doesn't distinguish "the
+			// indexer prunes below here" from "a replica still catching up (or a
+			// load balancer fronting a partially-populated node) served an empty
+			// range this once" — both come back as an empty getBlocks: [] with
+			// HTTP 200. Marking done on the wrong one is worse than not marking
+			// it at all: the coverage endpoint would then report complete: true
+			// while history is actually missing, silently and permanently, since
+			// nothing ever revisits a range once backfill has passed it.
+			//
+			// Confirm with a direct probe at the boundary height. A retry here
+			// costs one query and, on a genuinely pruned floor, would come back
+			// empty again anyway.
+			block, perr := s.client.GetBlock(ctx, minH-1)
+			if perr != nil {
+				log.Printf("[%s] syncBlocks: floor probe at height %d failed: %v; retrying next pass", s.networkID, minH-1, perr)
+				return
+			}
+			if block != nil {
+				log.Printf("[%s] syncBlocks: empty page %d-%d but probe found height %d; treating as transient, retrying next pass", s.networkID, from, to, minH-1)
+				return
+			}
+			reachedFloor = true
+			break
+		}
+		minH = newMin
+	}
+	if minH <= 1 || reachedFloor {
+		if err := s.db.SetSyncState(blocksBackfillDoneKey(s.networkID), "1"); err != nil {
+			log.Printf("[%s] syncBlocks: mark done: %v", s.networkID, err)
+			return
+		}
+		reason := "reached genesis"
+		if reachedFloor {
+			reason = "pruned floor confirmed by probe"
+		}
+		log.Printf("[%s] syncBlocks: backfill done (%s), floor height %d", s.networkID, reason, minH)
+	}
+}
+
+// proposerID returns the interned id for an address, memoised in the syncer so
+// a 5,000-block page costs one query per *distinct* proposer instead of two per
+// block. gno.land runs a handful of validators, so the map stays tiny.
+func (s *Syncer) proposerID(address string) (int64, error) {
+	if s.proposerIDs == nil {
+		s.proposerIDs = make(map[string]int64)
+	}
+	if id, ok := s.proposerIDs[address]; ok {
+		return id, nil
+	}
+	id, err := s.db.InternProposer(s.networkID, address)
+	if err != nil {
+		return 0, err
+	}
+	s.proposerIDs[address] = id
+	return id, nil
+}
+
+// fetchBlockPage stores one height range. Returns false when the page failed,
+// so the caller stops and retries next pass rather than spinning.
+//
+// The whole page is written in one UpsertBlocks call: per-row writes would hold
+// and release the write lock 5,000 times, and the comment on UpsertTransactions
+// records that read requests already queue behind a per-row backfill of a
+// hundred rows.
+//
+// A page is all-or-nothing: if any row's proposer lookup fails, the page is
+// abandoned rather than written with that row missing. Writing the rest would
+// leave a silent hole in the stored range that no later pass ever revisits —
+// head sync only extends above MAX(height) and backfill only extends below
+// MIN(height), so a gap in the middle is permanent and undetectable. Retrying
+// the whole page next pass costs nothing (UpsertBlocks is idempotent) and
+// keeps the contiguous-range invariant the two cursors depend on.
+func (s *Syncer) fetchBlockPage(ctx context.Context, from, to int) bool {
+	blocks, err := s.client.GetBlocksInRange(ctx, from, to)
+	if err != nil {
+		log.Printf("[%s] syncBlocks: range %d-%d: %v", s.networkID, from, to, err)
+		return false
+	}
+	if len(blocks) == 0 {
+		return true
+	}
+
+	rows := make([]BlockRow, 0, len(blocks))
+	for _, b := range blocks {
+		var pid int64
+		if b.ProposerAddressRaw != "" {
+			pid, err = s.proposerID(b.ProposerAddressRaw)
+			if err != nil {
+				log.Printf("[%s] syncBlocks: intern proposer for range %d-%d: %v", s.networkID, from, to, err)
+				return false
+			}
+		}
+		rows = append(rows, BlockRow{Height: b.Height, Time: b.Time, ProposerID: pid, NumTxs: b.NumTxs})
+	}
+	if err := s.db.UpsertBlocks(s.networkID, rows); err != nil {
+		log.Printf("[%s] syncBlocks: upsert range %d-%d: %v", s.networkID, from, to, err)
+		return false
+	}
+	return true
 }
 
 func (s *Syncer) getLastBlockHeight(ctx context.Context, tableName string) (*int, error) {

--- a/syncer_test.go
+++ b/syncer_test.go
@@ -50,6 +50,13 @@ func seedNetwork(t *testing.T, db *DB, network string, height int) {
 	if err := db.UpsertTransaction(network, "TXHASH", height, "", 100, 200, 1, true); err != nil {
 		t.Fatalf("upsert transaction: %v", err)
 	}
+	proposerID, err := db.InternProposer(network, "g1proposer")
+	if err != nil {
+		t.Fatalf("intern proposer: %v", err)
+	}
+	if err := db.UpsertBlock(network, height, "", proposerID, 1); err != nil {
+		t.Fatalf("upsert block: %v", err)
+	}
 }
 
 func countNetworkRows(t *testing.T, db *DB, network string) int {
@@ -377,5 +384,204 @@ func TestValoperSubject(t *testing.T) {
 				t.Errorf("moniker = %q, want %q", moniker, tt.wantMoniker)
 			}
 		})
+	}
+}
+
+// newBlockTestSyncer bounds the block pager to a handful of blocks per pass.
+// What these tests check is that the budget is respected and that the backward
+// cursor advances; neither depends on the production page size, and seeding
+// 100k real blocks to observe it would not be a unit test.
+func newBlockTestSyncer(t *testing.T, network string, pageSize, pagesPerPass int) (*Syncer, *fakeIndexer, *DB) {
+	t.Helper()
+	s, fake, db := newTestSyncer(t, network)
+	s.blockPageSize, s.blockPagesPerPass = pageSize, pagesPerPass
+	return s, fake, db
+}
+
+func TestSyncBlocksBoundedPerPass(t *testing.T) {
+	// A pass must stop at its page budget rather than draining the whole chain
+	// inline, which would stall package/call/msg-run syncing behind it.
+	s, fake, db := newBlockTestSyncer(t, "gnoland1", 10, 3)
+	fake.setBlockRange(1, 500)
+
+	s.syncBlocks(context.Background())
+
+	minH, maxH, ok, err := db.BlockHeightBounds("gnoland1")
+	if err != nil || !ok {
+		t.Fatalf("bounds after one pass: ok=%v err=%v", ok, err)
+	}
+	stored := maxH - minH + 1
+	budget := s.blockPageSize * s.blockPagesPerPass
+	if stored > budget {
+		t.Errorf("stored %d blocks in one pass, budget is %d", stored, budget)
+	}
+	if stored == 0 {
+		t.Error("stored no blocks at all")
+	}
+	if fake.blockQueryCount() == 0 {
+		t.Error("made no block queries")
+	}
+}
+
+func TestSyncBlocksResumesBackward(t *testing.T) {
+	// Successive passes must extend the range downward, not restart at the tip.
+	s, fake, db := newBlockTestSyncer(t, "gnoland1", 10, 3)
+	fake.setBlockRange(1, 500)
+
+	s.syncBlocks(context.Background())
+	min1, max1, _, _ := db.BlockHeightBounds("gnoland1")
+
+	s.syncBlocks(context.Background())
+	min2, max2, _, _ := db.BlockHeightBounds("gnoland1")
+
+	if min2 >= min1 {
+		t.Errorf("second pass did not extend backward: min went %d -> %d", min1, min2)
+	}
+	if max2 < max1 {
+		t.Errorf("second pass lost head blocks: max went %d -> %d", max1, max2)
+	}
+}
+
+func TestSyncBlocksTerminatesAtGenesis(t *testing.T) {
+	// A small chain must reach the bottom and set the done flag rather than
+	// retrying a range that will never return rows.
+	s, fake, db := newBlockTestSyncer(t, "gnoland1", 10, 3)
+	fake.setBlockRange(1, 20)
+
+	for i := 0; i < 5; i++ {
+		s.syncBlocks(context.Background())
+	}
+
+	done, err := db.GetSyncState(blocksBackfillDoneKey("gnoland1"))
+	if err != nil {
+		t.Fatalf("get sync state: %v", err)
+	}
+	if done != "1" {
+		t.Errorf("backfill done flag = %q, want \"1\"", done)
+	}
+}
+
+func TestSyncBlocksTerminatesOnPrunedIndexer(t *testing.T) {
+	// A pruned indexer never serves below its floor (here 500, well above
+	// genesis). The backfill must notice a page that returns nothing new,
+	// mark itself done, and stop — otherwise every future cycle would refetch
+	// the identical empty range and break again, forever.
+	s, fake, db := newBlockTestSyncer(t, "gnoland1", 10, 3)
+	fake.setBlockRange(500, 600)
+
+	for i := 0; i < 6; i++ {
+		s.syncBlocks(context.Background())
+	}
+	callsBefore := fake.blockQueryCount()
+
+	s.syncBlocks(context.Background())
+	callsAfter := fake.blockQueryCount()
+
+	if callsAfter != callsBefore {
+		t.Errorf("block queries kept growing after termination: %d -> %d", callsBefore, callsAfter)
+	}
+
+	done, err := db.GetSyncState(blocksBackfillDoneKey("gnoland1"))
+	if err != nil {
+		t.Fatalf("get sync state: %v", err)
+	}
+	if done != "1" {
+		t.Errorf("backfill done flag = %q, want \"1\" once the pruned floor is hit", done)
+	}
+
+	minH, _, ok, err := db.BlockHeightBounds("gnoland1")
+	if err != nil || !ok {
+		t.Fatalf("bounds: ok=%v err=%v", ok, err)
+	}
+	if minH < 500 {
+		t.Errorf("stored below the indexer's floor: minH=%d", minH)
+	}
+}
+
+func TestSyncBlocksTransientEmptyPageDoesNotMarkDone(t *testing.T) {
+	// A single empty range response must not be treated as proof of a pruned
+	// floor: a replica still catching up, or a load balancer fronting a
+	// partially-populated node, can return getBlocks: [] for a range that
+	// genuinely has data. Only a confirming probe at the boundary height may
+	// conclude the floor is real; until then, backfill must retry rather than
+	// permanently self-certifying incomplete history as done.
+	s, fake, db := newBlockTestSyncer(t, "gnoland1", 10, 3)
+	fake.setBlockRange(1, 500) // large enough that one pass can't reach genesis
+
+	s.syncBlocks(context.Background())
+	minAfterFirst, _, ok, err := db.BlockHeightBounds("gnoland1")
+	if err != nil || !ok {
+		t.Fatalf("bounds after first pass: ok=%v err=%v", ok, err)
+	}
+	if minAfterFirst <= 1 {
+		t.Fatalf("first pass reached genesis already; test needs more headroom (minH=%d)", minAfterFirst)
+	}
+
+	fake.forceEmptyRange()
+	s.syncBlocks(context.Background())
+
+	done, err := db.GetSyncState(blocksBackfillDoneKey("gnoland1"))
+	if err != nil {
+		t.Fatalf("get sync state: %v", err)
+	}
+	if done == "1" {
+		t.Error("backfill marked done after a single transient empty page")
+	}
+
+	// Progress must resume once the transient condition clears.
+	s.syncBlocks(context.Background())
+	minAfterResume, _, ok, err := db.BlockHeightBounds("gnoland1")
+	if err != nil || !ok {
+		t.Fatalf("bounds after resume pass: ok=%v err=%v", ok, err)
+	}
+	if minAfterResume >= minAfterFirst {
+		t.Errorf("backfill did not resume after the transient empty page cleared: min stayed at %d", minAfterResume)
+	}
+}
+
+func TestSyncBlocksAbandonsPageOnProposerInternFailure(t *testing.T) {
+	// A page is all-or-nothing. If a proposer lookup fails partway through a
+	// page, writing the surviving rows would leave a hole inside the stored
+	// [MIN, MAX] range that no later pass ever revisits (head sync only extends
+	// above MAX, backfill only extends below MIN) — a silent, permanent gap.
+	// The whole page must be abandoned instead.
+	ctx := context.Background()
+	network := "gnoland1"
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	db, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	fake, client := newFakeIndexer(t)
+	fake.chainID = "testchain"
+	fake.setBlockRange(1, 100)
+
+	s := NewSyncer(client, db, NewAnalyzer(db), network)
+
+	// Force InternProposer to fail: close the database after the fake indexer is
+	// set up but before the page is processed, so GetBlocksInRange (pure HTTP,
+	// no db) still succeeds while the db write path fails.
+	if err := db.db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	if s.fetchBlockPage(ctx, 1, 50) {
+		t.Fatal("fetchBlockPage succeeded despite a broken proposer lookup")
+	}
+
+	// Reopen a fresh connection to the same file: nothing should have been
+	// committed, since the page must be abandoned before any write.
+	db2, err := NewDB(dbPath)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer db2.Close()
+
+	if _, _, ok, err := db2.BlockHeightBounds(network); err != nil {
+		t.Fatalf("bounds: %v", err)
+	} else if ok {
+		t.Error("page was partially written despite a proposer intern failure")
 	}
 }


### PR DESCRIPTION
Blocks and proposers are persisted by the syncer and served as four endpoints
behind the batch 1 dashboards config: /api/timeseries/blocks,
/api/blocks/time-histogram, /api/blocks/proposers and /api/blocks/coverage.

Backfill walks backward from MIN(height) with a per-pass page budget, so a full
history fill spreads over many passes instead of stalling package, call and
msg-run syncing behind one long run. A page is all-or-nothing: a proposer
intern failure abandons the whole page rather than leaving a hole inside the
stored [MIN, MAX] range that no later pass revisits.

Rebased onto main:
- Routes register through RegisterRoutes(mux) rather than inline in run().
- The blocks index joins the existing block_time index group.
- The ?window= contract is documented in batch 1, so 2a's restatement is
  dropped; the four block endpoints are documented here.
- Dropped a duplicate newTestDB; main already has one.
- The six block-sync tests are ported onto main's fake indexer, which #65
  rewrote. They previously relied on a private fake with a virtual block range;
  the page budget is now a Syncer field, so a test bounds a pass to a handful
  of real blocks instead of asserting against a million imaginary ones. Checked
  by mutation: ignoring the budget still fails the test (stored 500, budget 30).
- seedNetwork covers blocks and proposers, keeping main's invariant that every
  network-scoped table has a seeded row.

Second of the batches split out of #66.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>