### PR TITLE
perf: stop deduplicating the same rows twice

### DIFF
--- a/analytics_test.go
+++ b/analytics_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 )
 
 // seedSharedRealm deploys the same package path on two chains and gives it very
@@ -697,4 +698,100 @@ func TestBankRollupKeepsEachRankingsOwnTop(t *testing.T) {
 	if len(s.TopReceiversCnt) == 0 || s.TopReceiversCnt[0].Count != 3 {
 		t.Errorf("top receiver by count = %+v, want one of the frequent receivers", s.TopReceiversCnt)
 	}
+}
+
+// Deduplicating twice costs twice and buys nothing.
+//
+// Five queries wrapped an inner UNION in an outer SELECT DISTINCT over the same
+// key — or, for the time series, a coarser one. The inner dedup could only
+// remove rows the outer one would remove anyway. Measured on production: the
+// active-address series went 4.81s to 2.58s with byte-identical output.
+//
+// This pins the *results*, since that is what switching to UNION ALL could have
+// changed. Duplicate rows are seeded deliberately so a missing outer DISTINCT
+// would show up as inflated counts.
+func TestDedupOnceGivesTheSameCounts(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}, {ID: "b"}})
+
+	when := time.Now().UTC().Add(-2 * time.Hour).Format("2006-01-02T15:04:05Z")
+
+	// One address reachable through every table, on both chains, several times —
+	// so every branch of every union produces rows that overlap the others.
+	for _, net := range []string{"a", "b"} {
+		for i := 0; i < 3; i++ {
+			if err := db.InsertCall(net, fmt.Sprintf("c-%s-%d", net, i), 100+i, when,
+				"g1everywhere", "gno.land/r/demo/boards", "Post", true); err != nil {
+				t.Fatalf("InsertCall: %v", err)
+			}
+			if err := db.InsertBankSend(net, fmt.Sprintf("s-%s-%d", net, i), 200+i, when,
+				"g1everywhere", "g1everywhere", "1ugnot", true); err != nil {
+				t.Fatalf("InsertBankSend: %v", err)
+			}
+		}
+		if err := db.UpsertPackage(net, "gno.land/r/"+net+"/pkg", "pkg", "g1everywhere",
+			net+"-deploy", 300, when, true, 1); err != nil {
+			t.Fatalf("UpsertPackage: %v", err)
+		}
+		if err := db.InsertMsgRun(net, net+"-run", 400, when, "g1everywhere", "package main", true); err != nil {
+			t.Fatalf("InsertMsgRun: %v", err)
+		}
+	}
+
+	t.Run("analytics counts the address once per chain", func(t *testing.T) {
+		a, err := db.GetAnalytics("")
+		if err != nil {
+			t.Fatalf("GetAnalytics: %v", err)
+		}
+		// g1everywhere on two chains = 2. It appears in four tables and as both
+		// sender and receiver; none of that should multiply it.
+		if a.TotalAddresses != 2 {
+			t.Errorf("total addresses = %d, want 2 — the dedup collapsed to the wrong key", a.TotalAddresses)
+		}
+	})
+
+	t.Run("sanity counts the address once per chain", func(t *testing.T) {
+		ov, err := db.GetSanityOverview("")
+		if err != nil {
+			t.Fatalf("GetSanityOverview: %v", err)
+		}
+		if ov.ActiveAddresses24h != 2 {
+			t.Errorf("active addresses = %d, want 2", ov.ActiveAddresses24h)
+		}
+	})
+
+	t.Run("the time series counts it once per bucket per chain", func(t *testing.T) {
+		pts, err := db.GetActiveAddressTimeSeries("", "daily", 7)
+		if err != nil {
+			t.Fatalf("GetActiveAddressTimeSeries: %v", err)
+		}
+		total := 0
+		for _, p := range pts {
+			total += p.TotalActive
+		}
+		// One day of activity, one address, two chains.
+		if total != 2 {
+			t.Errorf("total active across buckets = %d, want 2", total)
+		}
+	})
+
+	t.Run("bank stats count it once per chain, live and rolled up", func(t *testing.T) {
+		live, err := db.GetBankStats("")
+		if err != nil {
+			t.Fatalf("GetBankStats: %v", err)
+		}
+		if err := db.RefreshGasRollups(); err != nil {
+			t.Fatalf("RefreshGasRollups: %v", err)
+		}
+		rolled, err := db.GetBankStats("")
+		if err != nil {
+			t.Fatalf("GetBankStats rolled: %v", err)
+		}
+		if live.UniqueAddresses != 2 {
+			t.Errorf("live unique addresses = %d, want 2", live.UniqueAddresses)
+		}
+		if rolled.UniqueAddresses != live.UniqueAddresses {
+			t.Errorf("rolled=%d live=%d", rolled.UniqueAddresses, live.UniqueAddresses)
+		}
+	})
 }

--- a/db.go
+++ b/db.go
@@ -1922,7 +1922,7 @@ func (d *DB) GetBankStats(network string) (*BankStats, error) {
 
 	d.db.QueryRow(`SELECT COUNT(*) FROM (SELECT DISTINCT addr, network FROM (
 		SELECT from_address as addr, network FROM bank_sends` + nFilter + `
-		UNION SELECT to_address, network FROM bank_sends` + nFilter + `))`).Scan(&s.UniqueAddresses)
+		UNION ALL SELECT to_address, network FROM bank_sends` + nFilter + `))`).Scan(&s.UniqueAddresses)
 	d.db.QueryRow(`SELECT COUNT(*) FROM (SELECT DISTINCT from_address, network FROM bank_sends` + nFilter + `)`).Scan(&s.UniqueSenders)
 	d.db.QueryRow(`SELECT COUNT(*) FROM (SELECT DISTINCT to_address, network FROM bank_sends` + nFilter + `)`).Scan(&s.UniqueReceivers)
 
@@ -2014,10 +2014,16 @@ func (d *DB) GetAnalytics(network string) (*Analytics, error) {
 	// actors with two histories, and collapsing them undercounts: 68,506
 	// blended against 68,806 counted honestly.
 	addrUnionFilter := " WHERE " + d.networkFilter("network", network)
+	// UNION ALL, not UNION.
+	//
+	// The outer SELECT DISTINCT already dedups on the same key (or a coarser
+	// one), so an inner UNION pays for the same deduplication twice. Measured on
+	// production: the active-address series went 4.81s -> 2.58s with byte-
+	// identical results.
 	d.db.QueryRow(`SELECT COUNT(*) FROM (SELECT DISTINCT addr, network FROM (
-		SELECT caller as addr, network FROM calls` + addrUnionFilter + ` UNION SELECT creator, network FROM packages` + addrUnionFilter + `
-		UNION SELECT caller, network FROM msg_runs` + addrUnionFilter + ` UNION SELECT from_address, network FROM bank_sends` + addrUnionFilter + `
-		UNION SELECT to_address, network FROM bank_sends` + addrUnionFilter + `
+		SELECT caller as addr, network FROM calls` + addrUnionFilter + ` UNION ALL SELECT creator, network FROM packages` + addrUnionFilter + `
+		UNION ALL SELECT caller, network FROM msg_runs` + addrUnionFilter + ` UNION ALL SELECT from_address, network FROM bank_sends` + addrUnionFilter + `
+		UNION ALL SELECT to_address, network FROM bank_sends` + addrUnionFilter + `
 	))`).Scan(&a.TotalAddresses)
 	d.db.QueryRow(`SELECT COALESCE(SUM(LENGTH(body)), 0) / 1024 FROM package_files WHERE ` +
 		d.networkFilter("network", network)).Scan(&a.TotalSourceKB)
@@ -2792,10 +2798,16 @@ func (d *DB) GetSanityOverview(network string) (*SanityOverview, error) {
 	// count collapsed an address seen on two chains into one. On production:
 	// 63,404 as written, 63,343 once topaz is excluded, 63,421 counted honestly.
 	addrFilter := " AND " + d.networkFilter("network", network)
+	// UNION ALL, not UNION.
+	//
+	// The outer SELECT DISTINCT already dedups on the same key (or a coarser
+	// one), so an inner UNION pays for the same deduplication twice. Measured on
+	// production: the active-address series went 4.81s -> 2.58s with byte-
+	// identical results.
 	addrQuery := `SELECT COUNT(*) FROM (SELECT DISTINCT addr, network FROM (
 		SELECT caller as addr, network FROM calls WHERE block_time >= ?` + addrFilter + `
-		UNION SELECT creator, network FROM packages WHERE block_time >= ?` + addrFilter + `
-		UNION SELECT from_address, network FROM bank_sends WHERE block_time >= ?` + addrFilter + `
+		UNION ALL SELECT creator, network FROM packages WHERE block_time >= ?` + addrFilter + `
+		UNION ALL SELECT from_address, network FROM bank_sends WHERE block_time >= ?` + addrFilter + `
 	))`
 	d.db.QueryRow(addrQuery, since24h, since24h, since24h).Scan(&ov.ActiveAddresses24h)
 
@@ -2970,8 +2982,8 @@ func (d *DB) GetActiveAddressTimeSeries(network, granularity string, days int) (
 		"SELECT bucket, COUNT(*) as cnt FROM ("+
 			" SELECT DISTINCT strftime('%s', block_time) as bucket, addr, network FROM ("+
 			"  SELECT caller as addr, block_time, network FROM calls WHERE block_time >= ?%s"+
-			"  UNION SELECT creator, block_time, network FROM packages WHERE block_time >= ?%s"+
-			"  UNION SELECT from_address, block_time, network FROM bank_sends WHERE block_time >= ?%s"+
+			"  UNION ALL SELECT creator, block_time, network FROM packages WHERE block_time >= ?%s"+
+			"  UNION ALL SELECT from_address, block_time, network FROM bank_sends WHERE block_time >= ?%s"+
 			" )) GROUP BY bucket ORDER BY bucket ASC",
 		sqlFmt, unionNetFilter, unionNetFilter, unionNetFilter)
 
@@ -3620,7 +3632,7 @@ func (d *DB) refreshBankRollups(tx *sql.Tx) error {
 		       (SELECT COUNT(*) FROM (
 		            SELECT DISTINCT addr FROM (
 		                SELECT from_address addr FROM bank_sends b WHERE b.network = s.network
-		                UNION SELECT to_address FROM bank_sends b WHERE b.network = s.network))),
+		                UNION ALL SELECT to_address FROM bank_sends b WHERE b.network = s.network))),
 		       ` + amountExpr + `
 		FROM bank_sends s WHERE ` + scope + `
 		GROUP BY s.network`); err != nil {


### PR DESCRIPTION
Five queries wrapped an inner `UNION` in an outer `SELECT DISTINCT` over the same key — or, in the time series, a coarser one. The inner deduplication could only ever remove rows the outer one would remove anyway, so it was paid for twice.

Measured on production, both builds against the **same snapshot**:

```
timeseries/active-addresses?days=30   14.65s  ->  8.77s   identical
analytics                              4.26s  ->  4.21s   identical
sanity/overview                        0.43s  ->  0.38s   identical
bankstats                              0.003s ->  0.003s  identical
```

The isolated query, to show where it comes from:

```
UNION      4.813s  buckets=31
UNION ALL  2.583s  buckets=31
identical results: True
```

## Why it is safe

`UNION` deduplicates; `UNION ALL` does not. Dropping the dedup changes results only if nothing downstream removes the duplicates. Here something always does:

- **analytics total addresses** — inner `UNION` on `(addr, network)`, outer `DISTINCT` on `(addr, network)`. Same key.
- **sanity active addresses in 24h** — same shape, same key.
- **active-address time series** — inner on `(addr, block_time, network)`, outer on `(bucket, addr, network)` where `bucket` is a *truncated* `block_time`. Strictly coarser, so the outer pass removes strictly more.
- **bank unique addresses**, in both the rollup and the live fallback — inner on `addr`, outer `DISTINCT addr`. Same key.

## Found by exhausting the cheaper options first

`active-addresses` was 13.7s and is the slowest thing the new dashboards page calls, so it needed attention regardless.

I tried `(network, block_time, addr)` covering indexes on all three tables first. They bought 26% — 6.83s to 5.07s — and the plan still showed `UNION USING TEMP B-TREE`, which is what pointed at the dedup rather than the access path. Those indexes are **not** in this PR: 26% is not worth three indexes on the hottest tables when the actual cause was doing the work twice.

## Test

`TestDedupOnceGivesTheSameCounts` seeds one address reachable through all four tables, on two chains, several times each — so every branch of every union produces rows overlapping the others — then asserts every affected count is 2, one per chain.

It pins the *results*, which is what `UNION ALL` could have broken. A missing outer `DISTINCT` shows up immediately as an inflated count rather than as a subtle drift.

## Still slow

8.8s for `active-addresses` is better but not good, and the dashboards page waits on it. The remaining cost is the outer `DISTINCT` plus three per-bucket distinct counts, none of which an index removes — the same situation that led to the gas and bank rollups. A time-series rollup is the answer but a larger design: it has to store distinct `(day, address)` tuples so weekly and monthly buckets can re-deduplicate correctly rather than summing daily counts. Filing rather than half-building it.
