### PR TITLE
perf: answer the active-address series from stored tuples

### DIFF
--- a/activeaddr_bench_test.go
+++ b/activeaddr_bench_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Production shape, as measured on the sapphire instance and recorded in #137.
+//
+// The point of matching it is that the two read paths are only interestingly
+// different at scale: on a handful of rows the union is instant and the rollup
+// buys nothing. These numbers put the same 1.27M rows, the same 58 days and the
+// same ~110k distinct (network, hour, address) tuples behind both.
+const (
+	benchDays      = 58
+	benchCalls     = 700_000
+	benchSends     = 550_000
+	benchDeploys   = 24_000
+	benchAddresses = 95_000
+
+	// How many distinct addresses are active in one hour on one chain.
+	//
+	// This is the number that decides whether the fixture measures anything.
+	// The rollup's whole value is that 1.27M rows carry only ~110k distinct
+	// (network, hour, address) tuples on production, a ratio of about 11.6 to 1;
+	// a fixture that gives every row its own address stores 1.27M tuples, and
+	// then the rollup is just the same scan under another name. Twenty per
+	// (network, hour) reproduces production's ratio.
+	benchPoolPerHour = 20
+)
+
+// seedProductionScale bulk-loads a chain's worth of activity.
+//
+// Raw SQL in one transaction rather than the Insert* methods: those take the
+// write lock and commit per row, which turns a minute of setup into an hour and
+// measures nothing anyone cares about.
+func seedProductionScale(tb testing.TB, db *DB) {
+	tb.Helper()
+
+	networks := []string{"alpha", "beta"}
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: networks[0]}, {ID: networks[1]}})
+
+	tx, err := db.db.Begin()
+	if err != nil {
+		tb.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+
+	hours := benchDays * 24
+	start := time.Now().UTC().Add(-time.Duration(hours) * time.Hour).Truncate(time.Hour)
+
+	// Rows are dealt out hour by hour: row i lands in hour i%hours on pass
+	// i/hours. The network alternates by pass so both chains get the whole
+	// history, and the address comes from that hour's pool, which is what makes
+	// the fixture compress the way production does.
+	at := func(i int) (string, string, int) {
+		hour, pass := i%hours, i/hours
+		ts := start.Add(time.Duration(hour)*time.Hour + time.Duration(pass%60)*time.Minute)
+		return networks[pass%len(networks)], ts.Format(time.RFC3339), hour
+	}
+	addr := func(i, hour int) string {
+		pass := i / hours
+		return fmt.Sprintf("g1addr%06d",
+			(hour*benchPoolPerHour+(pass/len(networks))%benchPoolPerHour)%benchAddresses)
+	}
+
+	stmt, err := tx.Prepare(`INSERT OR IGNORE INTO calls
+		(network, tx_hash, block_height, block_time, caller, pkg_path, func_name, success)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 1)`)
+	if err != nil {
+		tb.Fatalf("prepare calls: %v", err)
+	}
+	for i := 0; i < benchCalls; i++ {
+		net, ts, hour := at(i)
+		if _, err := stmt.Exec(net, fmt.Sprintf("call%07d", i), i, ts,
+			addr(i, hour), "gno.land/r/demo/boards", "Post"); err != nil {
+			tb.Fatalf("insert call: %v", err)
+		}
+	}
+	stmt.Close()
+
+	stmt, err = tx.Prepare(`INSERT OR IGNORE INTO bank_sends
+		(network, tx_hash, block_height, block_time, from_address, to_address, amount, success)
+		VALUES (?, ?, ?, ?, ?, ?, '1000ugnot', 1)`)
+	if err != nil {
+		tb.Fatalf("prepare sends: %v", err)
+	}
+	for i := 0; i < benchSends; i++ {
+		net, ts, hour := at(i)
+		if _, err := stmt.Exec(net, fmt.Sprintf("send%07d", i), i, ts,
+			addr(i, hour), "g1recipient"); err != nil {
+			tb.Fatalf("insert send: %v", err)
+		}
+	}
+	stmt.Close()
+
+	stmt, err = tx.Prepare(`INSERT OR IGNORE INTO packages
+		(network, path, name, creator, block_height, block_time, tx_hash, is_realm, num_files)
+		VALUES (?, ?, 'pkg', ?, ?, ?, ?, 1, 1)`)
+	if err != nil {
+		tb.Fatalf("prepare packages: %v", err)
+	}
+	for i := 0; i < benchDeploys; i++ {
+		net, ts, hour := at(i)
+		if _, err := stmt.Exec(net, fmt.Sprintf("gno.land/r/bench/p%06d", i),
+			addr(i, hour), i, ts, fmt.Sprintf("pkg%07d", i)); err != nil {
+			tb.Fatalf("insert package: %v", err)
+		}
+	}
+	stmt.Close()
+
+	if err := tx.Commit(); err != nil {
+		tb.Fatalf("commit: %v", err)
+	}
+}
+
+// BenchmarkActiveAddressSeries measures both read paths against one database.
+//
+//	go test -run '^$' -bench ActiveAddressSeries -benchtime 3x
+//
+// The live sub-benchmarks run before the refresh, so the dispatch in
+// GetActiveAddressTimeSeries picks the fallback; the rolled-up ones run after
+// it. Same fixture, same public entry point, so the difference is the path.
+func BenchmarkActiveAddressSeries(b *testing.B) {
+	db := newTestDB(b)
+
+	seedStart := time.Now()
+	seedProductionScale(b, db)
+	b.Logf("seeded %d rows in %s", benchCalls+benchSends+benchDeploys,
+		time.Since(seedStart).Round(time.Millisecond))
+
+	windows := []struct {
+		name        string
+		days        int
+		granularity string
+	}{
+		{"24h", 1, "hourly"},
+		{"7d", 7, "daily"},
+		{"90d", 90, "daily"},
+		{"1y", 365, "monthly"},
+	}
+
+	run := func(b *testing.B, days int, granularity string) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := db.GetActiveAddressTimeSeries("", granularity, days); err != nil {
+				b.Fatalf("GetActiveAddressTimeSeries: %v", err)
+			}
+		}
+	}
+
+	for _, w := range windows {
+		b.Run("live/"+w.name, func(b *testing.B) { run(b, w.days, w.granularity) })
+	}
+
+	refreshStart := time.Now()
+	if err := db.RefreshRollups(); err != nil {
+		b.Fatalf("RefreshRollups: %v", err)
+	}
+	b.Logf("rollup rebuilt in %s", time.Since(refreshStart).Round(time.Millisecond))
+
+	var tuples int
+	if err := db.db.QueryRow(`SELECT COUNT(*) FROM active_addr_rollup`).Scan(&tuples); err != nil {
+		b.Fatalf("count tuples: %v", err)
+	}
+	b.Logf("rollup holds %d tuples", tuples)
+
+	for _, w := range windows {
+		b.Run("rolledup/"+w.name, func(b *testing.B) { run(b, w.days, w.granularity) })
+	}
+}

--- a/activeaddr_test.go
+++ b/activeaddr_test.go
@@ -1,0 +1,468 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// seedActiveAt puts one address into all three activity tables at one instant.
+//
+// The three tables are what "active address" means: a caller, a deployer, a
+// sender. Seeding through the public inserters rather than raw SQL keeps the
+// test honest about the shape the syncer actually writes.
+func seedActiveAt(t *testing.T, db *DB, network, addr string, when time.Time, id string) {
+	t.Helper()
+	ts := when.UTC().Format("2006-01-02T15:04:05Z")
+	if err := db.InsertCall(network, "call-"+id, 1, ts, addr, "gno.land/r/demo/boards", "Post", true); err != nil {
+		t.Fatalf("InsertCall: %v", err)
+	}
+	if err := db.UpsertPackage(network, "gno.land/r/"+network+"/"+id, id, addr, "pkg-"+id, 2, ts, true, 1); err != nil {
+		t.Fatalf("UpsertPackage: %v", err)
+	}
+	if err := db.InsertBankSend(network, "send-"+id, 3, ts, addr, "g1recipient", "1ugnot", true); err != nil {
+		t.Fatalf("InsertBankSend: %v", err)
+	}
+}
+
+// An address active on several days is one weekly active address, not several.
+//
+// This is the specific error a count-per-day rollup would introduce: summing
+// daily counts to answer a weekly question overcounts anyone who came back, and
+// the error grows with the bucket width — worst on the 1y and all windows,
+// which is exactly where the number matters most. Storing distinct tuples
+// rather than counts is what makes the wider buckets re-deduplicate instead.
+func TestWiderBucketsCountAReturningAddressOnce(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}})
+
+	// Three days inside one ISO week and one month. Anchored on a Wednesday so
+	// that "three consecutive days" cannot straddle a week boundary whatever
+	// day the test runs.
+	base := time.Now().UTC().Add(-72 * time.Hour)
+	for base.Weekday() != time.Wednesday {
+		base = base.Add(-24 * time.Hour)
+	}
+	for i := 0; i < 3; i++ {
+		seedActiveAt(t, db, "a", "g1regular", base.Add(time.Duration(i)*24*time.Hour), fmt.Sprintf("d%d", i))
+	}
+
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
+	}
+
+	for _, tc := range []struct {
+		granularity string
+		want        int
+	}{
+		{"daily", 3},   // one per day it was active
+		{"weekly", 1},  // still one address
+		{"monthly", 1}, // still one address
+	} {
+		t.Run(tc.granularity, func(t *testing.T) {
+			pts, err := db.GetActiveAddressTimeSeries("", tc.granularity, 30)
+			if err != nil {
+				t.Fatalf("GetActiveAddressTimeSeries: %v", err)
+			}
+			total := 0
+			for _, p := range pts {
+				total += p.TotalActive
+			}
+			if total != tc.want {
+				t.Errorf("total active across %s buckets = %d, want %d", tc.granularity, total, tc.want)
+			}
+		})
+	}
+}
+
+// seedMixedActivity lays down a spread of activity designed to make a wrong
+// rollup disagree with the live query: several addresses, several chains
+// including one that is not configured, several kinds, and returning visitors
+// at hour, day, week and month distances.
+func seedMixedActivity(t *testing.T, db *DB) {
+	t.Helper()
+	now := time.Now().UTC()
+	n := 0
+	id := func() string { n++; return fmt.Sprintf("m%d", n) }
+
+	for _, net := range []string{"a", "b", "retired"} {
+		for _, back := range []time.Duration{
+			90 * time.Minute, 5 * time.Hour, 26 * time.Hour,
+			3 * 24 * time.Hour, 9 * 24 * time.Hour, 40 * 24 * time.Hour,
+		} {
+			when := now.Add(-back)
+			// Two addresses per instant: one that appears everywhere (so every
+			// branch of the union overlaps) and one unique to this instant.
+			seedActiveAt(t, db, net, "g1everywhere", when, id())
+			seedActiveAt(t, db, net, "g1"+net+fmt.Sprint(int(back.Hours())), when, id())
+
+			// A caller-only address, so the per-kind counts are not all equal.
+			if err := db.InsertCall(net, "conly-"+id(), 4, when.Format("2006-01-02T15:04:05Z"),
+				"g1calleronly", "gno.land/r/demo/boards", "Post", true); err != nil {
+				t.Fatalf("InsertCall: %v", err)
+			}
+		}
+	}
+}
+
+// The rollup must answer exactly what the live query answered.
+//
+// Same database, same windows, same granularities — the only difference is
+// which path produced the numbers. Before the first refresh the read falls back
+// to computing live, so capturing the series then and re-reading it after the
+// refresh diffs the two implementations against one snapshot.
+func TestRollupMatchesLiveComputationAtEveryGranularity(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}, {ID: "b"}})
+	seedMixedActivity(t, db)
+
+	type key struct {
+		network     string
+		granularity string
+		days        int
+	}
+	cases := []key{}
+	for _, net := range []string{"", "a", "b"} {
+		for _, g := range []string{"hourly", "daily", "weekly", "monthly"} {
+			for _, d := range []int{1, 7, 30, 365} {
+				cases = append(cases, key{net, g, d})
+			}
+		}
+	}
+
+	live := map[key][]ActiveAddressTimePoint{}
+	for _, c := range cases {
+		pts, err := db.GetActiveAddressTimeSeries(c.network, c.granularity, c.days)
+		if err != nil {
+			t.Fatalf("live %v: %v", c, err)
+		}
+		if len(pts) == 0 {
+			t.Fatalf("live %v returned no buckets — the fixture is not exercising anything", c)
+		}
+		live[c] = pts
+	}
+
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
+	}
+
+	for _, c := range cases {
+		got, err := db.GetActiveAddressTimeSeries(c.network, c.granularity, c.days)
+		if err != nil {
+			t.Fatalf("rolled %v: %v", c, err)
+		}
+		if !reflect.DeepEqual(got, live[c]) {
+			t.Errorf("network=%q granularity=%s days=%d\n rolled up: %+v\n live:      %+v",
+				c.network, c.granularity, c.days, got, live[c])
+		}
+	}
+}
+
+// A rollup built five minutes ago must not hide what happened since.
+//
+// The rebuild runs on a timer, so between two builds the newest rows exist only
+// in the source tables. Serving the series from the rollup alone would make the
+// current bucket lag by up to the refresh interval — visible on the 24h chart,
+// and enough to make this endpoint disagree with the live transaction feed
+// sitting next to it on the same page. Whatever the rollup does not cover yet
+// has to be read live and merged in.
+func TestSeriesIncludesActivityNewerThanTheRollup(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}})
+
+	seedActiveAt(t, db, "a", "g1early", time.Now().UTC().Add(-30*time.Hour), "early")
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
+	}
+
+	// Arrives after the rollup was built, as a live chain constantly does.
+	seedActiveAt(t, db, "a", "g1latecomer", time.Now().UTC(), "late")
+
+	pts, err := db.GetActiveAddressTimeSeries("", "daily", 7)
+	if err != nil {
+		t.Fatalf("GetActiveAddressTimeSeries: %v", err)
+	}
+	total := 0
+	for _, p := range pts {
+		total += p.TotalActive
+	}
+	if total != 2 {
+		t.Errorf("total active = %d, want 2 — the address that arrived after the rollup was built is missing", total)
+	}
+}
+
+// The merge of rolled-up and live rows must not count the overlap twice.
+//
+// The rollup covers everything up to the moment it was built, which includes
+// part of the hour it was built in. Reading that same hour live as well means
+// the same address arrives from both sides, and the merge has to collapse it.
+func TestMergingRollupAndLiveRowsDoesNotDoubleCount(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}})
+
+	// In the current hour, so it lands on both sides of the boundary.
+	seedActiveAt(t, db, "a", "g1boundary", time.Now().UTC(), "boundary")
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
+	}
+
+	pts, err := db.GetActiveAddressTimeSeries("", "hourly", 1)
+	if err != nil {
+		t.Fatalf("GetActiveAddressTimeSeries: %v", err)
+	}
+	total := 0
+	for _, p := range pts {
+		total += p.TotalActive
+	}
+	if total != 1 {
+		t.Errorf("total active = %d, want 1 — the rolled-up and live copies of the same address were both counted", total)
+	}
+}
+
+// Rows belonging to a network nobody configured are not this explorer's data.
+//
+// An empty network filter means "every configured network", never "every
+// network ever synced". Retired chains keep their rows, and counting them is
+// how the realm-count mismatch in #115 happened; the rollup must not
+// reintroduce it by aggregating over everything it can see.
+func TestRollupExcludesUnconfiguredNetworks(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}})
+
+	when := time.Now().UTC().Add(-2 * time.Hour)
+	seedActiveAt(t, db, "a", "g1configured", when, "cfg")
+	seedActiveAt(t, db, "retired", "g1retired", when, "old")
+
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
+	}
+
+	pts, err := db.GetActiveAddressTimeSeries("", "daily", 7)
+	if err != nil {
+		t.Fatalf("GetActiveAddressTimeSeries: %v", err)
+	}
+	total := 0
+	for _, p := range pts {
+		total += p.TotalActive
+	}
+	if total != 1 {
+		t.Errorf("total active = %d, want 1 — a retired network's rows were counted", total)
+	}
+}
+
+// The same address on two chains is two actors, in the rollup as everywhere.
+func TestRollupCountsAnAddressOncePerChain(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}, {ID: "b"}})
+
+	when := time.Now().UTC().Add(-2 * time.Hour)
+	seedActiveAt(t, db, "a", "g1everywhere", when, "a1")
+	seedActiveAt(t, db, "b", "g1everywhere", when, "b1")
+
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
+	}
+
+	pts, err := db.GetActiveAddressTimeSeries("", "daily", 7)
+	if err != nil {
+		t.Fatalf("GetActiveAddressTimeSeries: %v", err)
+	}
+	total := 0
+	for _, p := range pts {
+		total += p.TotalActive
+	}
+	if total != 2 {
+		t.Errorf("total active = %d, want 2 — one address on two chains is two actors", total)
+	}
+}
+
+// A chain reset drops the network's rows; the rollup's copy has to go too.
+//
+// DeleteNetworkData exists because a reset makes the stored history refer to
+// blocks that no longer exist. A rollup row surviving that would keep counting
+// an address whose activity has been deleted, until the next refresh — and the
+// next refresh is up to five minutes away.
+func TestChainResetClearsTheRolledUpTuples(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}, {ID: "b"}})
+
+	when := time.Now().UTC().Add(-2 * time.Hour)
+	seedActiveAt(t, db, "a", "g1onreset", when, "r1")
+	seedActiveAt(t, db, "b", "g1survivor", when, "r2")
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
+	}
+
+	if _, err := db.DeleteNetworkData("a"); err != nil {
+		t.Fatalf("DeleteNetworkData: %v", err)
+	}
+
+	pts, err := db.GetActiveAddressTimeSeries("", "daily", 7)
+	if err != nil {
+		t.Fatalf("GetActiveAddressTimeSeries: %v", err)
+	}
+	total := 0
+	for _, p := range pts {
+		total += p.TotalActive
+	}
+	if total != 1 {
+		t.Errorf("total active = %d, want 1 — the reset chain's rolled-up tuples outlived its rows", total)
+	}
+}
+
+// The sanity page's 24h figure deliberately stays live, and the rollup must not
+// quietly change it.
+//
+// It looks like the same question the series answers, and #137 suggests folding
+// it in, but its window is "the last 24 hours" to the second, while the stored
+// grain is the hour. Serving it from the rolled-up tuples would have to round
+// the window out to an hour boundary and would count up to an extra hour of
+// activity — a different number, arrived at by a change that was supposed to be
+// about speed. It is also a single 24h window over an indexed block_time, which
+// is not what was slow. This pins that it keeps answering exactly as before.
+func TestSanityActiveAddressesStayLiveAcrossARefresh(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}, {ID: "b"}})
+	seedMixedActivity(t, db)
+
+	liveOv, err := db.GetSanityOverview("")
+	if err != nil {
+		t.Fatalf("GetSanityOverview: %v", err)
+	}
+	if liveOv.ActiveAddresses24h == 0 {
+		t.Fatal("live active addresses 24h = 0 — the fixture is not exercising anything")
+	}
+
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
+	}
+
+	rolledOv, err := db.GetSanityOverview("")
+	if err != nil {
+		t.Fatalf("GetSanityOverview: %v", err)
+	}
+	if rolledOv.ActiveAddresses24h != liveOv.ActiveAddresses24h {
+		t.Errorf("rolled up = %d, live = %d", rolledOv.ActiveAddresses24h, liveOv.ActiveAddresses24h)
+	}
+}
+
+// The hour the window opens in belongs half outside the window.
+//
+// "The last 7 days" starts at an instant, not on an hour boundary, but the
+// stored grain is the hour: a tuple says an address was active somewhere in that
+// hour, never whether it was before or after 14:23. Reading that opening hour
+// from the rollup would count activity from before the window and inflate the
+// first bucket — invisibly, because the first bucket of a chart is exactly where
+// nobody checks.
+//
+// Seeding one address per minute across the two hours around the boundary means
+// some fall inside the window and some outside it whatever time the test runs,
+// so the two paths can only agree if the opening hour is handled to the second.
+func TestWindowOpeningHourMatchesLive(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}})
+
+	const days = 7
+	openingHour := time.Now().UTC().AddDate(0, 0, -days).Truncate(time.Hour)
+	for i := -60; i <= 60; i++ {
+		when := openingHour.Add(time.Duration(i) * time.Minute)
+		if err := db.InsertCall("a", fmt.Sprintf("edge%d", i), 1,
+			when.Format("2006-01-02T15:04:05Z"), fmt.Sprintf("g1edge%03d", i+60),
+			"gno.land/r/demo/boards", "Post", true); err != nil {
+			t.Fatalf("InsertCall: %v", err)
+		}
+	}
+
+	for _, granularity := range []string{"hourly", "daily"} {
+		live, err := db.GetActiveAddressTimeSeries("", granularity, days)
+		if err != nil {
+			t.Fatalf("live %s: %v", granularity, err)
+		}
+		if err := db.RefreshRollups(); err != nil {
+			t.Fatalf("RefreshRollups: %v", err)
+		}
+		rolled, err := db.GetActiveAddressTimeSeries("", granularity, days)
+		if err != nil {
+			t.Fatalf("rolled %s: %v", granularity, err)
+		}
+		if !reflect.DeepEqual(rolled, live) {
+			t.Errorf("%s: first bucket disagrees across the window edge\n rolled up: %+v\n live:      %+v",
+				granularity, rolled[0], live[0])
+		}
+	}
+}
+
+// The stored grain is one tuple per (network, hour, kind, address).
+//
+// Hourly rather than daily because the two measured within 15% of each other on
+// production (110,073 hourly tuples against 95,615 daily, from 1.27M raw rows),
+// and the finer grain removes the need for a second table or a live path for the
+// 24h and 7d windows. Repeat activity inside an hour collapses; the next hour is
+// a new tuple, which is what lets a wider bucket re-deduplicate exactly.
+func TestRollupStoresOneTuplePerAddressPerHourPerKind(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}})
+
+	hour := time.Now().UTC().Truncate(time.Hour).Add(-3 * time.Hour)
+	for i, offset := range []time.Duration{5 * time.Minute, 25 * time.Minute, 45 * time.Minute} {
+		seedActiveAt(t, db, "a", "g1busy", hour.Add(offset), fmt.Sprintf("same%d", i))
+	}
+	// A different hour is a different tuple.
+	seedActiveAt(t, db, "a", "g1busy", hour.Add(-2*time.Hour), "other")
+
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
+	}
+
+	var n int
+	if err := db.db.QueryRow(`SELECT COUNT(*) FROM active_addr_rollup`).Scan(&n); err != nil {
+		t.Fatalf("count rollup: %v", err)
+	}
+	// Two hours x three kinds x one address.
+	if n != 6 {
+		t.Errorf("rollup holds %d tuples, want 6 — the grain is not one row per (network, hour, kind, address)", n)
+	}
+
+	var earliest string
+	if err := db.db.QueryRow(`SELECT MIN(bucket) FROM active_addr_rollup`).Scan(&earliest); err != nil {
+		t.Fatalf("min bucket: %v", err)
+	}
+	if want := hour.Add(-2 * time.Hour).Format("2006-01-02T15"); earliest != want {
+		t.Errorf("earliest bucket = %q, want %q", earliest, want)
+	}
+}
+
+// Settled history is answered from the rollup, not recomputed from the union.
+//
+// Checked by mutation: the source rows are deleted after the refresh, leaving
+// only the rolled-up tuples. A read that still reports the day it deleted can
+// only have got the number from the rollup — which is the whole point of
+// building one, and the part a correctness-only test cannot observe.
+func TestSeriesReadsSettledHistoryFromTheRollup(t *testing.T) {
+	db := newTestDB(t)
+	db.SetConfiguredNetworks([]NetworkConfig{{ID: "a"}})
+
+	seedActiveAt(t, db, "a", "g1historic", time.Now().UTC().Add(-30*time.Hour), "h1")
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
+	}
+
+	for _, table := range []string{"calls", "packages", "bank_sends"} {
+		if _, err := db.db.Exec(`DELETE FROM ` + table); err != nil {
+			t.Fatalf("delete %s: %v", table, err)
+		}
+	}
+
+	pts, err := db.GetActiveAddressTimeSeries("", "daily", 7)
+	if err != nil {
+		t.Fatalf("GetActiveAddressTimeSeries: %v", err)
+	}
+	total := 0
+	for _, p := range pts {
+		total += p.TotalActive
+	}
+	if total != 1 {
+		t.Errorf("total active = %d, want 1 — the read recomputed from the source tables instead of reading the rollup", total)
+	}
+}

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -484,8 +484,8 @@ func TestGasRollups(t *testing.T) {
 		}
 	})
 
-	if err := db.RefreshGasRollups(); err != nil {
-		t.Fatalf("RefreshGasRollups: %v", err)
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
 	}
 
 	t.Run("the rollup gives the same answer", func(t *testing.T) {
@@ -540,8 +540,8 @@ func TestGasRollups(t *testing.T) {
 
 	t.Run("a refresh replaces rather than accumulates", func(t *testing.T) {
 		// Whole-table replacement, so running it twice must not double anything.
-		if err := db.RefreshGasRollups(); err != nil {
-			t.Fatalf("RefreshGasRollups: %v", err)
+		if err := db.RefreshRollups(); err != nil {
+			t.Fatalf("RefreshRollups: %v", err)
 		}
 		stats, err := db.GetGasStats("live", 10)
 		if err != nil {
@@ -575,8 +575,8 @@ func TestBankRollupMatchesLiveComputation(t *testing.T) {
 		t.Error("computed_at set before any refresh")
 	}
 
-	if err := db.RefreshGasRollups(); err != nil {
-		t.Fatalf("RefreshGasRollups: %v", err)
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
 	}
 
 	rolled, err := db.GetBankStats("")
@@ -679,8 +679,8 @@ func TestBankRollupKeepsEachRankingsOwnTop(t *testing.T) {
 		t.Fatalf("InsertBankSend: %v", err)
 	}
 
-	if err := db.RefreshGasRollups(); err != nil {
-		t.Fatalf("RefreshGasRollups: %v", err)
+	if err := db.RefreshRollups(); err != nil {
+		t.Fatalf("RefreshRollups: %v", err)
 	}
 	s, err := db.GetBankStats("n")
 	if err != nil {
@@ -780,8 +780,8 @@ func TestDedupOnceGivesTheSameCounts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetBankStats: %v", err)
 		}
-		if err := db.RefreshGasRollups(); err != nil {
-			t.Fatalf("RefreshGasRollups: %v", err)
+		if err := db.RefreshRollups(); err != nil {
+			t.Fatalf("RefreshRollups: %v", err)
 		}
 		rolled, err := db.GetBankStats("")
 		if err != nil {

--- a/db.go
+++ b/db.go
@@ -454,6 +454,39 @@ func initSchema(db *sql.DB) error {
 			PRIMARY KEY (network, kind, address)
 		);
 
+		-- Active addresses, stored as distinct tuples rather than as counts.
+		--
+		-- /api/timeseries/active-addresses was the slowest endpoint on the site
+		-- at 15.9s on production, and the one the dashboards page waits on. The
+		-- question — how many distinct addresses were active in each bucket —
+		-- means touching every call, deploy and send in the window and
+		-- deduplicating them per bucket, which no index removes: covering
+		-- indexes on (network, block_time, addr) bought 26% and left the plan
+		-- still building a temp B-tree.
+		--
+		-- Counts per day would not work. An address active on three days of a
+		-- week is one weekly active address, not three, so summing daily counts
+		-- overcounts, and the error grows with the bucket width — worst on the
+		-- 1y and all windows, where the number matters most. Storing the tuples
+		-- keeps every granularity exact, because the stored grain is finer than
+		-- anything served: hourly counts the tuples, wider buckets re-deduplicate.
+		--
+		-- Hourly is a measurement, not a guess. On the production database
+		-- 1,274,004 raw rows reduce to 95,615 distinct (network, day, address)
+		-- and 110,073 distinct (network, hour, address) — hourly is only 15%
+		-- larger than daily, so one table serves every window and no separate
+		-- live path is needed for 24h and 7d. Growth is ~1,650 rows/day.
+		--
+		-- WITHOUT ROWID: every column is part of the key, so a rowid would be a
+		-- second b-tree storing the same data twice.
+		CREATE TABLE IF NOT EXISTS active_addr_rollup (
+			network TEXT NOT NULL,
+			bucket  TEXT NOT NULL,   -- UTC hour, 'YYYY-MM-DDTHH'
+			kind    TEXT NOT NULL,   -- callers | deployers | senders
+			addr    TEXT NOT NULL,
+			PRIMARY KEY (network, bucket, kind, addr)
+		) WITHOUT ROWID;
+
 		CREATE TABLE IF NOT EXISTS sync_state (
 			key TEXT PRIMARY KEY,
 			value TEXT NOT NULL
@@ -843,6 +876,18 @@ func (d *DB) DeleteNetworkData(network string) (int64, error) {
 			total += n
 		}
 	}
+
+	// Derived rows go too, in the same transaction.
+	//
+	// Not counted in the total: the caller reports how much *data* a reset threw
+	// away, and a rollup tuple is a restatement of rows already counted above.
+	// Leaving them would keep the series reporting activity for a chain whose
+	// history has just been deleted, until the next refresh up to five minutes
+	// later — which is the stale-after-reset shape #19 was about.
+	if _, err := tx.Exec(`DELETE FROM active_addr_rollup WHERE network = ?`, network); err != nil {
+		return 0, fmt.Errorf("delete from active_addr_rollup: %w", err)
+	}
+
 	if err := tx.Commit(); err != nil {
 		return 0, err
 	}
@@ -1941,7 +1986,7 @@ func (d *DB) bankRollupReady() (bool, string) {
 		return false, ""
 	}
 	var at string
-	d.db.QueryRow(`SELECT value FROM sync_state WHERE key = ?`, gasRollupKey).Scan(&at)
+	d.db.QueryRow(`SELECT value FROM sync_state WHERE key = ?`, rollupComputedAtKey).Scan(&at)
 	return true, at
 }
 
@@ -2914,10 +2959,30 @@ func (d *DB) GetRealmsWithStorage(network string, days int) ([]string, error) {
 	return paths, rows.Err()
 }
 
+// GetActiveAddressTimeSeries answers how many distinct addresses were active in
+// each bucket, from the rollup where it can and from the source tables where it
+// must.
+//
+// Before the first refresh there is no rollup — a fresh database, or the first
+// start after this shipped — and the whole series is computed live rather than
+// reported as zero, which would read as "nobody has ever used this chain".
 func (d *DB) GetActiveAddressTimeSeries(network, granularity string, days int) ([]ActiveAddressTimePoint, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
+	if boundary, ok := d.activeAddrRollupBoundary(); ok {
+		return d.activeAddrSeriesRolledUp(network, granularity, days, boundary)
+	}
+	return d.activeAddrSeriesLive(network, granularity, days)
+}
+
+// activeAddrSeriesLive computes the series from calls, packages and bank_sends.
+//
+// This is what the endpoint used to do on every request: 15.9s on production,
+// growing with the chain. It stays as the fallback for a database whose rollup
+// has not been built yet, and as the reference the rollup path is diffed
+// against. Callers hold the read lock.
+func (d *DB) activeAddrSeriesLive(network, granularity string, days int) ([]ActiveAddressTimePoint, error) {
 	sqlFmt, step, truncFn := timeseriesFormat(granularity)
 	startTime := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
 
@@ -3008,6 +3073,167 @@ func (d *DB) GetActiveAddressTimeSeries(network, granularity string, days int) (
 		return nil, err
 	}
 
+	return activeAddrPoints(buckets, days, granularity, step, truncFn), nil
+}
+
+// activeAddrSeriesRolledUp answers the same question from the stored tuples,
+// merged with whatever is newer than the rollup.
+//
+// One statement, one shared source. The rolled-up hours and the live tail feed
+// the same deduplication rather than being counted separately and added, because
+// adding them would double-count every address that was active on both sides of
+// the boundary — which, on any bucket wider than an hour, is most of them.
+//
+// Both counts come back from one round trip: the per-kind figures grouped by
+// (bucket, kind), and the union total grouped by bucket, unioned into the
+// (bucket, typ, count) shape the live path already returns. Callers hold the
+// read lock.
+func (d *DB) activeAddrSeriesRolledUp(network, granularity string, days int, boundary time.Time) ([]ActiveAddressTimePoint, error) {
+	_, step, truncFn := timeseriesFormat(granularity)
+
+	start := time.Now().UTC().AddDate(0, 0, -days)
+	netFilter := d.networkFilter("network", network)
+
+	// The window opens at an instant — "now minus 30 days" — and the stored
+	// grain is the hour, so the hour the window opens in cannot be answered from
+	// the rollup: its tuples say the address was active somewhere in that hour,
+	// not whether it was before or after 14:23. Taking the whole hour would make
+	// the first bucket count activity from outside the window and disagree with
+	// the live path by exactly the rows in between. So the rollup starts at the
+	// next whole hour and that opening hour is read live.
+	firstWholeHour := start.Truncate(time.Hour)
+	if firstWholeHour.Before(start) {
+		firstWholeHour = firstWholeHour.Add(time.Hour)
+	}
+
+	// Buckets are fixed-width UTC hours, so string comparison is chronological
+	// and the primary key's leading (network, bucket) serves the range directly.
+	branches := []string{fmt.Sprintf(
+		"SELECT bucket AS hour, network, kind, addr FROM active_addr_rollup"+
+			" WHERE bucket >= ? AND bucket < ? AND %s", netFilter)}
+	args := []any{firstWholeHour.Format(activeAddrBucketLayout), boundary.Format(activeAddrBucketLayout)}
+
+	// The two stretches the rollup does not cover: the hour the window opens in,
+	// and everything newer than the build.
+	//
+	// They overlap whenever the last build is older than the window, and that is
+	// harmless rather than lucky — every branch feeds the same SELECT DISTINCT,
+	// and a row reaching it from two branches is identical in all four columns,
+	// so it collapses. Counting the stretches separately and adding them up is
+	// what would double.
+	liveWindows := []struct{ from, until time.Time }{
+		{start, firstWholeHour},
+		{boundary, time.Time{}},
+	}
+	for _, k := range activeAddrKinds {
+		for _, w := range liveWindows {
+			cond := "block_time >= ?"
+			args = append(args, w.from.Format(time.RFC3339))
+			if !w.until.IsZero() {
+				cond += " AND block_time < ?"
+				args = append(args, w.until.Format(time.RFC3339))
+			}
+			branches = append(branches, fmt.Sprintf(
+				"SELECT strftime('%%Y-%%m-%%dT%%H', block_time), network, '%s', %s FROM %s"+
+					" WHERE %s AND %s", k.kind, k.column, k.table, cond, netFilter))
+		}
+	}
+
+	// MATERIALIZED because src is read twice — once per grouping — and without
+	// it SQLite is free to inline the union into both, paying for the whole scan
+	// twice over.
+	//
+	// Chaining a second CTE, so that the total dedups the per-kind result rather
+	// than the raw union again, looks like it should be strictly cheaper and
+	// measured as noise on the wide windows and a regression on 24h: it trades
+	// one scan of src for an extra materialisation and re-sort, and the two are
+	// the same size whenever the bucket is the stored hour. Left as two passes.
+	bucket := activeAddrBucketExpr(granularity)
+	q := fmt.Sprintf(`
+		WITH src(hour, network, kind, addr) AS MATERIALIZED (%s)
+		SELECT bucket, kind AS typ, COUNT(*) AS cnt FROM (
+			SELECT DISTINCT %s AS bucket, kind, network, addr FROM src
+		) GROUP BY bucket, kind
+		UNION ALL
+		SELECT bucket, 'total' AS typ, COUNT(*) AS cnt FROM (
+			SELECT DISTINCT %s AS bucket, network, addr FROM src
+		) GROUP BY bucket`,
+		strings.Join(branches, " UNION ALL "), bucket, bucket)
+
+	rows, err := d.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	buckets := make(map[string]*ActiveAddressTimePoint)
+	for rows.Next() {
+		var bucket, typ string
+		var cnt int
+		if err := rows.Scan(&bucket, &typ, &cnt); err != nil {
+			return nil, err
+		}
+		pt, ok := buckets[bucket]
+		if !ok {
+			pt = &ActiveAddressTimePoint{Time: bucket}
+			buckets[bucket] = pt
+		}
+		switch typ {
+		case "callers":
+			pt.UniqueCallers = cnt
+		case "deployers":
+			pt.UniqueDeployers = cnt
+		case "senders":
+			pt.UniqueSenders = cnt
+		case "total":
+			pt.TotalActive = cnt
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return activeAddrPoints(buckets, days, granularity, step, truncFn), nil
+}
+
+// activeAddrBucketLayout is the stored bucket format: a UTC hour, fixed width so
+// that lexical order is chronological order.
+const activeAddrBucketLayout = "2006-01-02T15"
+
+// activeAddrBucketExpr maps a stored hour bucket onto the requested
+// granularity's key, and must agree with bucketKey for every granularity or the
+// series returns buckets the fill loop then cannot find.
+//
+// Three of the four are a prefix of 'YYYY-MM-DDTHH' rather than a strftime call,
+// which is not micro-optimisation: strftime parses a date string per row, and
+// the 90d window puts 135k rows through it. Only the ISO week needs real
+// calendar arithmetic.
+func activeAddrBucketExpr(granularity string) string {
+	switch granularity {
+	case "hourly":
+		return "hour"
+	case "weekly":
+		return "strftime('%G-W%V', hour || ':00:00')"
+	case "monthly":
+		return "substr(hour, 1, 7)"
+	default:
+		return "substr(hour, 1, 10)"
+	}
+}
+
+// activeAddrPoints turns the bucket map into the dense series the API returns,
+// filling the buckets nothing happened in.
+//
+// Shared by both read paths on purpose: an endpoint that answers with a
+// different set of buckets depending on whether a rollup happens to be built is
+// the same bug as answering with different numbers.
+func activeAddrPoints(
+	buckets map[string]*ActiveAddressTimePoint,
+	days int,
+	granularity string,
+	step time.Duration,
+	truncFn func(time.Time) time.Time,
+) []ActiveAddressTimePoint {
 	now := time.Now().UTC()
 	start := truncFn(now.AddDate(0, 0, -days))
 	end := truncFn(now)
@@ -3020,7 +3246,7 @@ func (d *DB) GetActiveAddressTimeSeries(network, granularity string, days int) (
 			out = append(out, ActiveAddressTimePoint{Time: k})
 		}
 	}
-	return out, nil
+	return out
 }
 
 // AddressLabel is a display name for an address, derived from on-chain data.
@@ -3511,21 +3737,27 @@ func (d *DB) AddressTransactions(network, addr string, limit, offset int) ([]Sto
 
 // --- Gas rollups ------------------------------------------------------------
 
-// gasRollupKey records when the rollups were last recomputed, so the page can
-// say how fresh its numbers are rather than presenting stale ones as live.
-const gasRollupKey = "gas_rollup_at"
+// rollupComputedAtKey records when the rollups were last recomputed, so the page
+// can say how fresh its numbers are rather than presenting stale ones as live —
+// and so the active-address series knows from which instant it has to stop
+// trusting stored tuples and read the source tables instead.
+//
+// The stored key still says "gas" because it was written by the first rollup to
+// need it and renaming it would reset every deployed instance's freshness stamp
+// to "never built" for one refresh interval.
+const rollupComputedAtKey = "gas_rollup_at"
 
-// gasRollupInterval is how often the rollups are rebuilt. These are all-time
+// rollupInterval is how often the rollups are rebuilt. These are all-time
 // aggregates, so minutes of staleness is invisible to a reader — and the
 // recompute takes the write lock, so doing it per sync pass would mean holding
 // it every 30 seconds for the sake of numbers nobody watches change.
-const gasRollupInterval = 5 * time.Minute
+const rollupInterval = 5 * time.Minute
 
 // bankTopRollupLimit is how many rows each bank leaderboard keeps. The read
 // shows ten; the slack absorbs a network filter narrowing the set afterwards.
 const bankTopRollupLimit = 400
 
-// RefreshGasRollups recomputes both gas aggregates for every configured network.
+// RefreshRollups recomputes both gas aggregates for every configured network.
 //
 // This is the expensive query the gas page used to run per request — 3.4s for
 // the realm attribution and 1.3s for the totals on sapphire, and both grow with
@@ -3533,7 +3765,7 @@ const bankTopRollupLimit = 400
 //
 // Whole-table replacement inside one transaction: readers see either the old
 // rollup or the new one, never a half-written mixture.
-func (d *DB) RefreshGasRollups() error {
+func (d *DB) RefreshRollups() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -3545,14 +3777,14 @@ func (d *DB) RefreshGasRollups() error {
 		if attempt > 0 {
 			time.Sleep(time.Duration(attempt) * 2 * time.Second)
 		}
-		if lastErr = d.refreshGasRollups(); lastErr == nil {
+		if lastErr = d.refreshRollups(); lastErr == nil {
 			return nil
 		}
 	}
 	return lastErr
 }
 
-func (d *DB) refreshGasRollups() error {
+func (d *DB) refreshRollups() error {
 
 	tx, err := d.db.Begin()
 	if err != nil {
@@ -3601,10 +3833,17 @@ func (d *DB) refreshGasRollups() error {
 		return err
 	}
 
+	// The active-address tuples too, for the same reason. They are also the
+	// reason the stamp written below has to be inside this transaction: the
+	// series reads it back to decide which hours it can trust.
+	if err := d.refreshActiveAddrRollup(tx); err != nil {
+		return err
+	}
+
 	if _, err := tx.Exec(
 		`INSERT INTO sync_state (key, value) VALUES (?, ?)
 		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-		gasRollupKey, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		rollupComputedAtKey, time.Now().UTC().Format(time.RFC3339)); err != nil {
 		return err
 	}
 	return tx.Commit()
@@ -3682,6 +3921,87 @@ func (d *DB) gasRollupReady() (bool, string) {
 		return false, ""
 	}
 	var at string
-	d.db.QueryRow(`SELECT value FROM sync_state WHERE key = ?`, gasRollupKey).Scan(&at)
+	d.db.QueryRow(`SELECT value FROM sync_state WHERE key = ?`, rollupComputedAtKey).Scan(&at)
 	return true, at
+}
+
+// --- Active-address rollup ---------------------------------------------------
+
+// activeAddrKinds are the three activities that make an address active, and the
+// values stored in active_addr_rollup.kind.
+//
+// They are named exactly as the series has always named them, so the read path
+// scans `kind` straight into the field it already had a case for. msg_runs is
+// deliberately absent: the series has never counted it, and adding it here would
+// change the numbers under cover of a performance change.
+var activeAddrKinds = []struct{ kind, table, column string }{
+	{"callers", "calls", "caller"},
+	{"deployers", "packages", "creator"},
+	{"senders", "bank_sends", "from_address"},
+}
+
+// refreshActiveAddrRollup rebuilds the distinct (network, hour, kind, address)
+// tuples for every configured network. Shares the caller's transaction, so
+// readers see either the whole previous generation or the whole new one.
+//
+// A full rebuild rather than an append from a watermark. The append would stay
+// flat as history grows, where this scales with all of it — 2.5s on production
+// today — but it would need a reset hook to be exactly right across chain
+// resets and backfills, and getting that wrong leaves tuples that no later pass
+// revisits. The gas rollups made the same trade for the same reason; a periodic
+// recompute is idempotent by construction. Revisit when the rebuild, not the
+// query, is what costs.
+func (d *DB) refreshActiveAddrRollup(tx *sql.Tx) error {
+	if _, err := tx.Exec(`DELETE FROM active_addr_rollup`); err != nil {
+		return err
+	}
+
+	scope := d.networkFilter("network", "")
+	branches := make([]string, 0, len(activeAddrKinds))
+	for _, k := range activeAddrKinds {
+		branches = append(branches, fmt.Sprintf(
+			"SELECT network, strftime('%%Y-%%m-%%dT%%H', block_time) AS bucket, '%s' AS kind, %s AS addr FROM %s WHERE %s",
+			k.kind, k.column, k.table, scope))
+	}
+
+	// block_time is nullable, and rows the syncer stored before it knew the
+	// block's timestamp produce a NULL bucket. The primary key would reject
+	// those and take the whole refresh down with it — silently, because the read
+	// path falls back to computing live and the endpoint merely stays slow. The
+	// live query drops the same rows, by way of `block_time >= ?`.
+	_, err := tx.Exec(`
+		INSERT INTO active_addr_rollup (network, bucket, kind, addr)
+		SELECT DISTINCT network, bucket, kind, addr
+		FROM (` + strings.Join(branches, " UNION ALL ") + `)
+		WHERE bucket IS NOT NULL`)
+	return err
+}
+
+// activeAddrRollupBoundary reports the instant from which the series still has
+// to read the source tables, and whether the rollup can be used at all.
+//
+// The rebuild runs on a timer, so between two builds the rollup holds part of
+// the hour it was built in and nothing after it. Serving the newest bucket from
+// it would make this endpoint lag by up to the refresh interval and disagree
+// with the live transaction feed on the same page — the class of bug that makes
+// every other number on the site suspect.
+//
+// So the boundary is the *hour containing* the build, not the build instant:
+// tuples strictly before it cover complete hours, and everything from it onward
+// is recomputed live over a window of at most one interval plus one hour, which
+// the (network, block_time) indexes serve directly.
+func (d *DB) activeAddrRollupBoundary() (time.Time, bool) {
+	var any int
+	if err := d.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM active_addr_rollup)`).Scan(&any); err != nil || any == 0 {
+		return time.Time{}, false
+	}
+	var at string
+	if err := d.db.QueryRow(`SELECT value FROM sync_state WHERE key = ?`, rollupComputedAtKey).Scan(&at); err != nil {
+		return time.Time{}, false
+	}
+	built, err := time.Parse(time.RFC3339, at)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return built.UTC().Truncate(time.Hour), true
 }

--- a/db_test.go
+++ b/db_test.go
@@ -12,13 +12,15 @@ import (
 // newTestDB opens a real SQLite file in a temp dir. The driver is pure Go, so
 // this works everywhere including CI, and it exercises the actual schema rather
 // than a mock.
-func newTestDB(t *testing.T) *DB {
-	t.Helper()
-	db, err := NewDB(filepath.Join(t.TempDir(), "test.db"))
+// Takes testing.TB rather than *testing.T so benchmarks can build the same
+// database the tests do.
+func newTestDB(tb testing.TB) *DB {
+	tb.Helper()
+	db, err := NewDB(filepath.Join(tb.TempDir(), "test.db"))
 	if err != nil {
-		t.Fatalf("NewDB: %v", err)
+		tb.Fatalf("NewDB: %v", err)
 	}
-	t.Cleanup(func() { db.Close() })
+	tb.Cleanup(func() { db.Close() })
 	return db
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -152,7 +152,7 @@ All accept `days` and `granularity`.
 | `GET /api/timeseries/packages` | deployments |
 | `GET /api/timeseries/callers` | unique callers |
 | `GET /api/timeseries/gas` | gas consumption. Buckets carry `by_network` in all-networks mode, so fees can be shown per chain rather than summed |
-| `GET /api/timeseries/active-addresses` | active addresses |
+| `GET /api/timeseries/active-addresses` | active addresses. Served from a rollup of distinct `(network, hour, kind, address)` tuples rebuilt every 5 minutes, merged with a live read of everything newer than the rollup — so the newest bucket does not lag the refresh interval. Falls back to computing live before the first build. Distinct tuples rather than per-day counts, because an address active on three days of a week is one weekly active address, not three |
 | `GET /api/timeseries/health` | chain health indicators |
 | `GET /api/timeseries/storage` | storage growth. `realm=<path>` scopes it to one realm |
 | `GET /api/timeseries/storage/realms` | realms that have storage data, for populating a selector |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -45,6 +45,28 @@ Derived, not stored:
 - **Account activity** is aggregated across `calls`, `msg_runs` and `bank_sends`.
 - **Balances** are not stored. They are fetched live from RPC per request.
 
+Derived and stored, on a timer:
+
+The `*_rollup` tables hold nothing the source tables do not already imply. They
+exist because a few aggregates cannot be indexed away and had grown into
+double-digit seconds. All of them are replaced wholesale inside one transaction
+every five minutes, so a reader sees one consistent generation, and all of them
+fall back to computing live before the first build rather than reporting zero.
+
+| table | grain | answers |
+|---|---|---|
+| `gas_realm_rollup` | one row per `(network, path)` | gas and fees attributed per realm |
+| `gas_totals_rollup` | one row per network | chain-wide gas totals |
+| `bank_totals_rollup` | one row per network | transfer volume and unique participants |
+| `bank_top_rollup` | one row per `(network, leaderboard, address)` | the transfer leaderboards, truncated per leaderboard |
+| `active_addr_rollup` | one row per `(network, hour, kind, address)` | how many distinct addresses were active per bucket |
+
+`active_addr_rollup` stores tuples rather than counts because counts cannot be
+re-aggregated: an address active on three days of a week is one weekly active
+address, not three. The hourly grain is finer than any bucket served, so every
+granularity is an exact re-deduplication. Reads merge it with a live query over
+everything newer than the build, so the newest bucket does not lag the timer.
+
 ## Semantics worth knowing
 
 - **`network` IDs are labels.** They name a configured network and key its rows.

--- a/main.go
+++ b/main.go
@@ -109,25 +109,29 @@ func run() error {
 		}
 	}
 
-	// Keep the gas rollups warm.
+	// Keep the rollups warm.
 	//
-	// The two aggregates behind the gas page scale with the chain and had
-	// reached 14 seconds on sapphire, against a 30-second write timeout. They
-	// cannot be indexed away — attributing gas per realm means touching every
-	// call — so they are precomputed here instead of per request.
+	// The aggregates behind the gas page, the bank page and the active-address
+	// series scale with the chain and had reached 14, 5 and 16 seconds on
+	// sapphire, against a 30-second write timeout. None can be indexed away —
+	// attributing gas per realm means touching every call, and counting distinct
+	// active addresses means touching every call, deploy and send — so they are
+	// precomputed here instead of per request.
 	//
-	// Every five minutes, not every sync pass: these are all-time totals, so
-	// five minutes of staleness costs nothing a reader would notice, and the
-	// recompute takes the write lock for a few seconds. The response carries
-	// computed_at so the page can say how fresh it is rather than implying live.
+	// Every five minutes, not every sync pass: the recompute takes the write
+	// lock for a few seconds, and nothing here is a number a reader watches tick.
+	// The gas and bank responses carry computed_at so the page can say how fresh
+	// they are; the active-address series instead reads everything newer than
+	// the build live, because a lagging newest bucket would disagree with the
+	// live feed beside it.
 	go func() {
 		refresh := func() {
 			start := time.Now()
-			if err := db.RefreshGasRollups(); err != nil {
-				log.Printf("gas rollup: %v", err)
+			if err := db.RefreshRollups(); err != nil {
+				log.Printf("rollups: %v", err)
 				return
 			}
-			log.Printf("gas rollup refreshed in %s", time.Since(start).Round(time.Millisecond))
+			log.Printf("rollups refreshed in %s", time.Since(start).Round(time.Millisecond))
 		}
 		// Wait out the startup ANALYZE before the first build. Both take the
 		// write lock, and racing it loses the whole refresh to SQLITE_BUSY —
@@ -136,7 +140,7 @@ func run() error {
 		db.WaitBackground()
 		refresh() // once at startup, so the first visitor is not the one who pays
 
-		ticker := time.NewTicker(gasRollupInterval)
+		ticker := time.NewTicker(rollupInterval)
 		defer ticker.Stop()
 		for {
 			select {


### PR DESCRIPTION
Closes #137.

`/api/timeseries/active-addresses` answers "how many distinct addresses were
active in each bucket", which means touching every call, deploy and send in the
window and deduplicating them per bucket. That is 15.9s on production and grows
with the chain, and #137 established that no index removes it — covering indexes
on `(network, block_time, addr)` bought 26% and left the plan still building a
temp B-tree.

So the tuples are stored instead:

```sql
CREATE TABLE active_addr_rollup (
    network TEXT NOT NULL,
    bucket  TEXT NOT NULL,   -- UTC hour, 'YYYY-MM-DDTHH'
    kind    TEXT NOT NULL,   -- callers | deployers | senders
    addr    TEXT NOT NULL,
    PRIMARY KEY (network, bucket, kind, addr)
) WITHOUT ROWID;
```

Tuples rather than counts, because counts cannot be re-aggregated: an address
active on three days of a week is **one** weekly active address, not three, and
summing daily counts overcounts by more the wider the bucket — worst exactly on
the `1y` and `all` windows the dashboards now offer. The stored grain is finer
than anything served, so every granularity is an exact re-deduplication.

`kind` is the one departure from the design in the issue. The endpoint returns
four numbers per bucket, not one — `total_active` plus a breakdown by callers,
deployers and senders — so the tuple carries which activity it was. The total is
still a dedup across all three, and `msg_runs` stays out because the series has
never counted it; adding it would change the numbers under cover of a
performance change.

## Numbers

Production-scale synthetic fixture, committed as `BenchmarkActiveAddressSeries`:
1.27M rows over 58 days on two chains, reducing to 135,360 tuples — matching the
1.27M / ~110k shape #137 measured on sapphire. Apple M1, `-benchtime 5x`, same
database and same public entry point for both paths.

| window | live | rolled up | |
|---|---|---|---|
| 24h, hourly | 72.3ms | **8.1ms** | 8.9x |
| 7d, daily | 665ms | **61.2ms** | 10.9x |
| 90d, daily | 12.98s | **709ms** | 18.3x |
| 1y, monthly | 13.01s | **713ms** | 18.3x |

**The 500ms bar in the acceptance criteria is not met at 90d and 1y on this
fixture**, which is 23% larger than production and running on a laptop against a
bulk-loaded database. It may well be met on the real instance, but I have not
measured there and am not going to claim it. If it is not, the next lever is
interning addresses to integers — dedup is sorting 135k 40-character strings —
and #131 is already introducing an intern table for proposers, so that work
wants to land on top of it rather than race it.

## Freshness, without a `computed_at`

The gas and bank rollups report `computed_at` and let the reader judge. That does
not work here: this series sits on the dashboards page next to the live feed, and
a newest bucket lagging by up to the refresh interval is the kind of
self-disagreement that makes every other number on the site suspect (#115's first
finding, in miniature).

So the read merges. Tuples cover the hours that are settled; everything from the
hour the rollup was built in onward is read live over a window of at most one
interval plus one hour, which the existing `(network, block_time)` indexes serve
directly. Both feed one `SELECT DISTINCT`, so an address appearing on both sides
of the boundary collapses rather than counting twice.

The same reasoning applies at the other end of the window, and that one was a
real bug I nearly shipped: the window opens at an instant ("now minus 7 days"),
but a tuple only says the address was active *somewhere* in that hour. Reading
the opening hour from the rollup counted activity from before the window.
Measured by mutation on the test below, the first bucket read 60 instead of 5.
The opening hour is read live too.

## Full rebuild, deliberately

Every five minutes, whole-table replacement inside the transaction that already
rebuilds the gas and bank rollups — one write-lock window rather than three.

#137 raises append-from-a-watermark, which would stay flat as history grows where
this scales with all of it (14.9s on the fixture). Not taken: it has to be exactly
right across chain resets and backfills, and getting it wrong leaves tuples no
later pass revisits. The gas rollups made the same trade for the same reason. A
chain reset does drop the tuples immediately, in `DeleteNetworkData`'s
transaction, rather than leaving them to age out over the next interval.

## What is not in here

`/api/sanity/overview`'s 24h figure stays live, and there is a test pinning that
it does. Its window is "the last 24 hours" to the second while the stored grain
is the hour, so serving it from tuples means rounding the window out and counting
up to an extra hour — a different number, arrived at by a change that was
supposed to be about speed. It is also a single 24h window over an indexed
`block_time`, which was never what was slow.

`/api/analytics`'s `total_addresses` also stays live. It looks like the same
query but counts a different population — all time, five sources including
`bank_sends.to_address` and `msg_runs` — and it has no time filter at all, so
rows with a NULL `block_time` count toward it today and would silently drop out
of a bucketed rollup. Worth doing, worth doing on purpose. Filed as a follow-up
comment on #137.

## Tests

Ten new tests in `activeaddr_test.go`. The ones that would have caught something:

- **`TestRollupMatchesLiveComputationAtEveryGranularity`** — 48 combinations of
  network, granularity and window diffed between the two paths against one
  seeded database, byte for byte. This is what makes the `substr` bucket
  extraction safe: three of the four granularities stopped calling `strftime`
  per row, and this pins that they still agree with the one that does.
- **`TestWindowOpeningHourMatchesLive`** — one address per minute across the two
  hours around the window edge, so some fall inside and some outside whatever
  time the test runs. Verified by mutation: reverting the opening-hour fix makes
  it fail 60 against 5.
- **`TestSeriesReadsSettledHistoryFromTheRollup`** — deletes the source rows
  after the refresh. A read that still reports the day it deleted can only have
  got it from the rollup, which is the part a correctness-only test cannot see.
- **`TestWiderBucketsCountAReturningAddressOnce`** — the naive-rollup error,
  asserted directly: one address on three days is 3 daily, 1 weekly, 1 monthly.
- **`TestMergingRollupAndLiveRowsDoesNotDoubleCount`**,
  **`TestChainResetClearsTheRolledUpTuples`**,
  **`TestRollupExcludesUnconfiguredNetworks`**,
  **`TestRollupCountsAnAddressOncePerChain`**.

`gofmt -l .` empty, `go vet ./...` and `go test ./...` clean.

## Also

`RefreshGasRollups` is now `RefreshRollups`, since it has rebuilt the bank
aggregates since #135 and rebuilds these too. The `sync_state` key it writes is
still `gas_rollup_at`, on purpose — renaming it would reset every deployed
instance's freshness stamp to "never built" for one interval.
