### PR TITLE
fix: keep the dependency graph's labels legible

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4365,15 +4365,108 @@ function renderDepGraph(imports, dependents, centerPath) {
     .attr('fill', d => depthColor(d.depth))
     .attr('stroke', '#000').attr('stroke-width', 1);
 
-  const labelEl = zoomG.append('g').selectAll('text').data(nodeArr).join('text')
+  // Labels are decluttered rather than all drawn.
+  //
+  // Every node carrying a label meant the dense centre of a graph like
+  // r/gnoswap/router rendered as a smear of overlapping text — worse than no
+  // labels, because it hides the shape of the graph as well as the names. And
+  // zooming could not help: the labels lived inside the zoomed group, so text
+  // and positions scaled together and two labels that overlapped at one scale
+  // overlapped at every scale.
+  //
+  // So labels sit outside the zoom group at a constant screen size, positioned
+  // by applying the current transform, and a greedy pass in screen space keeps
+  // the ones that fit. Zooming in now genuinely reveals more of them, because
+  // the nodes spread apart while the text does not grow. Anything dropped is
+  // one hover away, and the centre node always keeps its label.
+  const LABEL_FONT = 10;
+  const LABEL_CELL = 14;
+  // Rough, and deliberately so: measuring every label with getBBox would force
+  // a layout per label per frame. 0.55em per character over-estimates slightly
+  // for this font, which errs toward dropping a label rather than overlapping.
+  const LABEL_EM = 0.55;
+
+  // How many edges a node carries, as the tiebreak for who keeps their label.
+  // Read before the simulation starts, while link ends are still plain ids —
+  // forceLink replaces them with node objects on initialisation.
+  const degree = new Map();
+  for (const l of links) {
+    for (const end of [l.source, l.target]) {
+      const id = end && end.id !== undefined ? end.id : end;
+      degree.set(id, (degree.get(id) || 0) + 1);
+    }
+  }
+
+  const labelEl = svg.append('g').attr('pointer-events', 'none')
+    .selectAll('text').data(nodeArr).join('text')
     .text(d => d.id.split('/').slice(-2).join('/'))
-    .attr('font-size', 10).attr('fill', '#ccc').attr('dx', 14).attr('dy', 4);
+    .attr('font-size', LABEL_FONT).attr('fill', '#ccc');
+
+  // The order the greedy pass considers labels in, which is the order that
+  // decides who wins contested space: the centre, then the most-connected, then
+  // the shallowest.
+  const labelOrder = labelEl.nodes()
+    .map((node, i) => ({ node, d: nodeArr[i] }))
+    .sort((a, b) =>
+      (a.d.depth === 0 ? 0 : 1) - (b.d.depth === 0 ? 0 : 1) ||
+      (degree.get(b.d.id) || 0) - (degree.get(a.d.id) || 0) ||
+      a.d.depth - b.d.depth);
+
+  let hoveredNode = null;
+
+  function placeLabels() {
+    const t = d3.zoomTransform(svg.node());
+    const taken = new Set();
+    for (const entry of labelOrder) {
+      const d = entry.d, node = entry.node;
+      const x = t.applyX(d.x) + 14, y = t.applyY(d.y) + 4;
+      node.setAttribute('x', x);
+      node.setAttribute('y', y);
+
+      // A label panned off the canvas should neither be drawn — the svg does not
+      // clip, so it would land on the page around the panel — nor reserve space
+      // in the collision map for room nobody can see. Hovering is not a way back
+      // in here, because a node you cannot see is a node you cannot point at.
+      const MARGIN = 20;
+      if (x < -MARGIN || x > width + MARGIN || y < -MARGIN || y > height + MARGIN) {
+        node.style.display = 'none';
+        continue;
+      }
+
+      // The box the text actually occupies, not just its baseline: two labels
+      // one pixel apart vertically overlap on screen, and a grid keyed on the
+      // baseline row alone puts them in different rows and lets both through.
+      const left = x, right = x + node.textContent.length * LABEL_FONT * LABEL_EM;
+      const top = y - LABEL_FONT, bottom = y + 2;
+
+      const cells = [];
+      let clash = false;
+      for (let row = Math.floor(top / LABEL_CELL); row <= Math.floor(bottom / LABEL_CELL) && !clash; row++) {
+        for (let col = Math.floor(left / LABEL_CELL); col <= Math.floor(right / LABEL_CELL); col++) {
+          const key = col + ':' + row;
+          if (taken.has(key)) { clash = true; break; }
+          cells.push(key);
+        }
+      }
+
+      const keep = !clash || d.depth === 0 || d === hoveredNode;
+      node.style.display = keep ? '' : 'none';
+      if (keep) for (const key of cells) taken.add(key);
+    }
+  }
+
+  // Hovering a node reveals its label even when the pass dropped it, so a
+  // crowded cluster stays explorable without zooming.
+  nodeG.on('mouseenter', (e, d) => { hoveredNode = d; placeLabels(); })
+    .on('mouseleave', () => { hoveredNode = null; placeLabels(); });
+
+  zoom.on('zoom.labels', () => placeLabels());
 
   sim.on('tick', () => {
     linkEl.attr('x1', d => d.source.x).attr('y1', d => d.source.y)
       .attr('x2', d => d.target.x).attr('y2', d => d.target.y);
     nodeG.attr('transform', d => 'translate(' + d.x + ',' + d.y + ')');
-    labelEl.attr('x', d => d.x).attr('y', d => d.y);
+    placeLabels();
   });
 }
 


### PR DESCRIPTION
Closes the last open item of #115 (the graph half of §7).

The dependency graph drew a label for every node, unconditionally. In a dense
cluster — the review's example was `r/gnoswap/router` — that renders as a smear
of overlapping text, which is worse than no labels at all: it hides the shape of
the graph as well as the names.

The review noted that zoom mitigates it. Measured, it barely does, and the
reason is structural: the labels lived inside the zoomed group, so text and
positions scaled together. Two labels that overlap at one scale overlap at every
scale, and zooming only makes the smear bigger.

So two changes, and the second only works because of the first:

1. **Labels moved out of the zoom group** and are positioned by applying the
   current transform, at a constant screen size. Zooming in now spreads the
   nodes apart while the text stays put, which is what actually creates room.
2. **A greedy collision pass in screen space** keeps the labels that fit, in
   priority order: the centre node first, then the most-connected, then the
   shallowest. Anything dropped is one hover away, and the centre always keeps
   its label.

Collision is a uniform grid rather than pairwise boxes — it runs on every
simulation tick, so it has to be O(n) — and the box is the text's actual extent
rather than its baseline row. That distinction was a bug I had to fix twice:
keyed on the baseline row alone, two labels a pixel apart vertically land in
different rows and both get drawn, which left 13 overlaps in place.

## Measured

Against a seeded fixture of 171 nodes and 920 edges — one hub realm, 150
dependents, 20 shared packages — driven in headless Chromium, counting labels
whose bounding boxes actually intersect:

| | labels drawn | overlapping |
|---|---|---|
| `main`, default zoom | 171 / 171 | **58** |
| `main`, zoomed in 3x | 171 / 171 | **49** |
| this branch, default zoom | 82 / 171 | **0** |
| this branch, zoomed in 3x | 19 / 171 | **0** |

The `main` rows are the point: zooming in three steps removes 9 of 58 overlaps,
because everything scales together. That is the thing the issue described as
"zoom mitigates".

Hover was verified rather than asserted — the first attempt reported it broken,
and the test was wrong, not the code: it was picking nodes the force layout had
pushed outside the SVG box, which cannot be pointed at. Retargeted at an
on-screen node with a dropped label, hovering reveals it (`consumer09/app`).

No uncaught JS exceptions on the page.

## Not in here

The verification above was driven by an ad-hoc Playwright script. It belongs in
the repo as the harness #16 asks for, with this graph as one of its cases, and
that is the next thing I want to land rather than something to bolt onto this
diff.

One thing the run turned up that is unrelated and worth its own fix: the realm
page requests `/api/storage/{path}?network=all` on load, which is a documented
`400` — that endpoint requires a single network because storage figures are
denominated per chain. So every realm page view in all-networks mode logs a
failed request to the console. Filing separately.
