### PR TITLE
perf: precompute the gas aggregates instead of scanning per request

### DIFF
--- a/analytics_test.go
+++ b/analytics_test.go
@@ -442,3 +442,112 @@ func TestDerivedAddressLabels(t *testing.T) {
 		}
 	}
 }
+
+// The gas page reads precomputed rollups.
+//
+// Its two aggregates scale with the chain and had reached 14s on sapphire,
+// against a 30s server write timeout — the trajectory that broke the address
+// page twice. Neither can be indexed away: attributing gas per realm means
+// touching every call, and the totals sum every transaction.
+func TestGasRollups(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "live"}, {ID: "other"}})
+
+	const when = "2026-08-01T00:00:00Z"
+	seed := func(net, hash, path string, gas, fee int) {
+		t.Helper()
+		if err := db.UpsertTransaction(net, hash, 100, when, gas, gas*2, fee, true); err != nil {
+			t.Fatalf("UpsertTransaction: %v", err)
+		}
+		if err := db.InsertCall(net, hash, 100, when, "g1caller", path, "Post", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+	seed("live", "a", "gno.land/r/demo/boards", 100, 10)
+	seed("live", "b", "gno.land/r/demo/boards", 200, 20)
+	seed("live", "c", "gno.land/r/demo/users", 50, 5)
+	// The same path on another chain must stay a separate row in the rollup.
+	seed("other", "d", "gno.land/r/demo/boards", 999, 99)
+
+	t.Run("before any refresh it computes live rather than showing zeros", func(t *testing.T) {
+		// Zeros would read as "this chain has used no gas".
+		stats, err := db.GetGasStats("live", 10)
+		if err != nil {
+			t.Fatalf("GetGasStats: %v", err)
+		}
+		if stats.TotalGasUsed != 350 {
+			t.Errorf("gas used = %d, want 350 computed live", stats.TotalGasUsed)
+		}
+		if stats.ComputedAt != "" {
+			t.Errorf("computed_at = %q, want empty when computed live", stats.ComputedAt)
+		}
+	})
+
+	if err := db.RefreshGasRollups(); err != nil {
+		t.Fatalf("RefreshGasRollups: %v", err)
+	}
+
+	t.Run("the rollup gives the same answer", func(t *testing.T) {
+		stats, err := db.GetGasStats("live", 10)
+		if err != nil {
+			t.Fatalf("GetGasStats: %v", err)
+		}
+		if stats.TotalGasUsed != 350 || stats.TotalTxs != 3 {
+			t.Errorf("gas=%d txs=%d, want 350 and 3", stats.TotalGasUsed, stats.TotalTxs)
+		}
+		if stats.ComputedAt == "" {
+			t.Error("no computed_at, so the page cannot say how fresh these are")
+		}
+		if len(stats.TopRealms) == 0 || stats.TopRealms[0].Path != "gno.land/r/demo/boards" {
+			t.Errorf("top realm = %+v, want boards with 300 gas", stats.TopRealms)
+		}
+		if stats.TopRealms[0].Gas != 300 {
+			t.Errorf("boards gas = %d, want 300", stats.TopRealms[0].Gas)
+		}
+	})
+
+	t.Run("another chain's gas stays out", func(t *testing.T) {
+		stats, err := db.GetGasStats("live", 10)
+		if err != nil {
+			t.Fatalf("GetGasStats: %v", err)
+		}
+		if stats.TotalGasUsed != 350 {
+			t.Errorf("gas used = %d — the other chain's 999 leaked in", stats.TotalGasUsed)
+		}
+	})
+
+	t.Run("all networks re-groups a shared path across chains", func(t *testing.T) {
+		// The rollup stores (network, path); a path on two chains is two rows
+		// there and must be summed on read when both are in scope.
+		stats, err := db.GetGasStats("", 10)
+		if err != nil {
+			t.Fatalf("GetGasStats: %v", err)
+		}
+		if stats.TotalGasUsed != 1349 {
+			t.Errorf("gas used = %d, want 1349 across both chains", stats.TotalGasUsed)
+		}
+		var boards int
+		for _, r := range stats.TopRealms {
+			if r.Path == "gno.land/r/demo/boards" {
+				boards = r.Gas
+			}
+		}
+		if boards != 1299 {
+			t.Errorf("boards gas = %d, want 1299 (300 + 999) summed across chains", boards)
+		}
+	})
+
+	t.Run("a refresh replaces rather than accumulates", func(t *testing.T) {
+		// Whole-table replacement, so running it twice must not double anything.
+		if err := db.RefreshGasRollups(); err != nil {
+			t.Fatalf("RefreshGasRollups: %v", err)
+		}
+		stats, err := db.GetGasStats("live", 10)
+		if err != nil {
+			t.Fatalf("GetGasStats: %v", err)
+		}
+		if stats.TotalGasUsed != 350 {
+			t.Errorf("gas used = %d after a second refresh, want 350", stats.TotalGasUsed)
+		}
+	})
+}

--- a/api.go
+++ b/api.go
@@ -1388,6 +1388,9 @@ func (a *API) HandleGas(w http.ResponseWriter, r *http.Request) {
 		"total_source_bytes": a.db.TotalSourceBytes(network),
 		"top_realms":         stats.TopRealms,
 		"top_txs":            stats.TopTxs,
+		// When the rollups behind these figures were built. Empty means they
+		// were computed live, which happens before the first refresh.
+		"computed_at": stats.ComputedAt,
 	})
 }
 

--- a/db.go
+++ b/db.go
@@ -396,6 +396,39 @@ func initSchema(db *sql.DB) error {
 			PRIMARY KEY (network, tx_hash)
 		);
 
+		-- Gas rollups: the gas page's two expensive aggregates, precomputed.
+		--
+		-- Both scale with the chain and had reached 14s on sapphire, against a
+		-- 30s server write timeout — the same trajectory that broke the address
+		-- page twice. Neither can be indexed away: attributing gas per realm
+		-- means touching every call, and the totals are a sum over every
+		-- transaction.
+		--
+		-- Refreshed wholesale on a timer rather than maintained per insert.
+		-- Incremental maintenance would have to be exactly right across
+		-- re-syncs, backfills and chain resets, any of which would otherwise
+		-- double-count; a periodic recompute is idempotent by construction.
+		CREATE TABLE IF NOT EXISTS gas_realm_rollup (
+			network   TEXT NOT NULL,
+			path      TEXT NOT NULL,
+			gas_used  INTEGER NOT NULL,
+			gas_fee   INTEGER NOT NULL,
+			tx_count  INTEGER NOT NULL,
+			PRIMARY KEY (network, path)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_gas_rollup_gas
+			ON gas_realm_rollup(network, gas_used DESC);
+
+		CREATE TABLE IF NOT EXISTS gas_totals_rollup (
+			network       TEXT PRIMARY KEY,
+			tx_count      INTEGER NOT NULL,
+			gas_used      INTEGER NOT NULL,
+			gas_wanted    INTEGER NOT NULL,
+			gas_fee       INTEGER NOT NULL,
+			success_count INTEGER NOT NULL
+		);
+
 		CREATE TABLE IF NOT EXISTS sync_state (
 			key TEXT PRIMARY KEY,
 			value TEXT NOT NULL
@@ -1044,6 +1077,10 @@ type GasTx struct {
 
 // GasStats aggregates gas usage for a network.
 type GasStats struct {
+	// ComputedAt is when the rollups behind these figures were built, empty if
+	// they were computed live. Surfaced so a reader can tell fresh from stale.
+	ComputedAt string `json:"computed_at,omitempty"`
+
 	TotalTxs       int
 	TotalGasUsed   int
 	TotalGasWanted int
@@ -1064,6 +1101,12 @@ func (d *DB) GetGasStats(network string, topN int) (*GasStats, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
+	// Prefer the rollup. Both aggregates below scale with the chain and had
+	// reached 14s on sapphire; precomputed they are a lookup. ComputedAt tells
+	// the reader how fresh the figures are — showing stale numbers without
+	// saying so is the failure mode this avoids.
+	rollupReady, computedAt := d.gasRollupReady()
+
 	// Always filter, even for "all networks": an empty WHERE cannot use the
 	// (network, gas_used) index, which is what makes the top-gas sort scan the
 	// whole table. Scoping to the configured set keeps the index usable and
@@ -1071,14 +1114,22 @@ func (d *DB) GetGasStats(network string, topN int) (*GasStats, error) {
 	where := " WHERE " + d.networkFilter("network", network)
 	args := []any{}
 
-	out := &GasStats{}
-	err := d.db.QueryRow(`
+	out := &GasStats{ComputedAt: computedAt}
+
+	totalsQuery := `
 		SELECT COUNT(*),
 		       COALESCE(SUM(gas_used), 0),
 		       COALESCE(SUM(gas_wanted), 0),
 		       COALESCE(SUM(gas_fee), 0),
 		       COALESCE(SUM(CASE WHEN success THEN 1 ELSE 0 END), 0)
-		FROM transactions`+where, args...).
+		FROM transactions` + where
+	if rollupReady {
+		totalsQuery = `
+		SELECT COALESCE(SUM(tx_count),0), COALESCE(SUM(gas_used),0), COALESCE(SUM(gas_wanted),0),
+		       COALESCE(SUM(gas_fee),0), COALESCE(SUM(success_count),0)
+		FROM gas_totals_rollup` + where
+	}
+	err := d.db.QueryRow(totalsQuery, args...).
 		Scan(&out.TotalTxs, &out.TotalGasUsed, &out.TotalGasWanted, &out.TotalFees, &out.SuccessCount)
 	if err != nil {
 		return nil, fmt.Errorf("gas totals: %w", err)
@@ -1091,21 +1142,30 @@ func (d *DB) GetGasStats(network string, topN int) (*GasStats, error) {
 	// its ephemeral path is unique per run and would otherwise be one row each.
 	realmWhere := " AND " + d.networkFilter("t.network", network)
 	realmArgs := []any{}
-	rows, err := d.db.Query(`
+
+	realmQuery := `
 		SELECT path, SUM(gas_used), SUM(gas_fee), COUNT(*) FROM (
 			SELECT c.pkg_path AS path, t.gas_used, t.gas_fee, t.tx_hash
 			  FROM calls c JOIN transactions t
-			    ON t.network = c.network AND t.tx_hash = c.tx_hash`+realmWhere+`
+			    ON t.network = c.network AND t.tx_hash = c.tx_hash` + realmWhere + `
 			UNION ALL
 			SELECT p.path AS path, t.gas_used, t.gas_fee, t.tx_hash
 			  FROM packages p JOIN transactions t
-			    ON t.network = p.network AND t.tx_hash = p.tx_hash`+realmWhere+`
+			    ON t.network = p.network AND t.tx_hash = p.tx_hash` + realmWhere + `
 			UNION ALL
 			SELECT 'MsgRun by ' || m.caller AS path, t.gas_used, t.gas_fee, t.tx_hash
 			  FROM msg_runs m JOIN transactions t
-			    ON t.network = m.network AND t.tx_hash = m.tx_hash`+realmWhere+`
-		) GROUP BY path ORDER BY SUM(gas_used) DESC LIMIT ?`,
-		append(realmArgs, topN)...)
+			    ON t.network = m.network AND t.tx_hash = m.tx_hash` + realmWhere + `
+		) GROUP BY path ORDER BY SUM(gas_used) DESC LIMIT ?`
+	if rollupReady {
+		// The rollup is per (network, path); a path on two chains stays two
+		// rows there, so the read re-groups when several networks are in scope.
+		realmQuery = `
+		SELECT path, SUM(gas_used), SUM(gas_fee), SUM(tx_count)
+		FROM gas_realm_rollup WHERE ` + d.networkFilter("network", network) + `
+		GROUP BY path ORDER BY SUM(gas_used) DESC LIMIT ?`
+	}
+	rows, err := d.db.Query(realmQuery, append(realmArgs, topN)...)
 	if err != nil {
 		return nil, fmt.Errorf("gas by realm: %w", err)
 	}
@@ -3346,4 +3406,112 @@ func (d *DB) AddressTransactions(network, addr string, limit, offset int) ([]Sto
 		out = append(out, t)
 	}
 	return out, total, rows.Err()
+}
+
+// --- Gas rollups ------------------------------------------------------------
+
+// gasRollupKey records when the rollups were last recomputed, so the page can
+// say how fresh its numbers are rather than presenting stale ones as live.
+const gasRollupKey = "gas_rollup_at"
+
+// gasRollupInterval is how often the rollups are rebuilt. These are all-time
+// aggregates, so minutes of staleness is invisible to a reader — and the
+// recompute takes the write lock, so doing it per sync pass would mean holding
+// it every 30 seconds for the sake of numbers nobody watches change.
+const gasRollupInterval = 5 * time.Minute
+
+// RefreshGasRollups recomputes both gas aggregates for every configured network.
+//
+// This is the expensive query the gas page used to run per request — 3.4s for
+// the realm attribution and 1.3s for the totals on sapphire, and both grow with
+// the chain. Running it on a timer instead turns a 14-second page into a lookup.
+//
+// Whole-table replacement inside one transaction: readers see either the old
+// rollup or the new one, never a half-written mixture.
+func (d *DB) RefreshGasRollups() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// A busy write lock loses the whole refresh, and the failure is quiet: the
+	// read path falls back to computing live, so the page merely stays slow.
+	// Retry rather than wait for the next tick.
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * 2 * time.Second)
+		}
+		if lastErr = d.refreshGasRollups(); lastErr == nil {
+			return nil
+		}
+	}
+	return lastErr
+}
+
+func (d *DB) refreshGasRollups() error {
+
+	tx, err := d.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	scope := d.networkFilter("t.network", "")
+
+	if _, err := tx.Exec(`DELETE FROM gas_realm_rollup`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO gas_realm_rollup (network, path, gas_used, gas_fee, tx_count)
+		SELECT network, path, SUM(gas_used), SUM(gas_fee), COUNT(*) FROM (
+			SELECT t.network, c.pkg_path AS path, t.gas_used, t.gas_fee
+			  FROM calls c JOIN transactions t
+			    ON t.network = c.network AND t.tx_hash = c.tx_hash AND ` + scope + `
+			UNION ALL
+			SELECT t.network, p.path, t.gas_used, t.gas_fee
+			  FROM packages p JOIN transactions t
+			    ON t.network = p.network AND t.tx_hash = p.tx_hash AND ` + scope + `
+			UNION ALL
+			SELECT t.network, 'MsgRun by ' || m.caller, t.gas_used, t.gas_fee
+			  FROM msg_runs m JOIN transactions t
+			    ON t.network = m.network AND t.tx_hash = m.tx_hash AND ` + scope + `
+		) GROUP BY network, path`); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(`DELETE FROM gas_totals_rollup`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO gas_totals_rollup (network, tx_count, gas_used, gas_wanted, gas_fee, success_count)
+		SELECT network, COUNT(*), COALESCE(SUM(gas_used),0), COALESCE(SUM(gas_wanted),0),
+		       COALESCE(SUM(gas_fee),0), COALESCE(SUM(CASE WHEN success THEN 1 ELSE 0 END),0)
+		FROM transactions t WHERE ` + scope + `
+		GROUP BY network`); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(
+		`INSERT INTO sync_state (key, value) VALUES (?, ?)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		gasRollupKey, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// gasRollupReady reports whether the rollups hold anything, and when they were
+// built. Callers hold the read lock.
+//
+// An empty rollup means the timer has not fired yet — a fresh database, or the
+// first start after this shipped. The gas page falls back to computing live in
+// that case rather than showing zeros, which would read as "this chain has used
+// no gas".
+func (d *DB) gasRollupReady() (bool, string) {
+	var n int
+	if err := d.db.QueryRow(`SELECT COUNT(*) FROM gas_totals_rollup`).Scan(&n); err != nil || n == 0 {
+		return false, ""
+	}
+	var at string
+	d.db.QueryRow(`SELECT value FROM sync_state WHERE key = ?`, gasRollupKey).Scan(&at)
+	return true, at
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -121,7 +121,7 @@ labels this figure "recent" for the same reason.
 |---|---|
 | `GET /api/stats` | totals: transactions, calls, deploys, msg_runs, sends, realms, packages, unique callers, latest block |
 | `GET /api/analytics` | leaderboards and aggregate breakdowns. Every ranking row carries its `network`; rankings are scoped to the selected chain |
-| `GET /api/gas` | gas usage, by realm |
+| `GET /api/gas` | gas usage, by realm. Totals and the per-realm breakdown come from rollups rebuilt every 5 minutes, with `computed_at` saying when. Neither can be indexed away — attributing gas per realm means touching every call — and both had reached 14s. Falls back to computing live if the rollups are not built yet |
 | `GET /api/bankstats` | transfer volume statistics. Carries `by_network` in all-networks mode, because volume cannot be summed across chains. Every ranking row is keyed by `(address, network)` and carries its `network` |
 | `GET /api/tokens` | detected token packages. Rows carry their `network` |
 | `GET /api/validators` | valoper registrations, **served from storage** rather than the indexer. Flat rows with `address`, `moniker`, `func` and `success` — `address` is the validator the call is about, which is not always the caller |

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2937,6 +2937,16 @@ async function loadGas() {
   try {
     const data = await api('gas');
     container.textContent = '';
+    // Say how fresh these are. They come from rollups rebuilt on a timer, and
+    // presenting precomputed numbers as live is how a page quietly stops being
+    // trustworthy.
+    if (data.computed_at) {
+      const note = el('div', { className: 'section-sub' });
+      note.append('totals and per-realm gas as of ');
+      note.appendChild(timeEl(data.computed_at));
+      note.append(' \u00b7 rebuilt every few minutes');
+      container.appendChild(note);
+    }
     // Stats
     const statsBar = el('div', { className: 'stats-bar' });
     statsBar.appendChild(el('div', { className: 'stat' }, el('span', { className: 'label' }, 'total txs'), el('span', { className: 'value' }, fmtNum(data.total_txs))));

--- a/main.go
+++ b/main.go
@@ -109,6 +109,45 @@ func run() error {
 		}
 	}
 
+	// Keep the gas rollups warm.
+	//
+	// The two aggregates behind the gas page scale with the chain and had
+	// reached 14 seconds on sapphire, against a 30-second write timeout. They
+	// cannot be indexed away — attributing gas per realm means touching every
+	// call — so they are precomputed here instead of per request.
+	//
+	// Every five minutes, not every sync pass: these are all-time totals, so
+	// five minutes of staleness costs nothing a reader would notice, and the
+	// recompute takes the write lock for a few seconds. The response carries
+	// computed_at so the page can say how fresh it is rather than implying live.
+	go func() {
+		refresh := func() {
+			start := time.Now()
+			if err := db.RefreshGasRollups(); err != nil {
+				log.Printf("gas rollup: %v", err)
+				return
+			}
+			log.Printf("gas rollup refreshed in %s", time.Since(start).Round(time.Millisecond))
+		}
+		// Wait out the startup ANALYZE before the first build. Both take the
+		// write lock, and racing it loses the whole refresh to SQLITE_BUSY —
+		// which is silent, because the read path just falls back to computing
+		// live and the page stays slow with nothing obviously broken.
+		db.WaitBackground()
+		refresh() // once at startup, so the first visitor is not the one who pays
+
+		ticker := time.NewTicker(gasRollupInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				refresh()
+			}
+		}
+	}()
+
 	// Set up API routes
 	api := NewAPI(db, clients, cfg.Networks, analyzer)
 	mux := http.NewServeMux()


### PR DESCRIPTION
Closes #110. The gas page had reached **14 seconds** on sapphire against a 30-second server write timeout — the same trajectory that broke the address page twice.

```
                  before      after
gas?network=sapphire   11.81s   →   0.038s     (310x)
gas (all networks)      8.92s   →   0.353s     (25x)
gas?network=gnoland1    0.016s  →   0.008s
```

## Why an index could not fix this

#109 already covered the join. What remains is inherent: attributing gas per realm means touching every call — 1,063,672 of them on sapphire to display 20 rows — and the totals sum every transaction. Profiled today, both grow with the chain:

```
by realm      3.44s
totals        1.26s
source bytes  0.02s
TOTAL         4.72s   (C sqlite; the Go driver runs ~2.4x slower)
```

Sapphire grew 51,000 calls in the four days since I last measured, taking the endpoint from 7.6s to 14s.

## Rebuilt on a timer, not maintained per write

Two rollup tables, recomputed wholesale every five minutes inside one transaction, so a reader sees either the old rollup or the new one and never a half-written mixture.

Incremental maintenance would have to be exactly right across re-syncs, backfills and chain resets, any of which would double-count. A periodic recompute is idempotent by construction — and the test asserts a second refresh does not accumulate.

Five minutes rather than per sync pass: these are all-time totals, so that staleness is invisible, and the rebuild takes the write lock for ~12 seconds.

**The response carries `computed_at`, and the page says "totals and per-realm gas as of …".** Precomputed numbers presented as live is exactly the quiet dishonesty this project keeps removing.

If the rollups are not built yet — a fresh database, or the first start after this ships — it computes live rather than returning zeros, which would read as "this chain has used no gas".

## A bug the first run caught

The first verification produced this:

```
gas rollup: database is locked (5) (SQLITE_BUSY)
```

The startup refresh raced the background `ANALYZE`, both wanting the write lock. **The failure is silent by design** — the read path falls back to computing live, so nothing looks broken; the page just stays slow forever. I only saw it because I checked the log rather than only the timings, which were unchanged and would have read as "the rollup did not help".

Two fixes: wait for startup work before the first build (the same `WaitBackground` the dependency re-extraction needed), and retry with backoff so a transient lock costs a few seconds rather than the whole refresh.

## Verified identical, after a false alarm

My first comparison showed every total differing and concluded nothing. That was two servers reading two *different* databases — one live and still syncing, one a snapshot minutes old. Eleven rows of drift, not a correctness problem.

Re-run with both binaries against the **same** snapshot:

```
sapphire      total_txs, gas_used, gas_wanted, fees, success, fail   all OK
              top_realms identical: True (20 rows)
all networks  same
```

Byte-identical, including all twenty realm rows and their gas, fees and counts.
