### PR TITLE
test(e2e): drive the frontend in a browser against a seeded fixture

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,62 @@
+name: e2e
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  browser:
+    name: browser tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      # Node is a development dependency here and nowhere else: it drives the
+      # browser and never touches the binary, which still embeds the frontend
+      # with no build step.
+      - name: Set up Node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: e2e
+
+      - name: Install browser
+        run: npx playwright install --with-deps chromium
+        working-directory: e2e
+
+      - name: Run
+        run: npx playwright test
+        working-directory: e2e
+
+      # Screenshot, video and trace for anything that failed. Without these a
+      # red run in CI is a mystery, which is most of why this suite exists.
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-artifacts
+          path: |
+            e2e/test-results/
+            e2e/playwright-report/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: e2e/package-lock.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ mygnoscan.db
 
 # local dev server config (machine-specific paths)
 .claude/launch.json
+
+# browser tests: dependencies and per-run output. e2e/package-lock.json is
+# committed, everything else here is generated.
+e2e/node_modules/
+e2e/.tmp/
+e2e/test-results/
+e2e/playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ syncer.go     background sync from tx-indexer into SQLite
 api.go        REST API handlers
 ws.go         SSE live feed (polls the indexer, fans out to browsers)
 frontend/     static HTML/JS/CSS, embedded with go:embed
+e2e/          browser tests (Node, development only — never in the binary)
 docs/         project documentation
 ```
 
@@ -55,7 +56,9 @@ Break these and things go wrong in ways that are hard to see:
   a real database works everywhere including CI.
 - **Commits are conventional and single-line**: `feat:`, `fix:`, `docs:`, `ci:`,
   `refactor:`, `test:`, `chore:`. No trailing co-author lines.
-- **`make` targets** are the entry points: `test`, `run`, `install`, `dev`.
+- **`make` targets** are the entry points: `test`, `e2e`, `run`, `install`, `dev`.
+  `test` is Go only. `e2e` drives a headless browser and is the only thing in the
+  repo that needs Node; changing anything in `frontend/` should run it.
 - **Errors go up, not into logs.** The exception is the sync loop, which logs and
   continues per-item so one bad package cannot stall a whole pass. Do not copy
   that pattern into query paths — several aggregate readers currently swallow

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test run install dev build
+.PHONY: test e2e run install dev build
 
 build:
 	CGO_ENABLED=0 go build -o mygnoscan .
@@ -11,6 +11,11 @@ install:
 
 test:
 	go test ./...
+
+# Browser tests. Separate from `test` because they need Node and a browser,
+# which the binary never does — see e2e/README.md.
+e2e:
+	cd e2e && npm ci && npx playwright install --with-deps chromium && npx playwright test
 
 dev:
 	goloop . -- go run .

--- a/docs/development.md
+++ b/docs/development.md
@@ -58,6 +58,24 @@ go test ./... -run TestResolveConfig -v
 Tests use temp SQLite files rather than mocks, and an `httptest` server in place of
 a real indexer. Table-driven where there is more than one case.
 
+### Browser tests
+
+Go tests cannot see the frontend break. Its failure mode is "the JSON was fine,
+the JS threw", so there is a second suite that runs the real binary against a
+seeded fixture and drives it in a headless browser:
+
+```bash
+make e2e
+```
+
+It is not part of `make test`, because it needs Node and a browser — neither of
+which the binary ever does. Node lives in `e2e/` and nowhere else; the frontend
+still has no build step and the shipped artifact still has no Node in it.
+
+A failure leaves a screenshot, a video and a Playwright trace under
+`e2e/test-results/`, and CI uploads the same directory. See
+[`e2e/README.md`](../e2e/README.md).
+
 ## Before pushing
 
 ```bash

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -31,6 +31,10 @@ npx playwright show-trace test-results/<test>/trace.zip
 
 CI uploads the same directory as an artifact.
 
+**Node 24 or newer.** The fixture writes through `node:sqlite`, which needs
+`--experimental-sqlite` on 22 and is stable from 24 — which is also why there is
+no `sqlite3` CLI dependency here.
+
 ## About the Node dependency
 
 Node lives here and nowhere else. It is not a build step for the frontend, it is

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,103 @@
+# Browser tests
+
+The frontend is one file of markup, CSS and vanilla JS served from `go:embed`,
+and the Go tests can say nothing about it. Their failure mode is "the JSON was
+fine, the JS threw" — which no amount of backend coverage catches, and which
+used to be found by a human loading the page.
+
+These tests run the real binary against a seeded SQLite fixture and drive it in
+a headless browser.
+
+## Running them
+
+```bash
+make e2e            # from the repo root: installs, builds, runs
+```
+
+or, once `npm ci` has been run in this directory:
+
+```bash
+npx playwright test                       # everything
+npx playwright test tests/graph.spec.js   # one file
+npx playwright test --headed              # watch it happen
+npx playwright test --debug               # step through it
+```
+
+A failure leaves a screenshot, a video and a trace under `test-results/`:
+
+```bash
+npx playwright show-trace test-results/<test>/trace.zip
+```
+
+CI uploads the same directory as an artifact.
+
+## About the Node dependency
+
+Node lives here and nowhere else. It is not a build step for the frontend, it is
+not in `go.mod`, and nothing it produces is embedded in the binary — the "no
+Node.js in the shipped artifact" property the README advertises is unchanged.
+`make test` remains Go-only; `make e2e` is the one that needs this directory.
+
+The alternative considered was `chromedp`, which would keep everything in Go.
+Playwright won on the thing the tests are for: when one fails in CI, the trace
+viewer shows the DOM, the network log and the console at every step, and
+`chromedp` has no equivalent.
+
+## How it is wired
+
+`harness/global-setup.mjs` does the whole thing, in an order that matters:
+
+1. `go build` the binary.
+2. Start `harness/fake-indexer.mjs`, so the suite is offline. It answers the
+   three GraphQL queries the client makes with valid, empty payloads — enough
+   that indexer-backed endpoints return "nothing here" rather than "the indexer
+   is down", which would otherwise show up as a failed request on every page.
+3. Run the binary with `-sync=false` against a fresh database. **The binary owns
+   the schema**, so it has to start before anything can be inserted; the schema
+   is never restated in JavaScript, because two copies of it would drift.
+4. Seed `harness/fixture.mjs` straight into the SQLite file.
+
+This is a `globalSetup` rather than Playwright's `webServer` for step 3 and 4:
+`webServer` only knows how to wait for a URL to answer, and it answers before
+the fixture exists.
+
+## What the fixture is
+
+Two networks, `alpha` and `beta`, with the same package path deployed on both —
+so anything that joins on path alone instead of `(path, network)` shows up as
+wrong counts. On `alpha`, one hub realm with 60 dependents and 12 shared
+packages, which is what makes the dependency graph dense enough for the label
+assertions to mean anything, plus calls, runs, sends and transactions.
+
+## What is asserted
+
+`tests/pages.spec.js` visits every route in the nav and every tab on the realm
+page, and requires: HTTP 200, something rendered, **no uncaught JS exceptions,
+no console errors, and no failed requests**. The last one is what catches the
+frontend calling an endpoint the backend does not serve — it found exactly that
+on its first run (`/api/storage` answers 400 in all-networks mode by design, and
+the realm page asked anyway).
+
+`tests/graph.spec.js` covers the dependency graph, which is the feature the tool
+exists for and the one D3 can break while the JSON stays perfect: nodes actually
+render, no two labels overlap, zooming reveals labels rather than magnifying the
+pile, and a label the declutter dropped comes back on hover.
+
+Content assertions are deliberately weak. This suite is not trying to pin what
+each page says; it is trying to notice when one of them stops working at all.
+
+## Adding a test
+
+Waiting is the part that goes wrong. The app signals nothing when it has
+finished rendering, so:
+
+- `settle(page)` in `tests/helpers.js` waits for the network to go quiet and the
+  loading skeletons to clear.
+- The graph needs more: `waitStable` polls until every node position *and* the
+  label visibility pattern repeat three times running. Sampling one node twice
+  was not enough — a slow-drifting layout produces two equal-looking samples
+  while still moving, which passed alone and failed in the full run.
+
+If a new page calls an endpoint this harness cannot answer, add it to
+`EXPECTED_FAILURES` in `tests/helpers.js` **with the reason**. Every entry there
+is a claim that a failure is the harness's fault rather than the page's.

--- a/e2e/harness/fake-indexer.mjs
+++ b/e2e/harness/fake-indexer.mjs
@@ -1,0 +1,50 @@
+// A tx-indexer stand-in, so the suite is offline and deterministic.
+//
+// The real client speaks a small slice of GraphQL and dispatches on what the
+// query string contains — the same three cases the Go fake in
+// fakeindexer_test.go covers. Answering them with a valid, empty payload is
+// what keeps the indexer-backed endpoints returning "nothing here" instead of
+// "the indexer is down", which would otherwise show up as failed requests in
+// every page assertion and drown out the ones that mean something.
+//
+// It deliberately serves no rows. Everything the suite asserts on is stored
+// data, seeded directly into SQLite; anything that can only come from an
+// indexer is out of scope here and stays that way until this grows a real
+// fixture chain.
+import { createServer } from 'node:http';
+
+export function startFakeIndexer() {
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      let query = '';
+      try {
+        query = JSON.parse(body || '{}').query || '';
+      } catch {
+        // A malformed body is the caller's problem, and answering an empty
+        // payload keeps the failure on their side rather than turning it into
+        // a transport error.
+      }
+
+      let data = {};
+      if (query.includes('latestBlockHeight')) {
+        data = { latestBlockHeight: 0 };
+      } else if (query.includes('getBlocks')) {
+        data = { getBlocks: [] };
+      } else if (query.includes('getTransactions')) {
+        data = { getTransactions: [] };
+      }
+
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ data }));
+    });
+  });
+
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, url: `http://127.0.0.1:${port}/graphql/query` });
+    });
+  });
+}

--- a/e2e/harness/fixture.mjs
+++ b/e2e/harness/fixture.mjs
@@ -1,0 +1,102 @@
+// The seeded chain the suite runs against.
+//
+// Rows are written straight into the SQLite file the binary has already created,
+// rather than through the syncer, so the fixture is a fact rather than the
+// outcome of a sync. The schema is never restated here — the binary owns it, and
+// duplicating it in JavaScript would let the two drift silently.
+import { DatabaseSync } from 'node:sqlite';
+
+export const NETWORKS = ['alpha', 'beta'];
+
+// One heavily-depended-upon realm, which is what makes the dependency graph
+// dense enough for the label collision assertions to mean anything. Sixty
+// dependents is well past the point where every label fits.
+export const HUB = 'gno.land/r/hub/core';
+export const HUB_ROUTE = 'r/hub/core';
+export const DEPENDENTS = 60;
+export const SHARED_PACKAGES = 12;
+
+export const HUB_CREATOR = 'g1hubcreator00000000000000000000000000';
+export const BUSY_CALLER = 'g1busycaller0000000000000000000000000';
+
+const TS = '2026-08-01T12:00:00Z';
+
+export function seed(dbPath) {
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec('BEGIN');
+
+    const pkg = db.prepare(`INSERT OR REPLACE INTO packages
+      (network, path, name, creator, block_height, block_time, tx_hash, is_realm, num_files)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)`);
+    const file = db.prepare(`INSERT OR REPLACE INTO package_files
+      (network, package_path, file_name, body) VALUES (?, ?, ?, ?)`);
+    const dep = db.prepare(`INSERT OR REPLACE INTO dependencies
+      (network, package_path, import_path) VALUES (?, ?, ?)`);
+    const call = db.prepare(`INSERT OR REPLACE INTO calls
+      (network, tx_hash, block_height, block_time, caller, pkg_path, func_name, success)
+      VALUES (?, ?, ?, ?, ?, ?, ?, 1)`);
+    const run = db.prepare(`INSERT OR REPLACE INTO msg_runs
+      (network, tx_hash, block_height, block_time, caller, source, success)
+      VALUES (?, ?, ?, ?, ?, ?, 1)`);
+    const send = db.prepare(`INSERT OR REPLACE INTO bank_sends
+      (network, tx_hash, block_height, block_time, from_address, to_address, amount, success)
+      VALUES (?, ?, ?, ?, ?, ?, ?, 1)`);
+    const tx = db.prepare(`INSERT OR REPLACE INTO transactions
+      (network, tx_hash, block_height, block_time, gas_used, gas_wanted, gas_fee, success)
+      VALUES (?, ?, ?, ?, ?, ?, ?, 1)`);
+
+    const addPackage = (network, path, creator, height, isRealm) => {
+      const name = path.split('/').pop();
+      pkg.run(network, path, name, creator, height, TS, `tx-${network}-${height}`, isRealm ? 1 : 0);
+      file.run(network, path, `${name}.gno`, `package ${name}\n\nfunc Render(path string) string { return "${name}" }\n`);
+      tx.run(network, `tx-${network}-${height}`, height, TS, 100000, 200000, 1000);
+    };
+
+    let height = 100;
+    addPackage('alpha', HUB, HUB_CREATOR, height++, true);
+
+    const shared = [];
+    for (let i = 0; i < SHARED_PACKAGES; i++) {
+      const path = `gno.land/p/common/util${String(i).padStart(2, '0')}`;
+      shared.push(path);
+      addPackage('alpha', path, 'g1packager0000000000000000000000000000', height++, false);
+      dep.run('alpha', HUB, path);
+    }
+
+    for (let i = 0; i < DEPENDENTS; i++) {
+      const path = `gno.land/r/consumer${String(i).padStart(2, '0')}/app`;
+      // Two deployers only, so the dependents list has same-deployer churn to
+      // group — the thing #115 asked the UI to make legible.
+      addPackage('alpha', path, `g1consumer${i % 2}00000000000000000000000000`, height++, true);
+      dep.run('alpha', path, HUB);
+      for (let j = 0; j < 3; j++) dep.run('alpha', path, shared[(i + j) % shared.length]);
+    }
+
+    // A second chain carrying the same package path, so anything that joins on
+    // path alone rather than (path, network) shows up as wrong counts.
+    addPackage('beta', HUB, 'g1betacreator000000000000000000000000', 500, true);
+    addPackage('beta', 'gno.land/r/beta/only', 'g1betacreator000000000000000000000000', 501, true);
+
+    for (let i = 0; i < 40; i++) {
+      const network = NETWORKS[i % 2];
+      const h = 1000 + i;
+      call.run(network, `call-${network}-${i}`, h, TS, BUSY_CALLER, HUB, 'Render');
+      tx.run(network, `call-${network}-${i}`, h, TS, 90000, 150000, 800);
+    }
+    for (let i = 0; i < 5; i++) {
+      run.run('alpha', `run-${i}`, 2000 + i, TS, BUSY_CALLER, 'package main\n\nfunc main() {}\n');
+      tx.run('alpha', `run-${i}`, 2000 + i, TS, 50000, 60000, 500);
+    }
+    for (let i = 0; i < 20; i++) {
+      const network = NETWORKS[i % 2];
+      send.run(network, `send-${network}-${i}`, 3000 + i, TS, BUSY_CALLER,
+        'g1recipient00000000000000000000000000', '1000000ugnot');
+      tx.run(network, `send-${network}-${i}`, 3000 + i, TS, 40000, 50000, 400);
+    }
+
+    db.exec('COMMIT');
+  } finally {
+    db.close();
+  }
+}

--- a/e2e/harness/global-setup.mjs
+++ b/e2e/harness/global-setup.mjs
@@ -1,0 +1,98 @@
+// Builds the binary, starts it against a seeded database, and hands the tests
+// a base URL.
+//
+// Order matters and is the reason this is a global setup rather than
+// Playwright's `webServer`: the binary owns the schema, so it has to run once
+// before anything can be inserted, and the tests must not start until the
+// inserts are done. `webServer` only knows how to wait for a URL to answer,
+// which it does before the fixture exists.
+import { spawn } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { startFakeIndexer } from './fake-indexer.mjs';
+import { NETWORKS, seed } from './fixture.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const e2eDir = join(here, '..');
+const repoRoot = join(e2eDir, '..');
+const tmpDir = join(e2eDir, '.tmp');
+
+const run = (cmd, args, opts = {}) => new Promise((resolve, reject) => {
+  const child = spawn(cmd, args, { stdio: 'inherit', ...opts });
+  child.on('error', reject);
+  child.on('exit', code => code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`)));
+});
+
+async function waitFor(url, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // Not listening yet.
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+  throw new Error(`timed out waiting for ${url}`);
+}
+
+export default async function globalSetup() {
+  mkdirSync(tmpDir, { recursive: true });
+
+  const binary = join(tmpDir, 'mygnoscan');
+  await run('go', ['build', '-o', binary, '.'], { cwd: repoRoot });
+
+  const indexer = await startFakeIndexer();
+
+  const configPath = join(tmpDir, 'networks.json');
+  writeFileSync(configPath, JSON.stringify({
+    networks: NETWORKS.map(id => ({ id, indexer: indexer.url })),
+  }, null, 2));
+
+  // A fresh database every run. The suite asserts on exact counts, and a
+  // database left over from a previous run is the classic way for a suite to
+  // pass on evidence it did not produce.
+  const dbPath = join(tmpDir, 'e2e.db');
+  for (const suffix of ['', '-wal', '-shm']) rmSync(dbPath + suffix, { force: true });
+
+  const port = 8899 + Number(process.env.E2E_PORT_OFFSET || 0);
+  const baseURL = `http://127.0.0.1:${port}`;
+
+  const server = spawn(binary, [
+    '-db', dbPath,
+    '-config', configPath,
+    '-sync=false',
+    '-listen', `127.0.0.1:${port}`,
+  ], { cwd: repoRoot, stdio: ['ignore', 'pipe', 'pipe'] });
+
+  const log = [];
+  server.stdout.on('data', d => log.push(String(d)));
+  server.stderr.on('data', d => log.push(String(d)));
+  server.on('exit', code => {
+    if (code !== 0 && code !== null) {
+      console.error(`mygnoscan exited ${code}:\n${log.join('')}`);
+    }
+  });
+
+  try {
+    await waitFor(`${baseURL}/api/networks`);
+  } catch (err) {
+    server.kill('SIGKILL');
+    throw new Error(`${err.message}\nserver output:\n${log.join('')}`);
+  }
+
+  seed(dbPath);
+
+  // The response cache keys on path plus query and lives 30 seconds, so a
+  // request made between startup and the seed would pin an empty answer for
+  // longer than most of the suite takes to run. Nothing has asked yet — the
+  // readiness probe above is /api/networks, which reads config rather than the
+  // database — but this is worth knowing before adding a probe that does.
+  process.env.E2E_BASE_URL = baseURL;
+  writeFileSync(join(tmpDir, 'state.json'), JSON.stringify({ pid: server.pid, baseURL }));
+
+  server.unref();
+}

--- a/e2e/harness/global-teardown.mjs
+++ b/e2e/harness/global-teardown.mjs
@@ -1,0 +1,22 @@
+import { readFileSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const tmpDir = join(dirname(fileURLToPath(import.meta.url)), '..', '.tmp');
+
+export default async function globalTeardown() {
+  let state;
+  try {
+    state = JSON.parse(readFileSync(join(tmpDir, 'state.json'), 'utf8'));
+  } catch {
+    return; // Setup never got far enough to start anything.
+  }
+
+  try {
+    process.kill(state.pid, 'SIGTERM');
+  } catch {
+    // Already gone, which is the outcome we wanted.
+  }
+
+  rmSync(join(tmpDir, 'state.json'), { force: true });
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "mygnoscan-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mygnoscan-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.62.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,6 +11,6 @@
     "@playwright/test": "^1.62.0"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mygnoscan-e2e",
+  "private": true,
+  "type": "module",
+  "description": "Browser end-to-end tests. Development only — nothing here is built into the binary.",
+  "scripts": {
+    "test": "playwright test",
+    "install-browsers": "playwright install --with-deps chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  // The frontend is one file with no build step, so there is nothing to
+  // parallelise against: one worker keeps the shared server's response cache
+  // and the seeded database behaving predictably.
+  workers: 1,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  // A retry would hide exactly the kind of flake this suite exists to surface,
+  // except in CI where a cold browser start can genuinely time out once.
+  retries: process.env.CI ? 1 : 0,
+  timeout: 60_000,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+
+  globalSetup: './harness/global-setup.mjs',
+  globalTeardown: './harness/global-teardown.mjs',
+
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://127.0.0.1:8899',
+    // What #16 asked for: enough to diagnose a failure without reproducing it.
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'], viewport: { width: 1400, height: 1000 } } },
+  ],
+});

--- a/e2e/tests/graph.spec.js
+++ b/e2e/tests/graph.spec.js
@@ -1,0 +1,152 @@
+import { expect, test } from '@playwright/test';
+
+import { DEPENDENTS, HUB_ROUTE } from '../harness/fixture.mjs';
+import { watch } from './helpers.js';
+
+// The dependency graph is the feature the whole tool exists for and the one
+// piece of the frontend a backend test can say nothing about: the JSON can be
+// perfect and D3 can still draw an empty box.
+
+async function openGraph(page) {
+  await page.goto(`/realm/${HUB_ROUTE}?tab=graph`);
+  await page.waitForSelector('#dep-graph > svg', { timeout: 20_000 });
+
+  // The force simulation has to cool before any position means anything, and it
+  // emits no event when it does.
+  //
+  // Sampling one node twice was not enough: a slow-drifting layout produces two
+  // equal-looking samples while still moving, and the suite then measured a
+  // half-settled graph — which showed up as one test failing in the full run
+  // and passing on its own. So the signature covers every node position *and*
+  // the resulting label visibility, which is what the assertions actually read,
+  // and it has to repeat three times running.
+  await waitStable(page);
+}
+
+// Blocks until the rendered graph stops changing. Reused after zooming, which
+// re-runs the same layout work through a transition.
+async function waitStable(page) {
+  await page.waitForFunction(() => {
+    const svg = document.querySelector('#dep-graph > svg');
+    const nodes = Array.from(svg.querySelectorAll('g'))
+      .filter(g => g.querySelector(':scope > circle, :scope > polygon'));
+    if (!nodes.length) return false;
+
+    const signature = nodes.map(n => n.getAttribute('transform')).join('|') + '#' +
+      Array.from(svg.querySelectorAll('text')).map(t => t.style.display === 'none' ? '0' : '1').join('');
+
+    window.__stable = signature === window.__signature ? (window.__stable || 0) + 1 : 0;
+    window.__signature = signature;
+    return window.__stable >= 3;
+  }, null, { timeout: 30_000, polling: 300 });
+}
+
+// The graph's own SVG, not the legend's. The legend draws a circle and a
+// diamond in their own tiny inline <svg> elements inside the same container, so
+// `#dep-graph svg` finds one of those first — a selector mistake that reports a
+// perfectly good graph as having zero nodes.
+const GRAPH_SVG = '#dep-graph > svg';
+
+function measure() {
+  const svg = document.querySelector('#dep-graph > svg');
+  const texts = Array.from(svg.querySelectorAll('text'));
+  const visible = texts.filter(t => t.style.display !== 'none');
+  const boxes = visible.map(t => t.getBoundingClientRect());
+
+  let overlapping = 0;
+  for (let i = 0; i < boxes.length; i++) {
+    for (let j = i + 1; j < boxes.length; j++) {
+      const a = boxes[i], b = boxes[j];
+      const hit = !(a.right <= b.left || b.right <= a.left || a.bottom <= b.top || b.bottom <= a.top);
+      if (hit) { overlapping++; break; }
+    }
+  }
+
+  return {
+    nodes: svg.querySelectorAll('circle, polygon').length,
+    labelsTotal: texts.length,
+    labelsVisible: visible.length,
+    overlapping,
+  };
+}
+
+test('the graph draws a node per package, not an empty svg', async ({ page }) => {
+  const seen = watch(page);
+  await openGraph(page);
+
+  const stats = await page.evaluate(measure);
+  // The hub, its dependents, and the packages it imports.
+  expect(stats.nodes).toBeGreaterThan(DEPENDENTS);
+  expect(seen.jsErrors).toEqual([]);
+});
+
+test('no two labels overlap', async ({ page }) => {
+  await openGraph(page);
+
+  const stats = await page.evaluate(measure);
+  // Not "every label is drawn": in a cluster this dense they cannot all fit,
+  // and drawing them anyway is the bug (#115). What has to hold is that what
+  // *is* drawn is readable.
+  expect(stats.overlapping, 'overlapping labels').toBe(0);
+  expect(stats.labelsVisible).toBeGreaterThan(0);
+});
+
+test('zooming in reveals labels rather than magnifying the pile', async ({ page }) => {
+  await openGraph(page);
+
+  const before = await page.evaluate(measure);
+  for (let i = 0; i < 3; i++) {
+    await page.locator('#dep-graph button', { hasText: '+' }).first().click();
+    await page.waitForTimeout(400);
+  }
+  await waitStable(page);
+  const after = await page.evaluate(measure);
+
+  // The labels used to live inside the zoomed group, so text and positions
+  // scaled together and overlaps survived any zoom. They must not come back.
+  expect(after.overlapping, 'overlapping labels after zooming in').toBe(0);
+  expect(before.overlapping).toBe(0);
+});
+
+test('a label the declutter dropped comes back on hover', async ({ page }) => {
+  await openGraph(page);
+
+  const target = await page.evaluate(() => {
+    const svg = document.querySelector('#dep-graph > svg');
+    const box = svg.getBoundingClientRect();
+    const texts = Array.from(svg.querySelectorAll('text'));
+    // Node groups are the ones holding a shape; the layer groups are not.
+    const nodes = Array.from(svg.querySelectorAll('g'))
+      .filter(g => g.querySelector(':scope > circle, :scope > polygon'));
+
+    for (let i = 0; i < texts.length; i++) {
+      if (texts[i].style.display !== 'none') continue;
+      const r = nodes[i].getBoundingClientRect();
+      const x = r.x + r.width / 2, y = r.y + r.height / 2;
+      // Only a node actually on the canvas can be pointed at. The layout puts
+      // some outside it, and hovering those is not something to promise.
+      if (x > box.left + 20 && x < box.right - 20 && y > box.top + 20 && y < box.bottom - 20) {
+        return { index: i, x, y };
+      }
+    }
+    return null;
+  });
+
+  expect(target, 'a hidden label on an on-screen node').not.toBeNull();
+
+  await page.mouse.move(target.x, target.y);
+  await page.waitForTimeout(300);
+
+  const revealed = await page.evaluate(
+    i => document.querySelector('#dep-graph > svg').querySelectorAll('text')[i].style.display !== 'none',
+    target.index,
+  );
+  expect(revealed, 'hovering a node reveals its dropped label').toBe(true);
+});
+
+test('the graph svg is present and non-trivial', async ({ page }) => {
+  await openGraph(page);
+  const svg = page.locator(GRAPH_SVG);
+  await expect(svg).toBeVisible();
+  expect(await svg.locator('line').count()).toBeGreaterThan(0);
+});

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -1,0 +1,52 @@
+// watch attaches the assertions that matter on every page.
+//
+// #16's point is that backend tests cannot catch "the JSON was fine, the JS
+// threw", so what this collects is the browser's own account of the page:
+// uncaught exceptions, console errors, and requests that did not succeed.
+export function watch(page) {
+  const jsErrors = [];
+  const consoleErrors = [];
+  const failedRequests = [];
+
+  page.on('pageerror', err => jsErrors.push(String(err)));
+  page.on('console', msg => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('requestfailed', req => {
+    failedRequests.push(`${req.url()} — ${(req.failure() || {}).errorText}`);
+  });
+  page.on('response', res => {
+    if (res.status() >= 400) failedRequests.push(`${res.url()} — HTTP ${res.status()}`);
+  });
+
+  return { jsErrors, consoleErrors, failedRequests };
+}
+
+// Requests the harness cannot answer, and why.
+//
+// Every entry here is a claim that a failure is the *harness's* fault rather
+// than the page's, so each one has to say what it is waiting on. Anything not
+// listed fails the suite — which is the point: a page that starts calling an
+// endpoint the backend no longer serves should break this, loudly.
+export const EXPECTED_FAILURES = [
+  // The account balance comes from RPC, and no RPC is configured here. The
+  // fake indexer speaks GraphQL only.
+  { pattern: /\/api\/address\/[^/]+\?.*balance/, why: 'balance needs RPC' },
+];
+
+export function unexpected(failures) {
+  return failures.filter(f => !EXPECTED_FAILURES.some(e => e.pattern.test(f)));
+}
+
+// A page is "settled" when the SPA has finished its fetches and rendered. The
+// app marks nothing, so this waits for the network to go quiet and for the
+// loading skeletons to be gone — the shimmer that #115 found could otherwise
+// sit there forever and read as a rendered page.
+export async function settle(page) {
+  await page.waitForLoadState('networkidle');
+  await page.waitForFunction(
+    () => document.querySelectorAll('.skeleton, .shimmer').length === 0,
+    null,
+    { timeout: 15_000 },
+  ).catch(() => {});
+}

--- a/e2e/tests/pages.spec.js
+++ b/e2e/tests/pages.spec.js
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test';
+
+import { HUB_ROUTE, BUSY_CALLER } from '../harness/fixture.mjs';
+import { settle, unexpected, watch } from './helpers.js';
+
+// Every route reachable from the nav, plus the detail pages.
+//
+// The assertion is deliberately the same for all of them and deliberately weak
+// on content: this suite is not trying to pin what each page says, it is trying
+// to notice when one of them stops working at all. Content assertions belong
+// with the feature that owns them.
+const ROUTES = [
+  ['home', '/'],
+  ['watch', '/watch'],
+  ['realms', '/realms'],
+  ['packages', '/packages'],
+  ['transactions', '/txs'],
+  ['blocks', '/blocks'],
+  ['accounts', '/accounts'],
+  ['tokens', '/tokens'],
+  ['validators', '/validators'],
+  ['govdao', '/govdao'],
+  ['gas', '/gas'],
+  ['analytics', '/analytics'],
+  ['dashboards', '/dashboards'],
+  ['sanity', '/sanity'],
+  ['events', '/events'],
+  ['realm detail', `/realm/${HUB_ROUTE}`],
+  ['address detail', `/address/${BUSY_CALLER}`],
+];
+
+for (const [name, path] of ROUTES) {
+  test(`${name} renders without errors`, async ({ page }) => {
+    const seen = watch(page);
+
+    const response = await page.goto(path);
+    expect(response.status(), `${path} should be served`).toBe(200);
+    await settle(page);
+
+    expect(seen.jsErrors, `uncaught exceptions on ${path}`).toEqual([]);
+    expect(unexpected(seen.failedRequests), `failed requests on ${path}`).toEqual([]);
+    expect(unexpected(seen.consoleErrors), `console errors on ${path}`).toEqual([]);
+
+    // Something has to have been drawn. An empty <main> passes every assertion
+    // above and is exactly the regression this is meant to catch.
+    const main = page.locator('.view.active main').first();
+    await expect(main).not.toBeEmpty();
+  });
+}
+
+// The realm page's tabs are separate render paths behind one route, and a
+// broken one is invisible until someone clicks it.
+const TABS = ['info', 'source', 'calls', 'events', 'storage', 'deps', 'graph'];
+
+for (const tab of TABS) {
+  test(`realm ${tab} tab renders without errors`, async ({ page }) => {
+    const seen = watch(page);
+
+    await page.goto(`/realm/${HUB_ROUTE}?tab=${tab}`);
+    await settle(page);
+
+    expect(seen.jsErrors, `uncaught exceptions on the ${tab} tab`).toEqual([]);
+    expect(unexpected(seen.failedRequests), `failed requests on the ${tab} tab`).toEqual([]);
+
+    await expect(page.locator(`#tab-${tab}`)).toBeVisible();
+  });
+}
+
+test('the realm list pages and every row carries its network', async ({ page }) => {
+  const seen = watch(page);
+  await page.goto('/realms');
+  await settle(page);
+
+  // The fixture puts the same package path on two chains. A list that joins on
+  // path alone collapses them, which is the mistake the network-scoping
+  // invariant exists to prevent.
+  const rows = page.locator('#realms-list tr');
+  expect(await rows.count()).toBeGreaterThan(1);
+
+  expect(seen.jsErrors).toEqual([]);
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4365,15 +4365,108 @@ function renderDepGraph(imports, dependents, centerPath) {
     .attr('fill', d => depthColor(d.depth))
     .attr('stroke', '#000').attr('stroke-width', 1);
 
-  const labelEl = zoomG.append('g').selectAll('text').data(nodeArr).join('text')
+  // Labels are decluttered rather than all drawn.
+  //
+  // Every node carrying a label meant the dense centre of a graph like
+  // r/gnoswap/router rendered as a smear of overlapping text — worse than no
+  // labels, because it hides the shape of the graph as well as the names. And
+  // zooming could not help: the labels lived inside the zoomed group, so text
+  // and positions scaled together and two labels that overlapped at one scale
+  // overlapped at every scale.
+  //
+  // So labels sit outside the zoom group at a constant screen size, positioned
+  // by applying the current transform, and a greedy pass in screen space keeps
+  // the ones that fit. Zooming in now genuinely reveals more of them, because
+  // the nodes spread apart while the text does not grow. Anything dropped is
+  // one hover away, and the centre node always keeps its label.
+  const LABEL_FONT = 10;
+  const LABEL_CELL = 14;
+  // Rough, and deliberately so: measuring every label with getBBox would force
+  // a layout per label per frame. 0.55em per character over-estimates slightly
+  // for this font, which errs toward dropping a label rather than overlapping.
+  const LABEL_EM = 0.55;
+
+  // How many edges a node carries, as the tiebreak for who keeps their label.
+  // Read before the simulation starts, while link ends are still plain ids —
+  // forceLink replaces them with node objects on initialisation.
+  const degree = new Map();
+  for (const l of links) {
+    for (const end of [l.source, l.target]) {
+      const id = end && end.id !== undefined ? end.id : end;
+      degree.set(id, (degree.get(id) || 0) + 1);
+    }
+  }
+
+  const labelEl = svg.append('g').attr('pointer-events', 'none')
+    .selectAll('text').data(nodeArr).join('text')
     .text(d => d.id.split('/').slice(-2).join('/'))
-    .attr('font-size', 10).attr('fill', '#ccc').attr('dx', 14).attr('dy', 4);
+    .attr('font-size', LABEL_FONT).attr('fill', '#ccc');
+
+  // The order the greedy pass considers labels in, which is the order that
+  // decides who wins contested space: the centre, then the most-connected, then
+  // the shallowest.
+  const labelOrder = labelEl.nodes()
+    .map((node, i) => ({ node, d: nodeArr[i] }))
+    .sort((a, b) =>
+      (a.d.depth === 0 ? 0 : 1) - (b.d.depth === 0 ? 0 : 1) ||
+      (degree.get(b.d.id) || 0) - (degree.get(a.d.id) || 0) ||
+      a.d.depth - b.d.depth);
+
+  let hoveredNode = null;
+
+  function placeLabels() {
+    const t = d3.zoomTransform(svg.node());
+    const taken = new Set();
+    for (const entry of labelOrder) {
+      const d = entry.d, node = entry.node;
+      const x = t.applyX(d.x) + 14, y = t.applyY(d.y) + 4;
+      node.setAttribute('x', x);
+      node.setAttribute('y', y);
+
+      // A label panned off the canvas should neither be drawn — the svg does not
+      // clip, so it would land on the page around the panel — nor reserve space
+      // in the collision map for room nobody can see. Hovering is not a way back
+      // in here, because a node you cannot see is a node you cannot point at.
+      const MARGIN = 20;
+      if (x < -MARGIN || x > width + MARGIN || y < -MARGIN || y > height + MARGIN) {
+        node.style.display = 'none';
+        continue;
+      }
+
+      // The box the text actually occupies, not just its baseline: two labels
+      // one pixel apart vertically overlap on screen, and a grid keyed on the
+      // baseline row alone puts them in different rows and lets both through.
+      const left = x, right = x + node.textContent.length * LABEL_FONT * LABEL_EM;
+      const top = y - LABEL_FONT, bottom = y + 2;
+
+      const cells = [];
+      let clash = false;
+      for (let row = Math.floor(top / LABEL_CELL); row <= Math.floor(bottom / LABEL_CELL) && !clash; row++) {
+        for (let col = Math.floor(left / LABEL_CELL); col <= Math.floor(right / LABEL_CELL); col++) {
+          const key = col + ':' + row;
+          if (taken.has(key)) { clash = true; break; }
+          cells.push(key);
+        }
+      }
+
+      const keep = !clash || d.depth === 0 || d === hoveredNode;
+      node.style.display = keep ? '' : 'none';
+      if (keep) for (const key of cells) taken.add(key);
+    }
+  }
+
+  // Hovering a node reveals its label even when the pass dropped it, so a
+  // crowded cluster stays explorable without zooming.
+  nodeG.on('mouseenter', (e, d) => { hoveredNode = d; placeLabels(); })
+    .on('mouseleave', () => { hoveredNode = null; placeLabels(); });
+
+  zoom.on('zoom.labels', () => placeLabels());
 
   sim.on('tick', () => {
     linkEl.attr('x1', d => d.source.x).attr('y1', d => d.source.y)
       .attr('x2', d => d.target.x).attr('y2', d => d.target.y);
     nodeG.attr('transform', d => 'translate(' + d.x + ',' + d.y + ')');
-    labelEl.attr('x', d => d.x).attr('y', d => d.y);
+    placeLabels();
   });
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3425,6 +3425,17 @@ async function loadRealmDetail(path, initialTab) {
     const storageEl = clear('tab-storage'); if (activeTab === 'storage') storageEl.classList.add('active'); else storageEl.classList.remove('active');
     skeletonBlock(storageEl);
     (async () => {
+      // /api/storage refuses the all-networks case, and it is right to: storage
+      // figures are denominated amounts, so blending chains would be
+      // meaningless. Asking anyway turned every realm page view in the default
+      // mode into a 400 and a console error, and told the reader "something
+      // broke" when the real state is "pick a chain first".
+      if (getNetwork() === 'all') {
+        storageEl.textContent = '';
+        storageEl.appendChild(el('div', { style: { color: 'var(--fg2)' } },
+          'storage is denominated per chain — select a specific network to see it'));
+        return;
+      }
       try {
         const storagePath = path.replace('gno.land/', '');
         const sData = await api('storage/' + storagePath);
@@ -3675,15 +3686,23 @@ async function loadTxDetail(hash) {
           (txDelta >= 0 ? '+' : '') + fmtNum(txDelta) + ' B' + (Math.abs(txDelta) >= 1024 ? ' (' + (txDelta/1024).toFixed(2) + ' KB)' : ''));
         stBody.appendChild(el('tr', {}, realmTd, beforeTd, deltaCol, afterTd,
           el('td', { style: { ...mono, color: 'var(--fg2)' } }, fmtNum(txFee) + ' ugnot')));
-        // Async fetch before/after from storage history
+        // Async fetch before/after from storage history. Same all-networks
+        // guard as the realm page: the endpoint answers 400 there by design,
+        // and the .catch below would quietly render that as "?" — a failure
+        // dressed up as missing data.
         const apiPath = sPath.replace('gno.land/', '');
-        api('storage/' + apiPath).then(sd => {
-          let net = 0;
-          for (const e of (sd.storage?.entries || [])) net += e.type === 'deposit' ? e.bytes_delta : -e.bytes_delta;
-          const before = net - txDelta;
-          beforeTd.textContent = fmtNum(before) + ' B';
-          afterTd.textContent = fmtNum(net) + ' B';
-        }).catch(() => { beforeTd.textContent = '?'; afterTd.textContent = '?'; });
+        if (getNetwork() === 'all') {
+          beforeTd.textContent = '—'; afterTd.textContent = '—';
+          beforeTd.title = afterTd.title = 'select a specific network: storage is denominated per chain';
+        } else {
+          api('storage/' + apiPath).then(sd => {
+            let net = 0;
+            for (const e of (sd.storage?.entries || [])) net += e.type === 'deposit' ? e.bytes_delta : -e.bytes_delta;
+            const before = net - txDelta;
+            beforeTd.textContent = fmtNum(before) + ' B';
+            afterTd.textContent = fmtNum(net) + ' B';
+          }).catch(() => { beforeTd.textContent = '?'; afterTd.textContent = '?'; });
+        }
       }
       // Totals row
       stBody.appendChild(el('tr', { style: { borderTop: '1px solid var(--border)' } },


### PR DESCRIPTION
Closes #16. Closes #140.

**Stacked on #139** — the graph assertions here are what pin that change, so this
targets `fix/graph-label-declutter` in substance even though it opens against
`main`. Merge #139 first and this diff shrinks to the harness plus the storage
fix.

The frontend is one file of markup, CSS and vanilla JS served from `go:embed`,
with no automated coverage. Go tests cannot help: the failure mode is "the JSON
was fine, the JS threw". So this runs the real binary against a seeded SQLite
fixture and drives it in a headless browser.

## It found a bug on its first run

Eight tests failed immediately, all on the same thing:

```
http://127.0.0.1:8899/api/storage/r/hub/core?network=all — HTTP 400
```

The realm page loads the storage tab eagerly, whatever tab is active, and
`/api/storage` refuses the all-networks case **by design** — storage figures are
denominated amounts, so blending chains would be meaningless. So every realm page
view in the default mode fired a request documented to fail, logged a console
error, and showed the reader `Error loading events: ...` when the real state was
"pick a chain first".

That is #140, which I filed from a manual run before writing any of this. It is
fixed in the first commit here — the all-networks state now says what to do
instead of asking, which is the pattern the block charts already use. The same
guard was needed on the transaction page, where the failure was worse: its
`.catch` rendered `?`, dressing a failed request up as missing data.

Fixing it is also what makes this suite green for the right reason rather than by
adding an exception.

## What it asserts

`tests/pages.spec.js` — every route in the nav, plus all seven tabs on the realm
page. Per page: HTTP 200, something rendered, **no uncaught JS exceptions, no
console errors, no failed requests**. Content assertions are deliberately weak;
this is not trying to pin what each page says, it is trying to notice when one
stops working at all.

`tests/graph.spec.js` — the dependency graph, which is both the feature the tool
exists for and the piece D3 can break while the JSON stays perfect: nodes render
rather than an empty `<svg>`, no two labels overlap, zooming reveals labels
instead of magnifying the pile, and a dropped label returns on hover.

Checked by mutation, against `main`'s `frontend/index.html`:

```
no two labels overlap                                       FAIL
zooming in reveals labels rather than magnifying the pile   FAIL
a label the declutter dropped comes back on hover           FAIL
the graph draws a node per package, not an empty svg        pass
the graph svg is present and non-trivial                    pass
```

The three that fail are the ones #139 fixes; the two that pass guard a different
regression and should pass on both.

30 tests, ~70s, and I ran the full suite three times consecutively before pushing
to confirm it is not flaky.

## The Node question

#16 asked for this to be decided explicitly rather than assumed, so: **Playwright,
as a devDependency in `e2e/` and nowhere else.**

Node is not a build step for the frontend, is not in `go.mod`, and nothing it
produces is embedded — the "no Node.js in the shipped artifact" property is
unchanged, and `make test` stays Go-only. The alternative, `chromedp`, keeps
everything in Go but loses the thing the suite is actually for: when one of these
fails in CI, the trace viewer shows the DOM, the network log and the console at
every step. #16 also notes this harness is shared with #17 (README screenshots),
which wants the browser tooling too.

## Two things worth review

**Setup order, and why it is not `webServer`.** The binary owns the schema, so it
has to run before anything can be inserted, and the tests must not start until
the fixture exists. Playwright's `webServer` only knows how to wait for a URL to
answer, and it answers before the seed. So `harness/global-setup.mjs` builds,
starts the fake indexer, starts the binary with `-sync=false`, waits, and *then*
seeds. The schema is never restated in JavaScript — two copies of it would drift.

**Waiting on the force simulation.** This is where the first version was wrong.
Sampling one node's transform twice looked settled while the layout was still
drifting, and the suite measured a half-settled graph: one test failed in the
full run and passed on its own. `waitStable` now requires every node position
*and* the whole label visibility pattern to repeat three times running.

## Not in here

The fake indexer answers the three GraphQL queries the client makes with valid
but **empty** payloads, which is enough that indexer-backed endpoints return
"nothing here" rather than "the indexer is down". That means no coverage of
transaction or block detail pages yet — they need a fixture chain, which is worth
doing next and is a bigger piece than this.

`EXPECTED_FAILURES` in `tests/helpers.js` is the escape hatch for requests the
harness genuinely cannot answer. It has one entry. Every entry is a claim that a
failure is the harness's fault rather than the page's, so it must carry a reason.
